### PR TITLE
fix: wrong timeout comment, Node version mismatch in README, debug log

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ So mixed setups are fine for getting files across, but they're **not fully priva
 ### Prerequisites
 
 - Rust 1.91+
-- Node.js 18+
+- Node.js 20.19+
 - npm or yarn
 
 ### Getting Started
@@ -311,7 +311,7 @@ See [PRIVACY.md](PRIVACY.md) for information about how AltSendme handles your da
 - Web version (Send and receive from browser)
 - iOS app
 
-[📫 Drop your Email to recieve updates](https://tally.so/r/ob2Vkx)
+[📫 Drop your Email to receive updates](https://tally.so/r/ob2Vkx)
 
 
 

--- a/web-app/src/components/common/UploadBox.tsx
+++ b/web-app/src/components/common/UploadBox.tsx
@@ -103,7 +103,6 @@ export default function UploadBox({ onUpload }: UploadBoxProps) {
 		if (files.length === 0) return
 		const items = mapFilesToUploadItems(files)
 		onUpload?.(items)
-		console.log(items)
 	}
 
 	const handleInputChange = (files: FileList | null) => {

--- a/web-app/src/components/sender/SharingActiveCard.tsx
+++ b/web-app/src/components/sender/SharingActiveCard.tsx
@@ -49,7 +49,7 @@ export function SharingActiveCard({
 						},
 					},
 				})
-				// Auto-close "You are broadcasting" notification after 1 seconds
+				// Auto-close "You are broadcasting" notification after 5 seconds
 				setTimeout(() => {
 					toastManager.close(toastId)
 				}, 5000)


### PR DESCRIPTION
Small fixes:

- SharingActiveCard comment said "after 1 seconds" but the timeout is actually 5000ms
- README says Node.js 18+ but \`package.json\` engines requires \`>=20.19\`
- "recieve" typo in the README email signup link
- \`console.log(items)\` left in UploadBox production code