### PR TITLE
feat: add 16 E2E integration tests for send/receive pipeline

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,23 @@
+name: E2E Tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  rust-e2e:
+    name: Rust E2E Transfer Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: swatinem/rust-cache@v2
+        with:
+          workspaces: './sendme -> target'
+      - name: Run sendme E2E tests
+        run: cargo test --manifest-path sendme/Cargo.toml -- --test-threads=1
+        timeout-minutes: 10

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,8 @@ on:
   pull_request:
     branches:
       - main
+      - dev
+      - release
 
 jobs:
   rust-e2e:

--- a/sendme/src/lib.rs
+++ b/sendme/src/lib.rs
@@ -5,7 +5,7 @@ pub use core::{
     send::start_share,
     send::start_share_items,
     types::{
-        AddrInfoOptions, AppHandle, EventEmitter, ReceiveOptions, ReceiveResult, RelayModeOption,
-        SendOptions, SendResult,
+        AddrInfoOptions, AppHandle, EventEmitter, FileMetadata, FilePreviewItem, ReceiveOptions,
+        ReceiveResult, RelayModeOption, SendOptions, SendResult,
     },
 };

--- a/sendme/tests/common/mod.rs
+++ b/sendme/tests/common/mod.rs
@@ -1,0 +1,125 @@
+#![allow(dead_code, unused_imports)]
+
+use sendme::EventEmitter;
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+
+// ─── MockEventEmitter ───────────────────────────────────────────────
+
+#[derive(Debug, Clone)]
+pub struct MockEvent {
+    pub name: String,
+    pub payload: Option<String>,
+}
+
+#[derive(Debug, Default)]
+pub struct MockEventEmitter {
+    events: Mutex<Vec<MockEvent>>,
+}
+
+impl MockEventEmitter {
+    pub fn new() -> Arc<Self> {
+        Arc::new(Self::default())
+    }
+
+    /// Returns a clone of all captured events.
+    pub fn events(&self) -> Vec<MockEvent> {
+        self.events.lock().unwrap().clone()
+    }
+
+    /// Returns true if any event with the given name was emitted.
+    pub fn has_event(&self, name: &str) -> bool {
+        self.events.lock().unwrap().iter().any(|e| e.name == name)
+    }
+
+    /// Returns all event names in order.
+    pub fn event_names(&self) -> Vec<String> {
+        self.events
+            .lock()
+            .unwrap()
+            .iter()
+            .map(|e| e.name.clone())
+            .collect()
+    }
+
+    /// Returns all events matching the given name.
+    pub fn events_with_name(&self, name: &str) -> Vec<MockEvent> {
+        self.events
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|e| e.name == name)
+            .cloned()
+            .collect()
+    }
+}
+
+impl EventEmitter for MockEventEmitter {
+    fn emit_event(&self, event_name: &str) -> Result<(), String> {
+        self.events.lock().unwrap().push(MockEvent {
+            name: event_name.to_string(),
+            payload: None,
+        });
+        Ok(())
+    }
+
+    fn emit_event_with_payload(&self, event_name: &str, payload: &str) -> Result<(), String> {
+        self.events.lock().unwrap().push(MockEvent {
+            name: event_name.to_string(),
+            payload: Some(payload.to_string()),
+        });
+        Ok(())
+    }
+}
+
+// ─── TestFixture ────────────────────────────────────────────────────
+
+/// Helper to manage temp directories and files for E2E tests.
+pub struct TestFixture {
+    pub dir: tempfile::TempDir,
+}
+
+impl TestFixture {
+    pub fn new() -> Self {
+        Self {
+            dir: tempfile::TempDir::new().expect("failed to create temp dir"),
+        }
+    }
+
+    /// Create a file with the given content, returns absolute path.
+    pub fn create_file(&self, name: &str, content: &[u8]) -> PathBuf {
+        let path = self.dir.path().join(name);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).expect("failed to create parent dirs");
+        }
+        std::fs::write(&path, content).expect("failed to write file");
+        path
+    }
+
+    /// Create a large file filled with a deterministic pattern.
+    pub fn create_large_file(&self, name: &str, size: usize) -> PathBuf {
+        let data: Vec<u8> = (0..size).map(|i| (i % 251) as u8).collect();
+        self.create_file(name, &data)
+    }
+
+    /// Create a directory with multiple files.
+    /// `files` is a slice of (relative_path, content) tuples.
+    pub fn create_dir_with_files(&self, dir_name: &str, files: &[(&str, &[u8])]) -> PathBuf {
+        let dir_path = self.dir.path().join(dir_name);
+        for (rel_path, content) in files {
+            let file_path = dir_path.join(rel_path);
+            if let Some(parent) = file_path.parent() {
+                std::fs::create_dir_all(parent).expect("failed to create parent dirs");
+            }
+            std::fs::write(&file_path, content).expect("failed to write file");
+        }
+        dir_path
+    }
+
+    /// Returns a fresh output directory for receiving files.
+    pub fn output_dir(&self) -> PathBuf {
+        let out = self.dir.path().join("received");
+        std::fs::create_dir_all(&out).expect("failed to create output dir");
+        out
+    }
+}

--- a/sendme/tests/common/mod.rs
+++ b/sendme/tests/common/mod.rs
@@ -4,8 +4,6 @@ use sendme::EventEmitter;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
-// ─── MockEventEmitter ───────────────────────────────────────────────
-
 #[derive(Debug, Clone)]
 pub struct MockEvent {
     pub name: String,
@@ -71,8 +69,6 @@ impl EventEmitter for MockEventEmitter {
         Ok(())
     }
 }
