### PR TITLE
feat(single-instance): enforce app to run only one instance at a time

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -74,6 +74,7 @@ dependencies = [
  "tauri-plugin-opener",
  "tauri-plugin-os",
  "tauri-plugin-shell",
+ "tauri-plugin-single-instance",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -6694,6 +6695,21 @@ dependencies = [
  "tauri-plugin",
  "thiserror 2.0.17",
  "tokio",
+]
+
+[[package]]
+name = "tauri-plugin-single-instance"
+version = "2.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acba6b5ca527a96cdfcc96ae09b09ccb91ddff5e33978ca6873b96ea16bb404c"
+dependencies = [
+ "serde",
+ "serde_json",
+ "tauri",
+ "thiserror 2.0.17",
+ "tracing",
+ "windows-sys 0.60.2",
+ "zbus",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -16,6 +16,7 @@ tauri = { version = "2.0", features = ["protocol-asset", "macos-private-api", "t
 tauri-plugin-dialog = "2.0"
 tauri-plugin-opener = "2.0"
 tauri-plugin-os = "2.0"
+tauri-plugin-single-instance = "2.0"
 tauri-plugin-http = "2.0"
 tauri-plugin-shell = "2.0"
 serde = { version = "1.0", features = ["derive"] }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -14,7 +14,6 @@ use state::AppState;
 use std::fs;
 use std::sync::Arc;
 
-#[cfg(target_os = "linux")]
 use tauri::Manager;
 
 /// Clean up any orphaned .sendme-* directories from previous runs
@@ -65,6 +64,13 @@ fn main() {
     );
 
     tauri::Builder::default()
+        .plugin(tauri_plugin_single_instance::init(|app, _args, _cwd| {
+            if let Some(window) = app.get_webview_window("main") {
+                let _ = window.show();
+                let _ = window.unminimize();
+                let _ = window.set_focus();
+            }
+        }))
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_os::init())


### PR DESCRIPTION
### DESCRIPTION

This PR enforces that only a single instance of the app can be ran at a time.

### CHANGES

- Add new tauri-plugin-single-instance dependency
- Show, Unminimize and Set Focus on existing window if user tries to run the executable again while an instance is already running

### RELATED ISSUES

> Add any related issues here