### PR TITLE
Truncate long file names in file picker

### DIFF
--- a/web-app/src/components/sender/Dropzone.tsx
+++ b/web-app/src/components/sender/Dropzone.tsx
@@ -150,7 +150,7 @@ export function Dropzone({
 					<p className=" hidden sm:block text-lg font-medium mb-2 text-accent-foreground">
 						{getStatusText()}
 					</p>
-					<div className="text-sm text-muted-foreground">{getSubText()}</div>
+					<div className="text-sm truncate text-muted-foreground">{getSubText()}</div>
 				</div>
 			</motion.div>
 		</motion.div>


### PR DESCRIPTION
## Description

This PR truncates long file names in the file picker.

## Preview

<img width="447" height="90" alt="Screenshot 2026-03-23 at 6 58 29 PM" src="https://github.com/user-attachments/assets/6f6d28da-92f8-4a3f-9485-663c4abf99c7" />

## Checklist

- [x] I have run **`npm run lint`** before raising this PR
- [x] I have run **`npm run format`** before raising this PR