-
-// ─── TestFixture ────────────────────────────────────────────────────
 
 /// Helper to manage temp directories and files for E2E tests.
 pub struct TestFixture {

--- a/sendme/tests/common/mod.rs
+++ b/sendme/tests/common/mod.rs
@@ -118,4 +118,12 @@ impl TestFixture {
         std::fs::create_dir_all(&out).expect("failed to create output dir");
         out
     }
+
+    /// Returns a fresh named output directory for receiving files.
+    /// Use this when a single test needs multiple independent receive directories.
+    pub fn output_dir_named(&self, name: &str) -> PathBuf {
+        let out = self.dir.path().join(name);
+        std::fs::create_dir_all(&out).expect("failed to create output dir");
+        out
+    }
 }

--- a/sendme/tests/test_conflicts.rs
+++ b/sendme/tests/test_conflicts.rs
@@ -33,6 +33,13 @@ async fn e2e_filename_conflict_resolved() {
         .expect("renamed file should exist");
     assert_eq!(renamed, "new version of report");
 
+    let original = std::fs::read_to_string(recv_dir.join("report.txt"))
+        .expect("original file should still exist");
+    assert_eq!(
+        original, "old version of report",
+        "original file must NOT be overwritten during conflict resolution"
+    );
+
     assert!(
         receiver_emitter.has_event("receive-conflicts"),
         "should emit receive-conflicts event"

--- a/sendme/tests/test_conflicts.rs
+++ b/sendme/tests/test_conflicts.rs
@@ -1,0 +1,80 @@
+mod common;
+
+use common::{MockEventEmitter, TestFixture};
+use sendme::{download, start_share, ReceiveOptions, SendOptions};
+
+#[tokio::test]
+async fn e2e_filename_conflict_resolved() {
+    let fixture = TestFixture::new();
+    let source = fixture.create_file("report.txt", b"new version of report");
+    let recv_dir = fixture.output_dir();
+
+    // Pre-create a conflicting file at the destination
+    std::fs::write(recv_dir.join("report.txt"), b"old version of report")
+        .expect("should create conflicting file");
+
+    let receiver_emitter = MockEventEmitter::new();
+
+    let share = start_share(source, SendOptions::default(), None, None)
+        .await
+        .expect("start_share should succeed");
+
+    download(
+        share.ticket.clone(),
+        ReceiveOptions {
+            output_dir: Some(recv_dir.clone()),
+            ..Default::default()
+        },
+        Some(receiver_emitter.clone()),
+    )
+    .await
+    .expect("download should succeed even with conflict");
+
+    // New file should be renamed to avoid overwriting
+    let renamed = std::fs::read_to_string(recv_dir.join("report (1).txt"))
+        .expect("renamed file should exist");
+    assert_eq!(renamed, "new version of report");
+
+    // Conflict event should have been emitted
+    assert!(
+        receiver_emitter.has_event("receive-conflicts"),
+        "should emit receive-conflicts event"
+    );
+
+    drop(share);
+}
+
+#[tokio::test]
+async fn e2e_original_file_preserved() {
+    let fixture = TestFixture::new();
+    let source = fixture.create_file("keep_me.txt", b"incoming data");
+    let recv_dir = fixture.output_dir();
+
+    // Pre-create the file that should NOT be overwritten
+    std::fs::write(recv_dir.join("keep_me.txt"), b"original data, do not touch")
+        .expect("should create original file");
+
+    let share = start_share(source, SendOptions::default(), None, None)
+        .await
+        .expect("start_share should succeed");
+
+    download(
+        share.ticket.clone(),
+        ReceiveOptions {
+            output_dir: Some(recv_dir.clone()),
+            ..Default::default()
+        },
+        None,
+    )
+    .await
+    .expect("download should succeed");
+
+    // Original file should be completely untouched
+    let original = std::fs::read_to_string(recv_dir.join("keep_me.txt")).unwrap();
+    assert_eq!(
+        original, "original data, do not touch",
+        "original file must NOT be overwritten"
+    );
+
+    drop(share);
+}

--- a/sendme/tests/test_conflicts.rs
+++ b/sendme/tests/test_conflicts.rs
@@ -71,5 +71,9 @@ async fn e2e_original_file_preserved() {
         "original file must NOT be overwritten"
     );
 
+    let renamed = std::fs::read_to_string(recv_dir.join("keep_me (1).txt"))
+        .expect("incoming file should have been saved under a conflict-resolved name");
+    assert_eq!(renamed, "incoming data", "incoming content must be preserved");
+
     drop(share);
 }

--- a/sendme/tests/test_conflicts.rs
+++ b/sendme/tests/test_conflicts.rs
@@ -9,7 +9,6 @@ async fn e2e_filename_conflict_resolved() {
     let source = fixture.create_file("report.txt", b"new version of report");
     let recv_dir = fixture.output_dir();
 
-    // Pre-create a conflicting file at the destination
     std::fs::write(recv_dir.join("report.txt"), b"old version of report")
         .expect("should create conflicting file");
 
@@ -30,12 +29,10 @@ async fn e2e_filename_conflict_resolved() {
     .await
     .expect("download should succeed even with conflict");
 
-    // New file should be renamed to avoid overwriting
     let renamed = std::fs::read_to_string(recv_dir.join("report (1).txt"))
         .expect("renamed file should exist");
     assert_eq!(renamed, "new version of report");
 
-    // Conflict event should have been emitted
     assert!(
         receiver_emitter.has_event("receive-conflicts"),
         "should emit receive-conflicts event"
@@ -50,7 +47,6 @@ async fn e2e_original_file_preserved() {
     let source = fixture.create_file("keep_me.txt", b"incoming data");
     let recv_dir = fixture.output_dir();
 
-    // Pre-create the file that should NOT be overwritten
     std::fs::write(recv_dir.join("keep_me.txt"), b"original data, do not touch")
         .expect("should create original file");
 
@@ -69,7 +65,6 @@ async fn e2e_original_file_preserved() {
     .await
     .expect("download should succeed");
 
-    // Original file should be completely untouched
     let original = std::fs::read_to_string(recv_dir.join("keep_me.txt")).unwrap();
     assert_eq!(
         original, "original data, do not touch",

--- a/sendme/tests/test_directory.rs
+++ b/sendme/tests/test_directory.rs
@@ -1,0 +1,94 @@
+mod common;
+
+use common::TestFixture;
+use sendme::{download, start_share, ReceiveOptions, SendOptions};
+
+#[tokio::test]
+async fn e2e_directory_roundtrip() {
+    let fixture = TestFixture::new();
+    let source_dir = fixture.create_dir_with_files(
+        "my_folder",
+        &[
+            ("root.txt", b"root file content"),
+            ("sub/nested.txt", b"nested file content"),
+        ],
+    );
+    let recv_dir = fixture.output_dir();
+
+    let share = start_share(source_dir, SendOptions::default(), None, None)
+        .await
+        .expect("start_share should succeed");
+
+    assert_eq!(share.entry_type, "directory");
+
+    download(
+        share.ticket.clone(),
+        ReceiveOptions {
+            output_dir: Some(recv_dir.clone()),
+            ..Default::default()
+        },
+        None,
+    )
+    .await
+    .expect("download should succeed");
+
+    // Verify directory structure is preserved
+    let root_content =
+        std::fs::read(recv_dir.join("my_folder/root.txt")).expect("root.txt should exist");
+    assert_eq!(root_content, b"root file content");
+
+    let nested_content = std::fs::read(recv_dir.join("my_folder/sub/nested.txt"))
+        .expect("sub/nested.txt should exist");
+    assert_eq!(nested_content, b"nested file content");
+
+    drop(share);
+}
+
+#[tokio::test]
+async fn e2e_directory_with_deep_nesting() {
+    let fixture = TestFixture::new();
+    let source_dir = fixture.create_dir_with_files(
+        "deep",
+        &[
+            ("a.txt", b"level 0"),
+            ("l1/b.txt", b"level 1"),
+            ("l1/l2/c.txt", b"level 2"),
+            ("l1/l2/l3/d.txt", b"level 3"),
+        ],
+    );
+    let recv_dir = fixture.output_dir();
+
+    let share = start_share(source_dir, SendOptions::default(), None, None)
+        .await
+        .expect("start_share should succeed");
+
+    download(
+        share.ticket.clone(),
+        ReceiveOptions {
+            output_dir: Some(recv_dir.clone()),
+            ..Default::default()
+        },
+        None,
+    )
+    .await
+    .expect("download should succeed");
+
+    assert_eq!(
+        std::fs::read(recv_dir.join("deep/a.txt")).unwrap(),
+        b"level 0"
+    );
+    assert_eq!(
+        std::fs::read(recv_dir.join("deep/l1/b.txt")).unwrap(),
+        b"level 1"
+    );
+    assert_eq!(
+        std::fs::read(recv_dir.join("deep/l1/l2/c.txt")).unwrap(),
+        b"level 2"
+    );
+    assert_eq!(
+        std::fs::read(recv_dir.join("deep/l1/l2/l3/d.txt")).unwrap(),
+        b"level 3"
+    );
+
+    drop(share);
+}

--- a/sendme/tests/test_directory.rs
+++ b/sendme/tests/test_directory.rs
@@ -32,7 +32,6 @@ async fn e2e_directory_roundtrip() {
     .await
     .expect("download should succeed");
 
-    // Verify directory structure is preserved
     let root_content =
         std::fs::read(recv_dir.join("my_folder/root.txt")).expect("root.txt should exist");
     assert_eq!(root_content, b"root file content");

--- a/sendme/tests/test_events.rs
+++ b/sendme/tests/test_events.rs
@@ -6,7 +6,6 @@ use sendme::{download, start_share, ReceiveOptions, SendOptions};
 #[tokio::test]
 async fn e2e_receiver_event_sequence() {
     let fixture = TestFixture::new();
-    // Use a larger file to ensure progress events fire between started and completed
     let source = fixture.create_large_file("sequence.bin", 2_000_000);
     let recv_dir = fixture.output_dir();
 
@@ -29,13 +28,11 @@ async fn e2e_receiver_event_sequence() {
 
     let names = receiver_emitter.event_names();
 
-    // receive-started must exist and come first among receive events
     let started_idx = names
         .iter()
         .position(|n| n == "receive-started")
         .expect("should have receive-started event");
 
-    // receive-completed must exist and come last
     let completed_idx = names
         .iter()
         .rposition(|n| n == "receive-completed")
@@ -48,7 +45,6 @@ async fn e2e_receiver_event_sequence() {
         completed_idx,
     );
 
-    // receive-file-names should come before completed
     let file_names_idx = names
         .iter()
         .position(|n| n == "receive-file-names")
@@ -92,10 +88,8 @@ async fn e2e_sender_events_on_transfer() {
     .await
     .expect("download should succeed");
 
-    // Give the sender a moment to process the transfer completion
     tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
 
-    // Sender should have emitted transfer-completed after the receiver downloaded
     assert!(
         sender_emitter.has_event("transfer-completed"),
         "sender should emit transfer-completed. Events: {:?}",

--- a/sendme/tests/test_events.rs
+++ b/sendme/tests/test_events.rs
@@ -1,0 +1,121 @@
+mod common;
+
+use common::{MockEventEmitter, TestFixture};
+use sendme::{download, start_share, ReceiveOptions, SendOptions};
+
+#[tokio::test]
+async fn e2e_receiver_event_sequence() {
+    let fixture = TestFixture::new();
+    // Use a larger file to ensure progress events fire between started and completed
+    let source = fixture.create_large_file("sequence.bin", 2_000_000);
+    let recv_dir = fixture.output_dir();
+
+    let receiver_emitter = MockEventEmitter::new();
+
+    let share = start_share(source, SendOptions::default(), None, None)
+        .await
+        .expect("start_share should succeed");
+
+    download(
+        share.ticket.clone(),
+        ReceiveOptions {
+            output_dir: Some(recv_dir.clone()),
+            ..Default::default()
+        },
+        Some(receiver_emitter.clone()),
+    )
+    .await
+    .expect("download should succeed");
+
+    let names = receiver_emitter.event_names();
+
+    // receive-started must exist and come first among receive events
+    let started_idx = names
+        .iter()
+        .position(|n| n == "receive-started")
+        .expect("should have receive-started event");
+
+    // receive-completed must exist and come last
+    let completed_idx = names
+        .iter()
+        .rposition(|n| n == "receive-completed")
+        .expect("should have receive-completed event");
+
+    assert!(
+        started_idx < completed_idx,
+        "receive-started (idx {}) must come before receive-completed (idx {})",
+        started_idx,
+        completed_idx,
+    );
+
+    // receive-file-names should come before completed
+    let file_names_idx = names
+        .iter()
+        .position(|n| n == "receive-file-names")
+        .expect("should have receive-file-names event");
+
+    assert!(
+        file_names_idx < completed_idx,
+        "receive-file-names (idx {}) must come before receive-completed (idx {})",
+        file_names_idx,
+        completed_idx,
+    );
+
+    drop(share);
+}
+
+#[tokio::test]
+async fn e2e_sender_events_on_transfer() {
+    let fixture = TestFixture::new();
+    let source = fixture.create_large_file("sender_events.bin", 2_000_000);
+    let recv_dir = fixture.output_dir();
+
+    let sender_emitter = MockEventEmitter::new();
+
+    let share = start_share(
+        source,
+        SendOptions::default(),
+        Some(sender_emitter.clone()),
+        None,
+    )
+    .await
+    .expect("start_share should succeed");
+
+    download(
+        share.ticket.clone(),
+        ReceiveOptions {
+            output_dir: Some(recv_dir),
+            ..Default::default()
+        },
+        None,
+    )
+    .await
+    .expect("download should succeed");
+
+    // Give the sender a moment to process the transfer completion
+    tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
+
+    // Sender should have emitted transfer-completed after the receiver downloaded
+    assert!(
+        sender_emitter.has_event("transfer-completed"),
+        "sender should emit transfer-completed. Events: {:?}",
+        sender_emitter.event_names(),
+    );
+
+    drop(share);
+}
+
+#[tokio::test]
+async fn e2e_invalid_ticket_errors() {
+    let result = download(
+        "not-a-valid-ticket-string".to_string(),
+        ReceiveOptions::default(),
+        None,
+    )
+    .await;
+
+    assert!(
+        result.is_err(),
+        "download with invalid ticket should return error"
+    );
+}

--- a/sendme/tests/test_events.rs
+++ b/sendme/tests/test_events.rs
@@ -88,13 +88,16 @@ async fn e2e_sender_events_on_transfer() {
     .await
     .expect("download should succeed");
 
-    tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
-
-    assert!(
-        sender_emitter.has_event("transfer-completed"),
-        "sender should emit transfer-completed. Events: {:?}",
-        sender_emitter.event_names(),
-    );
+    tokio::time::timeout(tokio::time::Duration::from_secs(5), async {
+        loop {
+            if sender_emitter.has_event("transfer-completed") {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("timed out waiting for transfer-completed event");
 
     drop(share);
 }

--- a/sendme/tests/test_large_file.rs
+++ b/sendme/tests/test_large_file.rs
@@ -1,0 +1,93 @@
+mod common;
+
+use common::{MockEventEmitter, TestFixture};
+use sendme::{download, start_share, ReceiveOptions, SendOptions};
+
+#[tokio::test]
+async fn e2e_large_file_integrity() {
+    let fixture = TestFixture::new();
+    // 10MB deterministic pattern
+    let source = fixture.create_large_file("large.bin", 10_000_000);
+    let recv_dir = fixture.output_dir();
+
+    let share = start_share(source.clone(), SendOptions::default(), None, None)
+        .await
+        .expect("start_share should succeed");
+
+    assert_eq!(share.size, 10_000_000);
+
+    download(
+        share.ticket.clone(),
+        ReceiveOptions {
+            output_dir: Some(recv_dir.clone()),
+            ..Default::default()
+        },
+        None,
+    )
+    .await
+    .expect("download should succeed");
+
+    let original = std::fs::read(&source).unwrap();
+    let received = std::fs::read(recv_dir.join("large.bin")).expect("received file should exist");
+
+    assert_eq!(
+        received.len(),
+        original.len(),
+        "file size should match (10MB)"
+    );
+    assert_eq!(
+        received, original,
+        "10MB file should be identical after P2P transfer"
+    );
+
+    drop(share);
+}
+
+#[tokio::test]
+async fn e2e_progress_events_emitted() {
+    let fixture = TestFixture::new();
+    // 5MB to ensure progress events fire (they trigger every 1MB)
+    let source = fixture.create_large_file("progress.bin", 5_000_000);
+    let recv_dir = fixture.output_dir();
+
+    let receiver_emitter = MockEventEmitter::new();
+
+    let share = start_share(source, SendOptions::default(), None, None)
+        .await
+        .expect("start_share should succeed");
+
+    download(
+        share.ticket.clone(),
+        ReceiveOptions {
+            output_dir: Some(recv_dir.clone()),
+            ..Default::default()
+        },
+        Some(receiver_emitter.clone()),
+    )
+    .await
+    .expect("download should succeed");
+
+    // Progress events should have been emitted for a 5MB file
+    let progress_events = receiver_emitter.events_with_name("receive-progress");
+    assert!(
+        !progress_events.is_empty(),
+        "should have at least one progress event for a 5MB transfer"
+    );
+
+    // Verify progress payload format: "bytes_transferred:total_bytes:speed_int"
+    for event in &progress_events {
+        let payload = event.payload.as_ref().expect("progress event should have payload");
+        let parts: Vec<&str> = payload.split(':').collect();
+        assert_eq!(
+            parts.len(),
+            3,
+            "progress payload should have 3 colon-separated parts, got: {}",
+            payload
+        );
+    }
+
+    // Verify completion event fired
+    assert!(receiver_emitter.has_event("receive-completed"));
+
+    drop(share);
+}

--- a/sendme/tests/test_large_file.rs
+++ b/sendme/tests/test_large_file.rs
@@ -80,7 +80,7 @@ async fn e2e_progress_events_emitted() {
         assert_eq!(
             parts.len(),
             3,
-            "progress payload should have 3 colon-separated parts, got: {}",
+            "progress payload must be '<bytes_transferred>:<total_bytes>:<speed>', got: {}",
             payload
         );
     }

--- a/sendme/tests/test_large_file.rs
+++ b/sendme/tests/test_large_file.rs
@@ -6,7 +6,6 @@ use sendme::{download, start_share, ReceiveOptions, SendOptions};
 #[tokio::test]
 async fn e2e_large_file_integrity() {
     let fixture = TestFixture::new();
-    // 10MB deterministic pattern
     let source = fixture.create_large_file("large.bin", 10_000_000);
     let recv_dir = fixture.output_dir();
 
@@ -46,7 +45,6 @@ async fn e2e_large_file_integrity() {
 #[tokio::test]
 async fn e2e_progress_events_emitted() {
     let fixture = TestFixture::new();
-    // 5MB to ensure progress events fire (they trigger every 1MB)
     let source = fixture.create_large_file("progress.bin", 5_000_000);
     let recv_dir = fixture.output_dir();
 
@@ -67,16 +65,17 @@ async fn e2e_progress_events_emitted() {
     .await
     .expect("download should succeed");
 
-    // Progress events should have been emitted for a 5MB file
     let progress_events = receiver_emitter.events_with_name("receive-progress");
     assert!(
         !progress_events.is_empty(),
         "should have at least one progress event for a 5MB transfer"
     );
 
-    // Verify progress payload format: "bytes_transferred:total_bytes:speed_int"
     for event in &progress_events {
-        let payload = event.payload.as_ref().expect("progress event should have payload");
+        let payload = event
+            .payload
+            .as_ref()
+            .expect("progress event should have payload");
         let parts: Vec<&str> = payload.split(':').collect();
         assert_eq!(
             parts.len(),
@@ -86,7 +85,6 @@ async fn e2e_progress_events_emitted() {
         );
     }
 
-    // Verify completion event fired
     assert!(receiver_emitter.has_event("receive-completed"));
 
     drop(share);

--- a/sendme/tests/test_metadata.rs
+++ b/sendme/tests/test_metadata.rs
@@ -8,12 +8,13 @@ use sendme::{
 #[tokio::test]
 async fn e2e_metadata_preview() {
     let fixture = TestFixture::new();
-    let source = fixture.create_file("preview_test.txt", b"preview content here");
+    let content = b"preview content here";
+    let source = fixture.create_file("preview_test.txt", content);
 
     let metadata = FileMetadata {
         file_name: "preview_test.txt".into(),
         item_count: 1,
-        size: 20,
+        size: content.len() as u64,
         thumbnail: Some("data:image/png;base64,dGVzdA==".into()),
         mime_type: Some("text/plain".into()),
         items: None,
@@ -28,7 +29,7 @@ async fn e2e_metadata_preview() {
         .expect("fetch_metadata should succeed");
 
     assert_eq!(fetched.file_name, "preview_test.txt");
-    assert_eq!(fetched.size, 20);
+    assert_eq!(fetched.size, content.len() as u64);
     assert_eq!(fetched.mime_type, Some("text/plain".into()));
     assert_eq!(
         fetched.thumbnail,
@@ -42,13 +43,15 @@ async fn e2e_metadata_preview() {
 #[tokio::test]
 async fn e2e_metadata_multi_item() {
     let fixture = TestFixture::new();
-    let file_a = fixture.create_file("a.txt", b"aaa");
-    let file_b = fixture.create_file("b.txt", b"bbb");
+    let content_a = b"aaa";
+    let content_b = b"bbb";
+    let file_a = fixture.create_file("a.txt", content_a);
+    let file_b = fixture.create_file("b.txt", content_b);
 
     let metadata = FileMetadata {
         file_name: "2 items".into(),
         item_count: 2,
-        size: 6,
+        size: (content_a.len() + content_b.len()) as u64,
         thumbnail: None,
         mime_type: None,
         items: None,
@@ -69,7 +72,7 @@ async fn e2e_metadata_multi_item() {
 
     assert_eq!(fetched.file_name, "2 items");
     assert_eq!(fetched.item_count, 2);
-    assert_eq!(fetched.size, 6);
+    assert_eq!(fetched.size, (content_a.len() + content_b.len()) as u64);
 
     drop(share);
 }

--- a/sendme/tests/test_metadata.rs
+++ b/sendme/tests/test_metadata.rs
@@ -1,0 +1,81 @@
+mod common;
+
+use common::TestFixture;
+use sendme::{
+    fetch_metadata, start_share, start_share_items, FileMetadata, ReceiveOptions,
+    SendOptions,
+};
+
+#[tokio::test]
+async fn e2e_metadata_preview() {
+    let fixture = TestFixture::new();
+    let source = fixture.create_file("preview_test.txt", b"preview content here");
+
+    let metadata = FileMetadata {
+        file_name: "preview_test.txt".into(),
+        item_count: 1,
+        size: 20,
+        thumbnail: Some("data:image/png;base64,dGVzdA==".into()),
+        mime_type: Some("text/plain".into()),
+        items: None,
+    };
+
+    let share = start_share(
+        source,
+        SendOptions::default(),
+        None,
+        Some(metadata.clone()),
+    )
+    .await
+    .expect("start_share should succeed");
+
+    let fetched = fetch_metadata(share.ticket.clone(), ReceiveOptions::default())
+        .await
+        .expect("fetch_metadata should succeed");
+
+    assert_eq!(fetched.file_name, "preview_test.txt");
+    assert_eq!(fetched.size, 20);
+    assert_eq!(fetched.mime_type, Some("text/plain".into()));
+    assert_eq!(
+        fetched.thumbnail,
+        Some("data:image/png;base64,dGVzdA==".into())
+    );
+    assert_eq!(fetched.item_count, 1);
+
+    drop(share);
+}
+
+#[tokio::test]
+async fn e2e_metadata_multi_item() {
+    let fixture = TestFixture::new();
+    let file_a = fixture.create_file("a.txt", b"aaa");
+    let file_b = fixture.create_file("b.txt", b"bbb");
+
+    let metadata = FileMetadata {
+        file_name: "2 items".into(),
+        item_count: 2,
+        size: 6,
+        thumbnail: None,
+        mime_type: None,
+        items: None,
+    };
+
+    let share = start_share_items(
+        vec![file_a, file_b],
+        SendOptions::default(),
+        &None,
+        Some(metadata),
+    )
+    .await
+    .expect("start_share_items should succeed");
+
+    let fetched = fetch_metadata(share.ticket.clone(), ReceiveOptions::default())
+        .await
+        .expect("fetch_metadata should succeed");
+
+    assert_eq!(fetched.file_name, "2 items");
+    assert_eq!(fetched.item_count, 2);
+    assert_eq!(fetched.size, 6);
+
+    drop(share);
+}

--- a/sendme/tests/test_metadata.rs
+++ b/sendme/tests/test_metadata.rs
@@ -73,6 +73,8 @@ async fn e2e_metadata_multi_item() {
     assert_eq!(fetched.file_name, "2 items");
     assert_eq!(fetched.item_count, 2);
     assert_eq!(fetched.size, (content_a.len() + content_b.len()) as u64);
+    assert_eq!(fetched.thumbnail, None, "multi-item share should have no thumbnail");
+    assert_eq!(fetched.mime_type, None, "multi-item share should have no mime_type");
 
     drop(share);
 }

--- a/sendme/tests/test_metadata.rs
+++ b/sendme/tests/test_metadata.rs
@@ -2,8 +2,7 @@ mod common;
 
 use common::TestFixture;
 use sendme::{
-    fetch_metadata, start_share, start_share_items, FileMetadata, ReceiveOptions,
-    SendOptions,
+    fetch_metadata, start_share, start_share_items, FileMetadata, ReceiveOptions, SendOptions,
 };
 
 #[tokio::test]
@@ -20,14 +19,9 @@ async fn e2e_metadata_preview() {
         items: None,
     };
 
-    let share = start_share(
-        source,
-        SendOptions::default(),
-        None,
-        Some(metadata.clone()),
-    )
-    .await
-    .expect("start_share should succeed");
+    let share = start_share(source, SendOptions::default(), None, Some(metadata.clone()))
+        .await
+        .expect("start_share should succeed");
 
     let fetched = fetch_metadata(share.ticket.clone(), ReceiveOptions::default())
         .await

--- a/sendme/tests/test_multi_item.rs
+++ b/sendme/tests/test_multi_item.rs
@@ -1,0 +1,93 @@
+mod common;
+
+use common::TestFixture;
+use sendme::{download, start_share_items, ReceiveOptions, SendOptions};
+
+#[tokio::test]
+async fn e2e_multi_file_roundtrip() {
+    let fixture = TestFixture::new();
+    let file_a = fixture.create_file("doc.pdf", &vec![0xAA; 5000]);
+    let file_b = fixture.create_file("photo.jpg", &vec![0xBB; 3000]);
+    let file_c = fixture.create_file("notes.txt", b"some notes here");
+    let recv_dir = fixture.output_dir();
+
+    let share = start_share_items(
+        vec![file_a, file_b, file_c],
+        SendOptions::default(),
+        &None,
+        None,
+    )
+    .await
+    .expect("start_share_items should succeed");
+
+    assert_eq!(share.entry_type, "collection");
+
+    download(
+        share.ticket.clone(),
+        ReceiveOptions {
+            output_dir: Some(recv_dir.clone()),
+            ..Default::default()
+        },
+        None,
+    )
+    .await
+    .expect("download should succeed");
+
+    assert_eq!(std::fs::read(recv_dir.join("doc.pdf")).unwrap(), vec![0xAA; 5000]);
+    assert_eq!(std::fs::read(recv_dir.join("photo.jpg")).unwrap(), vec![0xBB; 3000]);
+    assert_eq!(
+        std::fs::read(recv_dir.join("notes.txt")).unwrap(),
+        b"some notes here"
+    );
+
+    drop(share);
+}
+
+#[tokio::test]
+async fn e2e_mixed_files_and_dirs() {
+    let fixture = TestFixture::new();
+    let single_file = fixture.create_file("standalone.txt", b"I am standalone");
+    let dir = fixture.create_dir_with_files(
+        "folder",
+        &[
+            ("inside.txt", b"I am inside a folder"),
+            ("sub/deep.txt", b"I am deep inside"),
+        ],
+    );
+    let recv_dir = fixture.output_dir();
+
+    let share = start_share_items(
+        vec![single_file, dir],
+        SendOptions::default(),
+        &None,
+        None,
+    )
+    .await
+    .expect("start_share_items should succeed");
+
+    download(
+        share.ticket.clone(),
+        ReceiveOptions {
+            output_dir: Some(recv_dir.clone()),
+            ..Default::default()
+        },
+        None,
+    )
+    .await
+    .expect("download should succeed");
+
+    assert_eq!(
+        std::fs::read(recv_dir.join("standalone.txt")).unwrap(),
+        b"I am standalone"
+    );
+    assert_eq!(
+        std::fs::read(recv_dir.join("folder/inside.txt")).unwrap(),
+        b"I am inside a folder"
+    );
+    assert_eq!(
+        std::fs::read(recv_dir.join("folder/sub/deep.txt")).unwrap(),
+        b"I am deep inside"
+    );
+
+    drop(share);
+}

--- a/sendme/tests/test_multi_item.rs
+++ b/sendme/tests/test_multi_item.rs
@@ -33,8 +33,14 @@ async fn e2e_multi_file_roundtrip() {
     .await
     .expect("download should succeed");
 
-    assert_eq!(std::fs::read(recv_dir.join("doc.pdf")).unwrap(), vec![0xAA; 5000]);
-    assert_eq!(std::fs::read(recv_dir.join("photo.jpg")).unwrap(), vec![0xBB; 3000]);
+    assert_eq!(
+        std::fs::read(recv_dir.join("doc.pdf")).unwrap(),
+        vec![0xAA; 5000]
+    );
+    assert_eq!(
+        std::fs::read(recv_dir.join("photo.jpg")).unwrap(),
+        vec![0xBB; 3000]
+    );
     assert_eq!(
         std::fs::read(recv_dir.join("notes.txt")).unwrap(),
         b"some notes here"
@@ -56,14 +62,9 @@ async fn e2e_mixed_files_and_dirs() {
     );
     let recv_dir = fixture.output_dir();
 
-    let share = start_share_items(
-        vec![single_file, dir],
-        SendOptions::default(),
-        &None,
-        None,
-    )
-    .await
-    .expect("start_share_items should succeed");
+    let share = start_share_items(vec![single_file, dir], SendOptions::default(), &None, None)
+        .await
+        .expect("start_share_items should succeed");
 
     download(
         share.ticket.clone(),

--- a/sendme/tests/test_single_file.rs
+++ b/sendme/tests/test_single_file.rs
@@ -1,0 +1,118 @@
+mod common;
+
+use common::{MockEventEmitter, TestFixture};
+use sendme::{download, start_share, ReceiveOptions, SendOptions};
+
+#[tokio::test]
+async fn e2e_single_text_file_roundtrip() {
+    let fixture = TestFixture::new();
+    let source = fixture.create_file("hello.txt", b"Hello from AltSendme E2E test!");
+    let recv_dir = fixture.output_dir();
+
+    let sender_emitter = MockEventEmitter::new();
+    let share = start_share(
+        source,
+        SendOptions::default(),
+        Some(sender_emitter.clone()),
+        None,
+    )
+    .await
+    .expect("start_share should succeed");
+
+    assert!(!share.ticket.is_empty(), "ticket should not be empty");
+    assert!(share.size > 0, "shared size should be > 0");
+    assert_eq!(share.entry_type, "file");
+
+    let receiver_emitter = MockEventEmitter::new();
+    let result = download(
+        share.ticket.clone(),
+        ReceiveOptions {
+            output_dir: Some(recv_dir.clone()),
+            ..Default::default()
+        },
+        Some(receiver_emitter.clone()),
+    )
+    .await
+    .expect("download should succeed");
+
+    assert!(!result.message.is_empty());
+
+    let received = std::fs::read(recv_dir.join("hello.txt")).expect("received file should exist");
+    assert_eq!(
+        received,
+        b"Hello from AltSendme E2E test!",
+        "file content should match exactly"
+    );
+
+    // Verify receiver events
+    assert!(
+        receiver_emitter.has_event("receive-started"),
+        "should emit receive-started"
+    );
+    assert!(
+        receiver_emitter.has_event("receive-completed"),
+        "should emit receive-completed"
+    );
+
+    drop(share);
+}
+
+#[tokio::test]
+async fn e2e_binary_file_roundtrip() {
+    let fixture = TestFixture::new();
+    let binary_data: Vec<u8> = (0..10_000u32).map(|i| (i % 256) as u8).collect();
+    let source = fixture.create_file("data.bin", &binary_data);
+    let recv_dir = fixture.output_dir();
+
+    let share = start_share(source, SendOptions::default(), None, None)
+        .await
+        .expect("start_share should succeed");
+
+    download(
+        share.ticket.clone(),
+        ReceiveOptions {
+            output_dir: Some(recv_dir.clone()),
+            ..Default::default()
+        },
+        None,
+    )
+    .await
+    .expect("download should succeed");
+
+    let received = std::fs::read(recv_dir.join("data.bin")).expect("received file should exist");
+    assert_eq!(
+        received.len(),
+        binary_data.len(),
+        "file size should match"
+    );
+    assert_eq!(received, binary_data, "binary content should match exactly");
+
+    drop(share);
+}
+
+#[tokio::test]
+async fn e2e_empty_file_roundtrip() {
+    let fixture = TestFixture::new();
+    let source = fixture.create_file("empty.txt", b"");
+    let recv_dir = fixture.output_dir();
+
+    let share = start_share(source, SendOptions::default(), None, None)
+        .await
+        .expect("start_share should succeed");
+
+    download(
+        share.ticket.clone(),
+        ReceiveOptions {
+            output_dir: Some(recv_dir.clone()),
+            ..Default::default()
+        },
+        None,
+    )
+    .await
+    .expect("download should succeed");
+
+    let received = std::fs::read(recv_dir.join("empty.txt")).expect("received file should exist");
+    assert_eq!(received.len(), 0, "empty file should remain 0 bytes");
+
+    drop(share);
+}

--- a/sendme/tests/test_single_file.rs
+++ b/sendme/tests/test_single_file.rs
@@ -39,12 +39,10 @@ async fn e2e_single_text_file_roundtrip() {
 
     let received = std::fs::read(recv_dir.join("hello.txt")).expect("received file should exist");
     assert_eq!(
-        received,
-        b"Hello from AltSendme E2E test!",
+        received, b"Hello from AltSendme E2E test!",
         "file content should match exactly"
     );
 
-    // Verify receiver events
     assert!(
         receiver_emitter.has_event("receive-started"),
         "should emit receive-started"
@@ -80,11 +78,7 @@ async fn e2e_binary_file_roundtrip() {
     .expect("download should succeed");
 
     let received = std::fs::read(recv_dir.join("data.bin")).expect("received file should exist");
-    assert_eq!(
-        received.len(),
-        binary_data.len(),
-        "file size should match"
-    );
+    assert_eq!(received.len(), binary_data.len(), "file size should match");
     assert_eq!(received, binary_data, "binary content should match exactly");
 
     drop(share);


### PR DESCRIPTION
### What this PR does

Adds comprehensive end-to-end integration tests for AltSendme's core P2P file transfer engine. These tests exercise the real `sendme` library API (same code path the Tauri app uses) to verify that files sent from a sender arrive intact at the receiver.

### Why

Currently there are zero automated tests verifying that file transfers actually work. Every release relies on manual testing. These tests catch regressions in the critical path — broken transfers, data corruption, directory structure issues — on every PR before it reaches users.

### Test coverage (16 tests across 7 files)

| File | Tests | What it verifies |
|------|-------|-----------------|
| `test_single_file.rs` | 3 | Text, binary, and empty file roundtrips |
| `test_directory.rs` | 2 | Nested directory structure preservation |
| `test_multi_item.rs` | 2 | Multi-file sharing via `start_share_items` |
| `test_metadata.rs` | 2 | `fetch_metadata` preview (name, size, thumbnail, mime) |
| `test_large_file.rs` | 2 | 10MB file integrity + progress event emission |
| `test_conflicts.rs` | 2 | Filename conflict auto-resolution, original file preserved |
| `test_events.rs` | 3 | Event ordering, sender events, invalid ticket error handling |

### Changes

- **`sendme/tests/`** — 7 new test files + shared `common/mod.rs` helper module
- **`sendme/src/lib.rs`** — Export `FileMetadata` and `FilePreviewItem` (needed by metadata tests)
- **`.github/workflows/test.yml`** — New CI workflow to run tests on every push/PR to main
- **No new dependencies** — uses `tempfile` and `rand` already in dev-dependencies

### How to run

```bash
# Run all tests (unit + E2E)
cargo test --manifest-path sendme/Cargo.toml -- --test-threads=1

# Run a specific test file
cargo test --manifest-path sendme/Cargo.toml --test test_single_file

# Run with visible output
cargo test --manifest-path sendme/Cargo.toml -- --test-threads=1 --nocapture
```

> **Note:** `--test-threads=1` is required because P2P tests bind network ports and may conflict if run in parallel.

### Test results (local - macOS)

```
Unit tests:       18 passed
test_conflicts:    2 passed
test_directory:    2 passed
test_events:       3 passed
test_large_file:   2 passed
test_metadata:     2 passed
test_multi_item:   2 passed
test_single_file:  3 passed
───────────────────────────
Total:            34 passed, 0 failed
```


## Checklist

- [ x] I have run **`npm run lint`** before raising this PR
- [ x] I have run **`npm run format`** before raising this PR
