### PR TITLE
feat: Persist android download folder

### DIFF
--- a/src-tauri/capabilities/android.json
+++ b/src-tauri/capabilities/android.json
@@ -30,6 +30,7 @@
 			],
 			"deny": []
 		},
+		"store:default",
 		"native-utils:default"
 	]
 }

--- a/web-app/src/components/sender/Sender.tsx
+++ b/web-app/src/components/sender/Sender.tsx
@@ -45,7 +45,6 @@ export function Sender({ onTransferStateChange }: SenderProps) {
 		copyTicket,
 		closeAlert,
 		resetForNewTransfer,
-		toggleBroadcastMode,
 	} = useSender()
 
 	const { t } = useTranslation()
@@ -133,7 +132,7 @@ export function Sender({ onTransferStateChange }: SenderProps) {
 							onStartSharing={startSharing}
 							onStopSharing={stopSharing}
 							onCopyTicket={copyTicket}
-							onToggleBroadcast={toggleBroadcastMode}
+							onSetBroadcast={setIsBroadcastMode}
 						/>
 					</div>
 				</>

--- a/web-app/src/components/sender/SharingActiveCard.tsx
+++ b/web-app/src/components/sender/SharingActiveCard.tsx
@@ -25,13 +25,13 @@ export function SharingActiveCard({
 	activeConnectionCount = 0,
 	onCopyTicket,
 	onStopSharing,
-	onToggleBroadcast: _onToggleBroadcast,
+	onSetBroadcast: _onSetBroadcast,
 }: SharingControlsProps) {
 	const { t } = useTranslation()
-	const onToggleBroadcast = () => {
-		if (_onToggleBroadcast) {
+	const onSetBroadcast = () => {
+		if (_onSetBroadcast) {
 			const isTurningOn = !isBroadcastMode
-			_onToggleBroadcast()
+			_onSetBroadcast(isTurningOn)
 			// Only show toast notification when turning broadcast mode ON, not for private sharing
 			if (isTurningOn) {
 				const toastId = crypto.randomUUID()
@@ -43,7 +43,7 @@ export function SharingActiveCard({
 					actionProps: {
 						children: t('common:undo'),
 						onClick: () => {
-							_onToggleBroadcast?.()
+							_onSetBroadcast?.(false)
 							toastManager.close(toastId)
 						},
 					},
@@ -200,7 +200,7 @@ export function SharingActiveCard({
 					copySuccess={copySuccess}
 					onCopyTicket={onCopyTicket}
 					isBroadcastMode={isBroadcastMode}
-					onToggleBroadcast={onToggleBroadcast}
+					onSetBroadcast={onSetBroadcast}
 				/>
 			)}
 
@@ -227,10 +227,10 @@ export function TicketDisplay({
 	copySuccess,
 	onCopyTicket,
 	isBroadcastMode,
-	onToggleBroadcast,
+	onSetBroadcast,
 }: TicketDisplayProps & {
 	isBroadcastMode?: boolean
-	onToggleBroadcast?: () => void
+	onSetBroadcast?: (broadcast: boolean) => void
 }) {
 	const { t } = useTranslation()
 
@@ -240,14 +240,14 @@ export function TicketDisplay({
 				<p className="block text-sm font-medium">
 					{t('common:sender.shareThisTicket')}
 				</p>
-				{isBroadcastMode !== undefined && onToggleBroadcast && (
+				{isBroadcastMode !== undefined && onSetBroadcast && (
 					<div className="flex items-start gap-2">
 						<Label htmlFor={'broadcast-toggle'} className="text-sm">
 							{t('common:sender.broadcastMode.index')}
 						</Label>
 						<Switch
 							checked={isBroadcastMode}
-							onCheckedChange={onToggleBroadcast}
+							onCheckedChange={onSetBroadcast}
 						/>
 					</div>
 				)}

--- a/web-app/src/hooks/useReceiver.ts
+++ b/web-app/src/hooks/useReceiver.ts
@@ -54,9 +54,7 @@ export function useReceiver(): UseReceiverReturn {
 	const [isCompleted, setIsCompleted] = useState(false)
 	const [savePath, setSavePath] = useState('')
 	const downloadsPath = useAppSettingStore((state) => state.downloadsPath)
-	const setDownloadsPath = useAppSettingStore(
-		(state) => state.setDownloadsPath
-	)
+	const setDownloadsPath = useAppSettingStore((state) => state.setDownloadsPath)
 	const [transferMetadata, setTransferMetadata] =
 		useState<TransferMetadata | null>(null)
 	const [transferProgress, setTransferProgress] =
@@ -211,7 +209,7 @@ export function useReceiver(): UseReceiverReturn {
 	useEffect(() => {
 		const initializeSavePath = async () => {
 			try {
-				if(IS_ANDROID) {
+				if (IS_ANDROID) {
 					setSavePath(downloadsPath)
 				} else {
 					const downloadsPath = await downloadDir()

--- a/web-app/src/hooks/useReceiver.ts
+++ b/web-app/src/hooks/useReceiver.ts
@@ -15,6 +15,7 @@ import type {
 } from '../types/transfer'
 import { SpeedAverager, calculateETA } from '../utils/etaUtils'
 import { IS_ANDROID } from '@/lib/platform'
+import { useAppSettingStore } from '@/store/app-setting'
 
 interface BackendFileMetadata {
 	file_name: string
@@ -52,6 +53,10 @@ export function useReceiver(): UseReceiverReturn {
 	const [isTransporting, setIsTransporting] = useState(false)
 	const [isCompleted, setIsCompleted] = useState(false)
 	const [savePath, setSavePath] = useState('')
+	const downloadsPath = useAppSettingStore((state) => state.downloadsPath)
+	const setDownloadsPath = useAppSettingStore(
+		(state) => state.setDownloadsPath
+	)
 	const [transferMetadata, setTransferMetadata] =
 		useState<TransferMetadata | null>(null)
 	const [transferProgress, setTransferProgress] =
@@ -206,15 +211,19 @@ export function useReceiver(): UseReceiverReturn {
 	useEffect(() => {
 		const initializeSavePath = async () => {
 			try {
-				const downloadsPath = await downloadDir()
-				setSavePath(downloadsPath)
+				if(IS_ANDROID) {
+					setSavePath(downloadsPath)
+				} else {
+					const downloadsPath = await downloadDir()
+					setSavePath(downloadsPath)
+				}
 			} catch (error) {
 				console.error('Failed to get downloads directory:', error)
 				setSavePath('')
 			}
 		}
 		initializeSavePath()
-	}, [])
+	}, [downloadsPath])
 
 	useEffect(() => {
 		let disposed = false
@@ -368,6 +377,7 @@ export function useReceiver(): UseReceiverReturn {
 				const response = await selectDownloadFolder()
 				if (!response) return
 				selected = response.path.toString()
+				setDownloadsPath(selected)
 			} else {
 				selected = await open({
 					multiple: false,

--- a/web-app/src/hooks/useSender.ts
+++ b/web-app/src/hooks/useSender.ts
@@ -38,7 +38,6 @@ export interface UseSenderReturn {
 	showAlert: (title: string, description: string, type?: AlertType) => void
 	closeAlert: () => void
 	resetForNewTransfer: () => Promise<void>
-	toggleBroadcastMode: () => void
 }
 
 export function useSender(): UseSenderReturn {
@@ -66,7 +65,6 @@ export function useSender(): UseSenderReturn {
 		setTransferMetadata,
 		setTransferProgress,
 		setIsBroadcastMode,
-		toggleBroadcastMode,
 		showAlert,
 		closeAlert,
 		resetToIdle,
@@ -678,6 +676,5 @@ export function useSender(): UseSenderReturn {
 		showAlert,
 		closeAlert,
 		resetForNewTransfer,
-		toggleBroadcastMode,
 	}
 }

--- a/web-app/src/lib/setting-store.ts
+++ b/web-app/src/lib/setting-store.ts
@@ -11,6 +11,7 @@ export const defaultAppSettings: AppSettingsState = {
 	darkMode: false,
 	autoUpdate: true,
 	showProgressOnIcon: false,
+	downloadsPath: ''
 }
 export const localSettingStore = new LazyStore(SETTING_FILE, {
 	autoSave: true,

--- a/web-app/src/lib/setting-store.ts
+++ b/web-app/src/lib/setting-store.ts
@@ -11,7 +11,7 @@ export const defaultAppSettings: AppSettingsState = {
 	darkMode: false,
 	autoUpdate: true,
 	showProgressOnIcon: false,
-	downloadsPath: ''
+	downloadsPath: '',
 }
 export const localSettingStore = new LazyStore(SETTING_FILE, {
 	autoSave: true,

--- a/web-app/src/store/app-setting.ts
+++ b/web-app/src/store/app-setting.ts
@@ -12,6 +12,7 @@ export type AppSettingsState = {
 	darkMode: boolean
 	autoUpdate: boolean
 	showProgressOnIcon: boolean
+	downloadsPath: string
 }
 
 export type AppSettingsActions = {
@@ -21,6 +22,7 @@ export type AppSettingsActions = {
 	setDarkMode: (value: boolean) => void
 	setAutoUpdate: (value: boolean) => void
 	toggleShowProgressOnIcon?: (value: boolean) => void
+	setDownloadsPath: (value: string) => void
 }
 
 export type AppSettings = AppSettingsState & AppSettingsActions
@@ -39,6 +41,7 @@ export const useAppSettingStore = create<AppSettings>()(
 			setAutoUpdate: (value: boolean) => set({ autoUpdate: value }),
 			toggleShowProgressOnIcon: (value: boolean) =>
 				set({ showProgressOnIcon: value }),
+			setDownloadsPath: (value: string) => set({downloadsPath: value})
 		}),
 		{
 			name: AppSettingsKey,

--- a/web-app/src/store/app-setting.ts
+++ b/web-app/src/store/app-setting.ts
@@ -41,7 +41,7 @@ export const useAppSettingStore = create<AppSettings>()(
 			setAutoUpdate: (value: boolean) => set({ autoUpdate: value }),
 			toggleShowProgressOnIcon: (value: boolean) =>
 				set({ showProgressOnIcon: value }),
-			setDownloadsPath: (value: string) => set({downloadsPath: value})
+			setDownloadsPath: (value: string) => set({ downloadsPath: value }),
 		}),
 		{
 			name: AppSettingsKey,

--- a/web-app/src/types/sender.ts
+++ b/web-app/src/types/sender.ts
@@ -37,7 +37,7 @@ export interface SharingControlsProps {
 	onStartSharing: () => Promise<void>
 	onStopSharing: () => Promise<void>
 	onCopyTicket: () => Promise<void>
-	onToggleBroadcast: () => void
+	onSetBroadcast: (broadcast: boolean) => void
 }
 
 export interface TicketDisplayProps {


### PR DESCRIPTION
## Description

Changed receive folder initialization to force user to choose a folder on first boot and persist save folder changes

fix: Changed broadcast undo so it sets value to false instead of toggling 

## Checklist

- [x] I have run **`npm run lint`** before raising this PR
- [x] I have run **`npm run format`** before raising this PR
