### PR TITLE
fix(web-app): move AppProviders to main.tsx to fix appTitle translation in titlebar failing on linux

### DIFF
--- a/web-app/src/components/layouts/RootLayout.tsx
+++ b/web-app/src/components/layouts/RootLayout.tsx
@@ -1,5 +1,5 @@
 import { Outlet } from 'react-router-dom'
-import { AppProviders } from './AppProviders'
+
 import { AppFooter } from '../AppFooter'
 import { TitleBar } from '../TitleBar'
 import { useTranslation } from '@/i18n'
@@ -8,7 +8,7 @@ import { AppUpdater } from '../common/AppUpdater'
 export function RootLayout() {
 	const { t } = useTranslation('common')
 	return (
-		<AppProviders>
+		<>
 			<AppUpdater />
 			<main className="h-screen flex flex-col relative glass-background select-none bg-background">
 				{IS_LINUX && <TitleBar title={t('appTitle')} />}
@@ -19,6 +19,6 @@ export function RootLayout() {
 				<Outlet />
 				<AppFooter />
 			</main>
-		</AppProviders>
+		</>
 	)
 }

--- a/web-app/src/main.tsx
+++ b/web-app/src/main.tsx
@@ -5,11 +5,14 @@ import './index.css'
 import './i18n'
 import { initializePlatformStyles } from './lib/platformStyles'
 import { routers } from './routes/routes.tsx'
+import { AppProviders } from './components/layouts/AppProviders'
 
 initializePlatformStyles()
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
 	<React.StrictMode>
-		<RouterProvider router={routers} />,
+		<AppProviders>
+			<RouterProvider router={routers} />
+		</AppProviders>
 	</React.StrictMode>
 )


### PR DESCRIPTION
### DESCRIPTION
This PR fixes the titlebar rendering issue on linux. The Titlebar was rendering common:appTitle instead of 'AltSendme' because RootLayout was trying to use translation before the AppProvider (which contains the TranslationProvider) was initialized.

### CHANGES
- Move AppProviders from RootLayout to main.tsx. This ensures TranslationProvider is available when RootLayout renders

### RELATED ISSUES
#95 