### PR TITLE
Ref/enhence UI multiple files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "AltSendme",
-	"version": "0.3.4",
+	"version": "0.3.5",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "AltSendme",
-			"version": "0.3.4",
+			"version": "0.3.5",
 			"dependencies": {
 				"@base-ui/react": "^1.1.0",
 				"@phosphor-icons/react": "^2.1.10",
@@ -2658,23 +2658,6 @@
 			"version": "2.10.1",
 			"resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-x64-gnu/-/cli-linux-x64-gnu-2.10.1.tgz",
 			"integrity": "sha512-2/12bEzsJS9fAKybxgicCDFxYD1WEI9kO+tlDwX5znWG2GwMBaiWcmhGlZ8fi+DMe9CXlcVarMTYc0L3REIRxw==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "Apache-2.0 OR MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">= 10"
-			}
-		},
-		"node_modules/@tauri-apps/cli-linux-x64-musl": {
-			"version": "2.10.1",
-			"resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-x64-musl/-/cli-linux-x64-musl-2.10.1.tgz",
-			"integrity": "sha512-Y8J0ZzswPz50UcGOFuXGEMrxbjwKSPgXftx5qnkuMs2rmwQB5ssvLb6tn54wDSYxe7S6vlLob9vt0VKuNOaCIQ==",
 			"cpu": [
 				"x64"
 			],

--- a/web-app/src/components/sender/Dropzone.tsx
+++ b/web-app/src/components/sender/Dropzone.tsx
@@ -14,6 +14,14 @@ import { useEffect, useRef, useState } from 'react'
 import { useTranslation } from '../../i18n/react-i18next-compat'
 import type { DropzoneProps } from '../../types/sender'
 import { getPreviewFileIcon } from '../../lib/fileIcons'
+import { buttonVariants } from '../ui/button'
+import { ScrollArea } from '../ui/scroll-area'
+import {
+	Tooltip,
+	TooltipContent,
+	TooltipProvider,
+	TooltipTrigger,
+} from '../ui/tooltip'
 
 const getPathBaseName = (path: string) => {
 	const normalized = path.replace(/\\/g, '/')
@@ -144,14 +152,12 @@ export function Dropzone({
 		if (selectedPath && !isLoading) {
 			return {
 				...baseStyles,
-				paddingBottom: '1.5rem',
 			}
 		}
 
 		if (isLoading) {
 			return {
 				...baseStyles,
-				paddingBottom: '4rem',
 			}
 		}
 
@@ -252,53 +258,94 @@ export function Dropzone({
 			layout
 			transition={{ duration: 0.3, ease: 'easeInOut' }}
 			style={getDropzoneStyles()}
-			className="relative border-2 border-dashed rounded-lg p-4 sm:p-6 text-center cursor-pointer transition-all duration-200 bg-accent text-accent-foreground h-64 border-border overflow-hidden"
+			className="relative border-2 border-dashed rounded-lg text-center cursor-pointer transition-all duration-200 bg-accent text-accent-foreground h-fit min-h-64 border-border overflow-hidden"
 		>
 			{selectedPath && !isLoading && (
-				<div className="absolute top-3 right-3 z-30 flex items-center gap-2 pointer-events-auto">
-					<motion.button
-						key="add-folder-button"
-						type="button"
-						initial={{ opacity: 0, filter: 'blur(4px)' }}
-						animate={{ opacity: 1, filter: 'blur(0px)' }}
-						onClick={(e) => {
-							e.stopPropagation()
-							void onAddFolders()
-						}}
-						className="p-1.5 rounded-md text-muted-foreground cursor-pointer"
-						aria-label="Add more folders"
-					>
-						<FolderPlus className="h-6 w-6" />
-					</motion.button>
-					<motion.button
-						key="add-button"
-						type="button"
-						initial={{ opacity: 0, filter: 'blur(4px)' }}
-						animate={{ opacity: 1, filter: 'blur(0px)' }}
-						onClick={(e) => {
-							e.stopPropagation()
-							void onAddFiles()
-						}}
-						className="p-1.5 rounded-md text-muted-foreground cursor-pointer"
-						aria-label="Add more files"
-					>
-						<FilePlus className="h-6 w-6" />
-					</motion.button>
-					<motion.button
-						key="clear-button"
-						type="button"
-						initial={{ opacity: 0, filter: 'blur(4px)' }}
-						animate={{ opacity: 1, filter: 'blur(0px)' }}
-						onClick={(e) => {
-							e.stopPropagation()
-							onClearSelection()
-						}}
-						className="p-1.5 rounded-md text-muted-foreground cursor-pointer"
-						aria-label="Clear selection"
-					>
-						<X className="h-6 w-6" />
-					</motion.button>
-				</div>
+				<TooltipProvider>
+					<div className="absolute top-3 right-3 z-30 flex items-center gap-2 pointer-events-auto">
+						<Tooltip>
+							<TooltipTrigger
+								render={
+									<motion.button
+										key="add-folder-button"
+										type="button"
+										initial={{
+											opacity: 0,
+											filter: 'blur(4px)',
+										}}
+										animate={{
+											opacity: 1,
+											filter: 'blur(0px)',
+										}}
+										onClick={(e) => {
+											e.stopPropagation()
+											void onAddFolders()
+										}}
+										className={buttonVariants({
+											variant: 'ghost',
+											size: 'icon',
+										})}
+										aria-label="Add more folders"
+									>
+										<FolderPlus strokeWidth={1.5} />
+									</motion.button>
+								}
+							></TooltipTrigger>
+							<TooltipContent>
+								<p>{t('common:sender.addMoreFolders')}</p>
+							</TooltipContent>
+						</Tooltip>
+						<Tooltip>
+							<TooltipTrigger
+								render={
+									<motion.button
+										key="add-file-button"
+										type="button"
+										initial={{
+											opacity: 0,
+											filter: 'blur(4px)',
+										}}
+										animate={{
+											opacity: 1,
+											filter: 'blur(0px)',
+										}}
+										onClick={(e) => {
+											e.stopPropagation()
+											void onAddFiles()
+										}}
+										className={buttonVariants({
+											variant: 'ghost',
+											size: 'icon',
+										})}
+										aria-label="Add more files"
+									>
+										<FilePlus strokeWidth={1.5} />
+									</motion.button>
+								}
+							></TooltipTrigger>
+							<TooltipContent>
+								<p>{t('common:sender.addMoreFiles')}</p>
+							</TooltipContent>
+						</Tooltip>
+						<motion.button
+							key="clear-button"
+							type="button"
+							initial={{ opacity: 0, filter: 'blur(4px)' }}
+							animate={{ opacity: 1, filter: 'blur(0px)' }}
+							onClick={(e) => {
+								e.stopPropagation()
+								onClearSelection()
+							}}
+							className={buttonVariants({
+								variant: 'secondary',
+							})}
+							aria-label="Clear selection"
+						>
+							<X />
+							Clear ({selectedPaths.length})
+						</motion.button>
+					</div>
+				</TooltipProvider>
 			)}
 			<motion.div
 				key={selectedPath ? 'selected' : 'empty'}
@@ -306,7 +353,7 @@ export function Dropzone({
 				animate={{ opacity: 1, filter: 'blur(0px)' }}
 				exit={{ opacity: 0, filter: 'blur(4px)' }}
 				transition={{ duration: 0.25 }}
-				className="h-full w-full"
+				className="h-full w-full p-4 sm:p-6"
 			>
 				{!hasSelection && (
 					<div className="h-full w-full flex flex-col items-center justify-center space-y-4">
@@ -336,69 +383,81 @@ export function Dropzone({
 							animate={{ opacity: 1, y: 0 }}
 							exit={{ opacity: 0, y: 6 }}
 							transition={{ duration: 0.2 }}
-							className="h-full w-full flex flex-col justify-center pt-12"
+							className="h-full w-full flex flex-col justify-center pt-4 gap-4"
 						>
-							<div className="relative">
-								{canScrollLeft ? (
-									<div className="pointer-events-none absolute inset-y-0 left-0 z-10 flex w-12 items-center justify-start bg-gradient-to-r from-accent via-accent/90 to-transparent pl-1">
-										<ChevronsLeft className="h-4 w-4 text-muted-foreground/80" />
-									</div>
-								) : null}
-								{canScrollRight ? (
-									<div className="pointer-events-none absolute inset-y-0 right-0 z-10 flex w-12 items-center justify-end bg-gradient-to-l from-accent via-accent/90 to-transparent pr-1">
-										<ChevronsRight className="h-4 w-4 text-muted-foreground/80" />
-									</div>
-								) : null}
-								<div
-									ref={attachPreviewScroller}
-									className="overflow-x-auto overflow-y-hidden pb-3 px-1"
-									onWheel={handlePreviewWheel}
+							<ScrollArea
+								ref={attachPreviewScroller}
+								className="overflow-x-auto overflow-y-hidden"
+								scrollFade
+								scrollbarGutter
+								onWheel={handlePreviewWheel}
+								aria-orientation="horizontal"
+							>
+								<motion.div
+									layout
+									className="inline-flex min-w-full justify-center gap-3 pr-3"
 								>
-									<motion.div
-										layout
-										className="inline-flex min-w-full justify-center gap-3 pr-3"
-									>
-										<AnimatePresence initial={false}>
-											{selectedPaths.map((path) => {
-												const fileName = getPathBaseName(path)
-												return (
-													<motion.div
-														key={path}
-														layout
-														initial={{ opacity: 0, scale: 0.94 }}
-														animate={{ opacity: 1, scale: 1 }}
-														exit={{ opacity: 0, scale: 0.94 }}
-														transition={{ duration: 0.16 }}
-														className="group relative w-44 shrink-0"
-													>
-														<div className="p-1">
-															<div className="relative flex h-36 w-full items-center justify-center overflow-hidden">
-																{renderPathIcon(path)}
-																<button
-																	type="button"
-																	onClick={(e) => {
-																		e.stopPropagation()
-																		onRemoveSelectedPath(path)
-																	}}
-																	className="absolute right-2 top-2 z-10 rounded-full border bg-background p-1 text-muted-foreground opacity-100 transition-opacity sm:opacity-0 sm:group-hover:opacity-100 focus-visible:opacity-100"
-																	aria-label={`Remove ${fileName}`}
-																	title="Remove from sharing"
-																>
-																	<X className="h-3.5 w-3.5" />
-																</button>
-															</div>
+									<AnimatePresence initial={false}>
+										{selectedPaths.map((path) => {
+											const fileName = getPathBaseName(path)
+											return (
+												<motion.div
+													key={path}
+													layout
+													initial={{
+														opacity: 0,
+														scale: 0.94,
+													}}
+													animate={{
+														opacity: 1,
+														scale: 1,
+													}}
+													exit={{
+														opacity: 0,
+														scale: 0.94,
+													}}
+													transition={{
+														duration: 0.16,
+													}}
+													className="group relative w-44 shrink-0"
+												>
+													<div className="p-1">
+														<div className="relative flex h-36 w-full items-center justify-center overflow-hidden">
+															{renderPathIcon(path)}
+															<Tooltip>
+																<TooltipTrigger
+																	render={
+																		<button
+																			type="button"
+																			onClick={(e) => {
+																				e.stopPropagation()
+																				onRemoveSelectedPath(path)
+																			}}
+																			className="absolute right-2 top-2 z-10 rounded-full border bg-background p-1 text-muted-foreground opacity-100 transition-opacity sm:opacity-0 sm:group-hover:opacity-100 focus-visible:opacity-100"
+																			aria-label={`Remove ${fileName}`}
+																		>
+																			<X className="h-3.5 w-3.5" />
+																		</button>
+																	}
+																></TooltipTrigger>
+																<TooltipContent>
+																	<p>
+																		{t('common:sender.removeFromSelection')}
+																	</p>
+																</TooltipContent>
+															</Tooltip>
 														</div>
+													</div>
 
-														<p className="mt-2 truncate text-base text-foreground">
-															{fileName}
-														</p>
-													</motion.div>
-												)
-											})}
-										</AnimatePresence>
-									</motion.div>
-								</div>
-							</div>
+													<p className="mt-2 truncate text-base text-foreground">
+														{fileName}
+													</p>
+												</motion.div>
+											)
+										})}
+									</AnimatePresence>
+								</motion.div>
+							</ScrollArea>
 						</motion.div>
 					)}
 				</AnimatePresence>

--- a/web-app/src/components/sender/Dropzone.tsx
+++ b/web-app/src/components/sender/Dropzone.tsx
@@ -1,8 +1,6 @@
 import { AnimatePresence, motion } from 'framer-motion'
 import { invoke } from '@tauri-apps/api/core'
 import {
-	ChevronsLeft,
-	ChevronsRight,
 	ChevronDown,
 	ChevronRight,
 	FolderPlus,
@@ -48,8 +46,8 @@ export function Dropzone({
 	>({})
 	const previewScrollerRef = useRef<HTMLDivElement | null>(null)
 	const previewScrollerCleanupRef = useRef<(() => void) | null>(null)
-	const [canScrollLeft, setCanScrollLeft] = useState(false)
-	const [canScrollRight, setCanScrollRight] = useState(false)
+	const [_canScrollLeft, setCanScrollLeft] = useState(false)
+	const [_canScrollRight, setCanScrollRight] = useState(false)
 
 	useEffect(() => {
 		if (!selectedPaths.length) {

--- a/web-app/src/components/sender/SharingActiveCard.tsx
+++ b/web-app/src/components/sender/SharingActiveCard.tsx
@@ -11,6 +11,7 @@ import { InputGroup, InputGroupAddon, InputGroupInput } from '../ui/input-group'
 import { Label } from '../ui/label'
 import { Switch } from '../ui/switch'
 import { toastManager } from '../ui/toast'
+import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip'
 
 export function SharingActiveCard({
 	selectedPaths,
@@ -90,15 +91,28 @@ export function SharingActiveCard({
 	return (
 		<div className="space-y-4">
 			<div className="p-4 rounded-lg absolute top-0 left-0">
-				<p className="text-xs mb-4 max-w-40 sm:max-w-120 truncate">
-					<strong className="mr-1">{t('common:sender.fileLabel')}</strong>{' '}
-					{selectedPaths.length > 1
-						? t('common:sender.multipleFilesSelected', {
-								name: selectedPaths[0]?.split('/').pop() || '',
-								count: selectedPaths.length - 1,
-							})
-						: selectedPath?.split('/').pop()}
-				</p>
+				<Tooltip disabled={!selectedPath && selectedPaths.length <= 1}>
+					<TooltipTrigger>
+						<p className="text-xs mb-4 max-w-40 sm:max-w-120 truncate">
+							<strong className="mr-1">{t('common:sender.fileLabel')}</strong>{' '}
+							{selectedPaths.length > 1
+								? t('common:sender.multipleFilesSelected', {
+										name: selectedPaths[0]?.split('/').pop() || '',
+										count: selectedPaths.length - 1,
+									})
+								: selectedPath?.split('/').pop()}
+						</p>
+					</TooltipTrigger>
+					<TooltipContent className="max-w-xs" side="inline-end">
+						<ul className="list-disc pl-4 text-left max-h-60 overflow-auto">
+							{selectedPaths.map((path) => (
+								<li key={path} className="text-xs">
+									{path.split('/').pop()}
+								</li>
+							))}
+						</ul>
+					</TooltipContent>
+				</Tooltip>
 
 				<StatusIndicator
 					isCompleted={isCompleted}

--- a/web-app/src/locales/en/common.json
+++ b/web-app/src/locales/en/common.json
@@ -44,6 +44,10 @@
 		"multipleFilesSelected": "{{name}} ... and {{count}} more",
 		"browseFile": "Browse File",
 		"browseFolder": "Browse Folder",
+		"addMoreFiles": "Add more files",
+		"addMoreFolders": "Add more folders",
+		"multipleItemsSelected": "{{firstName}} and {{count}} more",
+		"removeFromSelection": "Remove from selection",
 		"copyToClipboard": "Copy to clipboard",
 		"description": "Description (optional)",
 		"broadcastMode": {


### PR DESCRIPTION
## Description
Enhence UI UX with tooltip, use `ScrollArea` instead of custom one

<img width="1100" height="777" alt="image" src="https://github.com/user-attachments/assets/a6fb1a2c-3aaf-4042-8e79-2685840b356e" />
<img width="1100" height="777" alt="image" src="https://github.com/user-attachments/assets/6b0ce74a-b4e0-4916-8a8b-4c7fc28414e6" />


## Checklist

- [X] I have run **`npm run lint`** before raising this PR
- [X] I have run **`npm run format`** before raising this PR
