### PR TITLE
fix(relay): correct QUIC discovery port, pin image, templatize fly.dev

### DIFF
--- a/deploy/relay/Dockerfile
+++ b/deploy/relay/Dockerfile
@@ -1,9 +1,9 @@
 # Thin wrapper for Fly.io and other platforms that build from this directory.
 # Uses the official iroh-relay image as the runtime.
-FROM n0computer/iroh-relay:latest
+FROM n0computer/iroh-relay:v1.0.0
 
 COPY iroh-relay.conf /config/iroh-relay.conf
 
-EXPOSE 80/tcp 443/tcp 3478/udp 9090/tcp
+EXPOSE 80/tcp 443/tcp 7842/udp 9090/tcp
 
 CMD ["--config-path", "/config/iroh-relay.conf"]

--- a/deploy/relay/README.md
+++ b/deploy/relay/README.md
@@ -8,7 +8,7 @@ Run your own relay so AltSendme transfers do not use the public iroh relay infra
 |-------------|---------|
 | Server | VM or container with a **public IP** |
 | DNS | `A` / `AAAA` record for your relay hostname |
-| Ports | `80/tcp`, `443/tcp`, `3478/udp` (STUN), `9090/tcp` (metrics, optional) |
+| Ports | `80/tcp`, `443/tcp`, `7842/udp` (QUIC address discovery), `9090/tcp` (metrics, optional) |
 | TLS | Automatic via Let's Encrypt (built into `iroh-relay`) |
 
 For production, run **at least two relays** in different regions and add both URLs in AltSendme → Settings → Network.
@@ -51,6 +51,28 @@ fly deploy
 
 Update `iroh-relay.conf` so `hostname` matches the DNS name you point at the Fly app.
 
+## Quick deploy to Fly.io (no domain)
+
+For a fast functional test without owning a domain, use `fly.dev.toml`. It runs the relay
+in `--dev` mode (plain HTTP on port 3340); Fly's edge terminates TLS and proxies to it, so
+the relay is reachable at `https://<app>.fly.dev` with a valid cert.
+
+```bash
+cd deploy/relay
+# edit fly.dev.toml: set a unique `app` name and a nearby `primary_region`
+fly apps create <your-unique-name>
+fly deploy --config fly.dev.toml
+fly status   # confirm the machine is running
+```
+
+Then in AltSendme → **Settings → Network → Custom self-hosted**, add
+`https://<your-unique-name>.fly.dev` and click **Test connection**.
+
+> **Caveat:** this mode provides **relaying only** — QUIC address discovery / holepunch
+> assist is disabled in `--dev` (it needs direct UDP + TLS). It's ideal for trying the
+> feature, not for a production relay. For production, use the Let's Encrypt setup above
+> (`fly.toml` + your own domain).
+
 ## Private relay (shared token)
 
 To allow only clients that know your secret, uncomment and set in `iroh-relay.conf`:
@@ -68,7 +90,7 @@ After deployment, open AltSendme → Settings → Network → **Test connection*
 ## Troubleshooting
 
 - **ACME / TLS fails**: ensure port 80 is reachable from the internet and DNS points to this host.
-- **Test connection times out**: check firewall rules for 443/tcp and 3478/udp.
+- **Test connection times out**: check firewall rules for 443/tcp and 7842/udp.
 - **Auth fails**: confirm `access.shared_token` on the server matches the token in the app.
 
 ## References

--- a/deploy/relay/docker-compose.yml
+++ b/deploy/relay/docker-compose.yml
@@ -1,11 +1,11 @@
 services:
   relay:
-    image: n0computer/iroh-relay:latest
+    image: n0computer/iroh-relay:v1.0.0
     restart: unless-stopped
     ports:
       - "80:80"
       - "443:443"
-      - "3478:3478/udp"
+      - "7842:7842/udp"
       - "9090:9090"
     volumes:
       - ./iroh-relay.conf:/config/iroh-relay.conf:ro

--- a/deploy/relay/fly.dev.toml
+++ b/deploy/relay/fly.dev.toml
@@ -1,0 +1,30 @@
+# Quick-test iroh relay on Fly.io — NO custom domain.
+#
+# Runs iroh-relay in --dev mode (plain HTTP on :3340). Fly's edge terminates TLS and
+# proxies to it, so the relay is reachable at https://<app>.fly.dev with a valid cert.
+# This gives relaying only (QUIC address discovery is off in --dev). For a full
+# production relay with your own domain + Let's Encrypt, use fly.toml instead.
+#
+# Deploy:
+#   cd deploy/relay
+#   fly apps create --generate-name      # let Fly pick a random unique name...
+#   # ...or:  fly apps create my-relay   # ...or choose your own unique name
+#   # then set `app` below to the name Fly printed, and:
+#   fly deploy --config fly.dev.toml
+#   # relay URL = https://<app>.fly.dev
+
+app = "your-unique-relay-name"       # must be globally unique — replace before deploying
+primary_region = "iad"               # pick a region near you (e.g. ams, sin, sjc)
+
+[build]
+  image = "n0computer/iroh-relay:v1.0.0"   # pinned (matches app's iroh 1.0.0)
+
+[processes]
+  app = "--dev"                      # -> iroh-relay --dev : plain HTTP on :3340
+
+[http_service]
+  internal_port = 3340
+  force_https = true
+  auto_stop_machines = false
+  min_machines_running = 1           # keep the relay up
+  processes = ["app"]

--- a/deploy/relay/fly.toml
+++ b/deploy/relay/fly.toml
@@ -32,11 +32,11 @@ primary_region = "iad"
 
 [[services]]
   protocol = "udp"
-  internal_port = 3478
+  internal_port = 7842
   processes = ["app"]
 
   [[services.ports]]
-    port = 3478
+    port = 7842
 
 [[services]]
   protocol = "tcp"


### PR DESCRIPTION
- Replace stale STUN port 3478 with QUIC address discovery port 7842 (iroh 1.0 dropped STUN) in fly.toml, docker-compose.yml, Dockerfile, and README ports/troubleshooting
- Pin n0computer/iroh-relay to v1.0.0 in Dockerfile and docker-compose.yml to match fly.dev.toml and avoid :latest drift
- Replace hardcoded live app name in fly.dev.toml with a placeholder and document the `fly apps create --generate-name` randomiser flow

## Description

<!-- Briefly describe what this PR does -->

## Checklist

- [ ] I have run **`npm run lint`** before raising this PR
- [ ] I have run **`npm run format`** before raising this PR
