### PR TITLE
feat(desktop): add system tray support and fix version logging

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -12,7 +12,7 @@ tauri-build = { version = "2.0", features = [] }
 serde_json = "1.0"
 
 [dependencies]
-tauri = { version = "2.0", features = ["protocol-asset", "macos-private-api"] }
+tauri = { version = "2.0", features = ["protocol-asset", "macos-private-api", "tray-icon"] }
 tauri-plugin-dialog = "2.0"
 tauri-plugin-opener = "2.0"
 tauri-plugin-os = "2.0"

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -1,0 +1,96 @@
+// imports for tray
+use tauri::{
+    menu::{Menu, MenuItem},
+    tray::{MouseButton, TrayIconBuilder, TrayIconEvent},
+    AppHandle, Manager,
+};
+
+// to show confirmation dialog box for quit event from tray
+// use tauri_plugin_dialog::DialogExt;
+
+/// Return true if window was shown (or attempted) successfully, false otherwise.
+fn open_and_focus(app: &AppHandle) -> bool {
+    // try main window by label first
+    if let Some(window) = app.get_webview_window("main") {
+        if let Err(e) = window.show() {
+            tracing::warn!("Failed to show window: {}", e);
+            return false;
+        }
+        if let Err(e) = window.set_focus() {
+            tracing::warn!("Failed to set focus on window: {}", e);
+        }
+        return true;
+    }
+
+    // fallback: use the first available webview window
+    if let Some((_label, window)) = app.webview_windows().iter().next() {
+        if let Err(e) = window.show() {
+            tracing::warn!("Failed to show fallback window: {}", e);
+            return false;
+        }
+        if let Err(e) = window.set_focus() {
+            tracing::warn!("Failed to set focus on fallback window: {}", e);
+        }
+        return true;
+    }
+
+    tracing::error!("No window available to show");
+    false
+}
+
+pub fn setup_tray(app: &AppHandle) -> tauri::Result<()> {
+    let open = MenuItem::with_id(app, "open", "Open", true, None::<&str>)?; // open button
+    let quit = MenuItem::with_id(app, "quit", "Quit", true, None::<&str>)?; // quit button
+    let menu = Menu::with_items(app, &[&open, &quit])?;
+
+    let mut builder = TrayIconBuilder::new()
+        .menu(&menu)
+        .show_menu_on_left_click(false)
+        .tooltip("AltSendMe")
+        .on_menu_event(move |app, event| match event.id().as_ref() {
+            "open" => {
+                open_and_focus(app);
+            }
+            "quit" => {
+                tracing::info!("Quit requested from tray");
+
+                // If a confirmation dialog should be shown before quit:
+                // ----------------------------------------------
+                // let handle = app.clone();
+                // handle
+                //     .dialog()
+                //     .message("Are you sure you want to quit AltSendMe?")
+                //     .title("Confirm exit")
+                //     .buttons(tauri_plugin_dialog::MessageDialogButtons::OkCancel)
+                //     .kind(tauri_plugin_dialog::MessageDialogKind::Warning)
+                //     .show(move |proceed| {
+                //         if proceed {
+                //             handle.exit(0);
+                //         }
+                //     });
+                // ----------------------------------------------
+
+                app.exit(0);
+            }
+            _ => {}
+        })
+        .on_tray_icon_event(move |tray, event| match event {
+            TrayIconEvent::Click {
+                button: MouseButton::Left,
+                ..
+            } => {
+                let app = tray.app_handle();
+                let _ = open_and_focus(&app);
+            }
+            _ => {}
+        });
+
+    if let Some(icon) = app.default_window_icon() {
+        builder = builder.icon(icon.clone());
+    }
+
+    let tray = builder.build(app)?;
+
+    app.manage(tray);
+    Ok(())
+}

--- a/src-tauri/src/version.rs
+++ b/src-tauri/src/version.rs
@@ -15,7 +15,7 @@ pub fn get_app_version() -> String {
             serde_json::from_str(&package_json_str).expect("Failed to parse package.json");
 
         let version = match package_json.get("version") {
-            Some(v) => v.to_string(),
+            Some(v) => v.as_str().unwrap_or("").to_string(),
             None => panic!(""),
         };
 


### PR DESCRIPTION
## Description

This PR implements system tray support and improves application logging.

### Changes
- **System Tray**: Implemented tray icon with "Open" and "Quit" menu items.
- **UX Improvement**: Added support for **Single Left Click** on the tray icon to restore the window.
- **Logging**:
  - Added `tracing::debug!` log when the application is closed to the system tray.
  - Fixed an issue where the app version in startup logs was wrapped in extra quotes (e.g., `v"0.2.4"` -> `v0.2.4`).

Related Issues: 
#65, [#38](https://github.com/tonyantony300/alt-sendme/issues/38)