### PR TITLE
Fix external links/buttons by using opener plugin

### DIFF
--- a/web-app/src/components/AppFooter.tsx
+++ b/web-app/src/components/AppFooter.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from '@/i18n'
 import { AppVersion } from './AppVersionPayload'
 import { Separator } from './ui/separator'
 import { Link } from 'react-router-dom'
-//import { Link } from 'react-router-dom'
+import { handleExternalLinkClick } from '@/lib/openExternalUrl'
 
 const CONTACTS = [
 	{
@@ -36,6 +36,7 @@ export function AppFooter() {
 					<a
 						key={contact.link}
 						href={contact.link}
+						onClick={(event) => handleExternalLinkClick(event, contact.link)}
 						target="_blank"
 						rel="noopener noreferrer"
 						aria-label={contact['aria-label']}

--- a/web-app/src/components/setting-sidebar/setting-sidebar.tsx
+++ b/web-app/src/components/setting-sidebar/setting-sidebar.tsx
@@ -16,6 +16,7 @@ import { useTranslation } from '../../i18n'
 import { cn } from '../../lib/utils'
 import { LICENSE_LINK, PRIVACY_LINK, VERSION_DISPLAY } from '../../lib/version'
 import { Badge } from '../ui/badge'
+import { handleExternalLinkClick } from '@/lib/openExternalUrl'
 
 function SettingSidebarRoot(props: React.ComponentProps<typeof Sidebar>) {
 	return <Sidebar {...props} />
@@ -118,6 +119,7 @@ function SettingSidebarFooter({
 			<a
 				className="hover:underline hover:text-foreground transition-color"
 				href={PRIVACY_LINK}
+				onClick={(event) => handleExternalLinkClick(event, PRIVACY_LINK)}
 				target="_blank"
 				rel="noopener noreferrer"
 			>
@@ -127,6 +129,7 @@ function SettingSidebarFooter({
 			<a
 				className="hover:underline hover:text-foreground transition-color"
 				href={LICENSE_LINK}
+				onClick={(event) => handleExternalLinkClick(event, LICENSE_LINK)}
 				target="_blank"
 				rel="noopener noreferrer"
 			>

--- a/web-app/src/lib/openExternalUrl.ts
+++ b/web-app/src/lib/openExternalUrl.ts
@@ -1,0 +1,27 @@
+import { openUrl } from '@tauri-apps/plugin-opener'
+
+export async function openExternalUrl(url: string): Promise<void> {
+	if (IS_TAURI) {
+		await openUrl(url)
+		return
+	}
+
+	const openedWindow = window.open(url, '_blank', 'noopener,noreferrer')
+	if (openedWindow) {
+		openedWindow.opener = null
+	}
+}
+
+export function handleExternalLinkClick(
+	event: { preventDefault: () => void },
+	url: string
+): void {
+	if (!IS_TAURI) {
+		return
+	}
+
+	event.preventDefault()
+	void openExternalUrl(url).catch((error) => {
+		console.error('Failed to open external URL:', error)
+	})
+}

--- a/web-app/src/lib/version.ts
+++ b/web-app/src/lib/version.ts
@@ -3,6 +3,6 @@ import packageJson from '../../../package.json'
 export const VERSION = packageJson.version
 export const VERSION_DISPLAY = `v${VERSION}`
 export const PRIVACY_LINK =
-	'https://github.com/tonyantony300/alt-sendme/blob/main/PRIVACY'
+	'https://github.com/tonyantony300/alt-sendme/blob/main/PRIVACY.md'
 export const LICENSE_LINK =
 	'https://github.com/tonyantony300/alt-sendme/blob/main/LICENSE'


### PR DESCRIPTION
## Description

  Fixes #125 by making external links/buttons open reliably in the desktop app.

  ### What changed
  - Added a Tauri-aware external link helper:
    - Uses `@tauri-apps/plugin-opener` (`openUrl`) when running in Tauri.
    - Falls back to `window.open` for non-Tauri/web environments.
  - Wired external link handling to all affected UI links:
    - Footer external buttons (GitHub / Buy Me a Coffee / Website)
    - Settings footer links (Privacy Policy / License)
  - Fixed privacy document URL path from `PRIVACY` to `PRIVACY.md`.

  ### Why
  In the desktop environment, plain anchor links (`target="_blank"`) may not consistently open in the system browser. Routing link opening through the opener plugin makes behavior consistent across platforms.

  ## Checklist

  - [x] I have run **`npm run lint`** before raising this PR
  - [ ] I have run **`npm run format`** before raising this PR