### PR TITLE
fix: use larger 128x128 icon for system tray instead of default small…

### DIFF
--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -87,18 +87,17 @@ pub fn setup_tray(app: &AppHandle) -> tauri::Result<()> {
             _ => {}
         });
 
-   let icon_path = app
+ let icon_path = app
     .path()
-    .resource_dir()
-    .unwrap()
+    .resource_dir()?             
     .join("icons/128x128.png");
 
 let icon = tauri::image::Image::from_path(&icon_path)
-    .unwrap_or_else(|_| {
+    .or_else(|_| {
         app.default_window_icon()
-            .unwrap()
-            .clone()
-    });
+            .ok_or_else(|| tauri::Error::InvalidIcon)
+            .map(|i| i.clone())
+    })?;
 
 builder = builder.icon(icon);
 

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -87,9 +87,20 @@ pub fn setup_tray(app: &AppHandle) -> tauri::Result<()> {
             _ => {}
         });
 
-    if let Some(icon) = app.default_window_icon() {
-        builder = builder.icon(icon.clone());
-    }
+   let icon_path = app
+    .path()
+    .resource_dir()
+    .unwrap()
+    .join("icons/128x128.png");
+
+let icon = tauri::image::Image::from_path(&icon_path)
+    .unwrap_or_else(|_| {
+        app.default_window_icon()
+            .unwrap()
+            .clone()
+    });
+
+builder = builder.icon(icon);
 
     let tray = builder.build(app)?;
 


### PR DESCRIPTION
## Problem
System tray icon appears too small on 
Windows 11 because tray.rs uses 
default_window_icon() which loads 32x32.png.

## Fix
Changed tray.rs to load 128x128.png 
directly instead of using 
default_window_icon() for the system tray.

## Note
I was unable to test this locally due to 
MSVC build tools setup, but the fix is 
logically correct based on Tauri docs.
Happy to make any changes if needed!

Fixes #136