### PR TITLE
fix(linux): prevent AppImage crashes by disabling DMABUF

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -59,6 +59,13 @@ fn main() {
         .with_line_number(true)
         .init();
 
+    // Only disable hardware acceleration if running specifically as an AppImage
+    #[cfg(target_os = "linux")]
+    if std::env::var("APPIMAGE").is_ok() {
+        std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
+        tracing::debug!("AppImage detected: Disabling DMABUF for stability.");
+    }
+
     tracing::info!(
         "Starting AltSendme Desktop application v{}",
         version::get_app_version()
@@ -77,7 +84,6 @@ fn main() {
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_os::init())
         .plugin(tauri_plugin_http::init())
-        .plugin(tauri_plugin_shell::init())
         .plugin(tauri_plugin_shell::init())
         .manage(Arc::new(tokio::sync::Mutex::new({
             // Check for launch args (potential file path from context menu)


### PR DESCRIPTION
### DESCRIPTION
This PR fixes critical stability issues on Linux AppImages (specifically EGL_BAD_PARAMETER error)

### CHANGES
- Fix AppImage Crash: Enforce `WEBKIT_DISABLE_DMABUF_RENDERER=1` when the app is detected running as an AppImage. This resolves the `EGL_BAD_PARAMETER` error.

> Related Issues: #47, #59, #96, #71