### PR TITLE
fix(android): support native share sheet batches

### DIFF
--- a/frontend/src/hooks/useDragDrop.ts
+++ b/frontend/src/hooks/useDragDrop.ts
@@ -167,11 +167,13 @@ export function useDragDrop(
 			startCopy: (
 				onStart: (path: string, size: bigint) => void,
 				onEvent: (event: { progress: number }) => void,
-				onComplete: (path: string) => void,
+				onComplete: (paths: string[]) => void,
 				onError?: (message: string) => void
 			) => Promise<{ cancelJob: () => Promise<void> } | null>,
-			pathType: 'file' | 'directory'
+			pathType: 'file' | 'directory',
+			afterSelect?: () => void
 		) => {
+			let completed = false
 			const handler = await startCopy(
 				(path, size) => {
 					setCopyFileName(path.split(/[/\\]/).filter(Boolean).pop() || path)
@@ -182,15 +184,18 @@ export function useDragDrop(
 				(event) => {
 					setCopyProgress(event.progress)
 				},
-				async (path) => {
+				async (paths) => {
+					completed = true
 					setIsCopying(false)
 					setCopyProgress(0)
 					setCopyFileName('')
 					setCopyTotalBytes('0')
 					cancelRef.current = null
-					await triggerFilesSelect([path], pathType)
+					await triggerFilesSelect(paths, pathType)
+					afterSelect?.()
 				},
 				(message) => {
+					completed = true
 					setIsCopying(false)
 					setCopyProgress(0)
 					setCopyFileName('')
@@ -200,7 +205,7 @@ export function useDragDrop(
 				}
 			)
 
-			if (handler) {
+			if (handler && !completed) {
 				cancelRef.current = () => handler.cancelJob()
 			}
 
@@ -211,11 +216,9 @@ export function useDragDrop(
 
 	const consumeAndroidShare = useCallback(async (): Promise<boolean> => {
 		try {
-			useTransferTabStore.getState().requestTab('send')
-			if (cancelRef.current) {
-				await cancelCopy()
-			}
-			return await beginAndroidCacheCopy(consumeShareIntent, 'file')
+			return await beginAndroidCacheCopy(consumeShareIntent, 'file', () => {
+				useTransferTabStore.getState().requestTab('send')
+			})
 		} catch (error) {
 			console.error('Failed to consume Android share intent:', error)
 			showAlert(
@@ -225,7 +228,7 @@ export function useDragDrop(
 			)
 			return false
 		}
-	}, [beginAndroidCacheCopy, cancelCopy, showAlert, t])
+	}, [beginAndroidCacheCopy, showAlert, t])
 
 	const consumeAndroidShareRef = useRef(consumeAndroidShare)
 	consumeAndroidShareRef.current = consumeAndroidShare
@@ -447,21 +450,20 @@ export function useDragDrop(
 
 		let disposed = false
 		let unlistenShare: (() => void) | undefined
-		let settled = false
-		const retryTimers: number[] = []
-		// Widened window: cold-start IPC-bridge readiness can vary a lot across
-		// devices, so keep polling for several seconds rather than giving up early.
-		const retryDelaysMs = [400, 1000, 2000, 3500, 5500, 8000]
+		let pollInFlight = false
 
 		const run = async () => {
-			if (disposed || settled) return
-			const consumed = await consumeAndroidShareRef.current()
-			if (consumed) {
-				settled = true
+			if (disposed || pollInFlight || cancelRef.current) return
+			pollInFlight = true
+			try {
+				await consumeAndroidShareRef.current()
+			} finally {
+				pollInFlight = false
 			}
 		}
 
 		const setup = async () => {
+			void run()
 			unlistenShare = await onShareReceived(() => {
 				void run()
 			})
@@ -469,23 +471,15 @@ export function useDragDrop(
 				unlistenShare()
 				return
 			}
-			// Cold start: intent may already be pending before listeners registered.
-			void run()
-			// Native load() posts shareReceived after WebView is ready; these retries
-			// cover the case where the first consume ran before the URI was stashed.
-			for (const delay of retryDelaysMs) {
-				retryTimers.push(window.setTimeout(() => void run(), delay))
-			}
 		}
 
 		void setup()
+		const pollTimer = window.setInterval(() => void run(), 1000)
 
 		return () => {
 			disposed = true
 			unlistenShare?.()
-			for (const id of retryTimers) {
-				window.clearTimeout(id)
-			}
+			window.clearInterval(pollTimer)
 		}
 	}, [])
 

--- a/frontend/src/plugins/nativeUtils.ts
+++ b/frontend/src/plugins/nativeUtils.ts
@@ -10,6 +10,8 @@ export type CopyProgress = {
 	totalBytes: string
 	progress: number
 	cachedPath?: string
+	cachedPaths?: string
+	completed?: boolean
 	error?: string
 }
 
@@ -54,7 +56,7 @@ export async function openDownloadFolder(treeUri: string): Promise<void> {
 type CopyHandlers = {
 	onStart: (path: string, size: bigint) => void
 	onEvent: (event: CopyProgress) => void
-	onComplete: (path: string) => void
+	onComplete: (paths: string[]) => void
 	onError?: (message: string) => void
 }
 
@@ -63,14 +65,19 @@ function bindCopyChannel(
 	handlers: CopyHandlers
 ) {
 	channel.onmessage = (event: CopyProgress) => {
+		const cachedPaths = event.cachedPaths
+			? (JSON.parse(event.cachedPaths) as string[])
+			: null
 		if (event.error) {
 			handlers.onError?.(event.error)
 			return
 		}
-		if (event.cachedPath && (event.progress === 0 || event.progress === 0.0)) {
+		if (cachedPaths && event.completed) {
+			handlers.onComplete(cachedPaths)
+		} else if (event.cachedPath && event.completed) {
+			handlers.onComplete([event.cachedPath])
+		} else if (event.cachedPath && (event.progress === 0 || event.progress === 0.0)) {
 			handlers.onStart(event.cachedPath, BigInt(event.totalBytes || '0'))
-		} else if (event.cachedPath && event.progress >= 1) {
-			handlers.onComplete(event.cachedPath)
 		} else {
 			handlers.onEvent(event)
 		}
@@ -80,7 +87,7 @@ function bindCopyChannel(
 export async function selectSendDocument(
 	onStart: (path: string, size: bigint) => void,
 	onEvent: (event: CopyProgress) => void,
-	onComplete: (path: string) => void,
+	onComplete: (paths: string[]) => void,
 	onError?: (message: string) => void
 ): Promise<FileSelectedHandler | null> {
 	if (!IS_TAURI) {
@@ -89,7 +96,7 @@ export async function selectSendDocument(
 		const paths = Array.isArray(selected) ? selected : [selected]
 		for (const path of paths) {
 			onStart(path, BigInt(0))
-			onComplete(path)
+			onComplete([path])
 		}
 		return null
 	}
@@ -110,7 +117,7 @@ export async function selectSendDocument(
 export async function selectSendFolder(
 	onStart: (path: string, size: bigint) => void,
 	onEvent: (event: CopyProgress) => void,
-	onComplete: (path: string) => void,
+	onComplete: (paths: string[]) => void,
 	onError?: (message: string) => void
 ): Promise<FileSelectedHandler | null> {
 	if (!IS_TAURI) {
@@ -119,7 +126,7 @@ export async function selectSendFolder(
 		const path = Array.isArray(selected) ? selected[0] : selected
 		if (!path) return null
 		onStart(path, BigInt(0))
-		onComplete(path)
+		onComplete([path])
 		return null
 	}
 
@@ -136,11 +143,10 @@ export async function selectSendFolder(
 	return new FileSelectedHandler(String(channel.id))
 }
 
-/** Consume a pending Android Share-sheet intent (ACTION_SEND). */
 export async function consumeShareIntent(
 	onStart: (path: string, size: bigint) => void,
 	onEvent: (event: CopyProgress) => void,
-	onComplete: (path: string) => void,
+	onComplete: (paths: string[]) => void,
 	onError?: (message: string) => void
 ): Promise<FileSelectedHandler | null> {
 	if (!IS_TAURI) return null

--- a/src-tauri/gen/android/app/src/main/AndroidManifest.xml
+++ b/src-tauri/gen/android/app/src/main/AndroidManifest.xml
@@ -26,6 +26,7 @@
             <!-- Appear in the system Share sheet (Gallery, Files, etc.) -->
             <intent-filter>
                 <action android:name="android.intent.action.SEND" />
+                <action android:name="android.intent.action.SEND_MULTIPLE" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <data android:mimeType="*/*" />
             </intent-filter>

--- a/src-tauri/plugins/tauri-plugin-native-utils/android/src/main/java/com/altsendme/plugin/native_utils/CopyUtils.kt
+++ b/src-tauri/plugins/tauri-plugin-native-utils/android/src/main/java/com/altsendme/plugin/native_utils/CopyUtils.kt
@@ -55,6 +55,8 @@ data class CopyProgress(
     val copiedBytes: Long,
     val totalBytes: Long,
     val cachedPath: String?,
+    val cachedPaths: List<String>? = null,
+    val completed: Boolean = false,
 ) {
     val progress: Float = if (totalBytes == 0L) 0f else copiedBytes / totalBytes.toFloat()
 
@@ -62,6 +64,8 @@ data class CopyProgress(
         put("copiedBytes", copiedBytes.toString())
         put("totalBytes", totalBytes.toString())
         put("cachedPath", cachedPath)
+        put("cachedPaths", cachedPaths?.let { org.json.JSONArray(it).toString() })
+        put("completed", completed)
         put("progress", progress)
     }
 }
@@ -139,6 +143,7 @@ fun copyUri(
             copiedBytes = finalTotal,
             totalBytes = finalTotal,
             target.absolutePath,
+            completed = true,
         )
     )
 }
@@ -205,7 +210,8 @@ private fun copyUriTreeWithProgress(
         CopyProgress(
             copiedBytes = totalBytes,
             totalBytes = totalBytes,
-            targetFolder.absolutePath
+            targetFolder.absolutePath,
+            completed = true,
         )
     )
 }

--- a/src-tauri/plugins/tauri-plugin-native-utils/android/src/main/java/com/altsendme/plugin/native_utils/NativeUtils.kt
+++ b/src-tauri/plugins/tauri-plugin-native-utils/android/src/main/java/com/altsendme/plugin/native_utils/NativeUtils.kt
@@ -1,6 +1,7 @@
 package com.altsendme.plugin.native_utils
 
 import android.app.Activity
+import android.content.ContentResolver
 import android.content.Intent
 import android.net.Uri
 import android.os.Build
@@ -28,7 +29,7 @@ import kotlinx.coroutines.launch
 import java.io.File
 import java.io.IOException
 import java.util.concurrent.ConcurrentHashMap
-import java.util.concurrent.atomic.AtomicReference
+import java.util.concurrent.ConcurrentLinkedQueue
 
 @InvokeArg
 class SelectorArgs {
@@ -61,16 +62,13 @@ data class DownloadFolderSelectionResponse(
 class NativeUtils(private val activity: Activity) : Plugin(activity) {
     private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
     private val jobs = ConcurrentHashMap<Long, Pair<Job, String>>()
-    private val pendingShareUri = AtomicReference<Uri?>(null)
+    private val pendingShareBatches = ConcurrentLinkedQueue<List<Uri>>()
 
     companion object {
         private const val RW_PERMISSION_FLAGS =
             Intent.FLAG_GRANT_WRITE_URI_PERMISSION or Intent.FLAG_GRANT_READ_URI_PERMISSION
         private const val SHARE_RECEIVED_EVENT = "shareReceived"
     }
-
-    private val consumedShareUris =
-        java.util.Collections.synchronizedSet(mutableSetOf<String>())
 
     @Command
     fun select_download_folder(invoke: Invoke) = startActivityForResult(
@@ -98,10 +96,10 @@ class NativeUtils(private val activity: Activity) : Plugin(activity) {
     @Command
     fun consume_share_intent(invoke: Invoke) {
         val args = invoke.parseArgs(SelectorArgs::class.java)
-        val uri = takePendingOrIntentShare()
+        val uris = takePendingOrIntentShare()
             ?: return invoke.resolveObject(false)
 
-        startUriCopy(uri, args.channel)
+        startUriCopy(uris, args.channel)
         invoke.resolveObject(true)
     }
 
@@ -210,18 +208,17 @@ class NativeUtils(private val activity: Activity) : Plugin(activity) {
 
         val uri = result.data?.data ?: return invoke.resolveObject(false)
 
-        startUriCopy(uri, channel)
+        startUriCopy(listOf(uri), channel)
         invoke.resolveObject(true)
     }
 
     override fun load(webView: WebView) {
         super.load(webView)
-
         // Cold start: capture share URI before / as the frontend mounts.
         // Skip wiping file_cache when a share is pending so cleanup cannot race the copy.
-        val shareUri = peekShareUri(activity.intent)
-        if (shareUri != null) {
-            pendingShareUri.set(shareUri)
+        val shareUris = takeShareUris(activity.intent)
+        if (shareUris != null) {
+            pendingShareBatches.add(shareUris)
             // Notify after the WebView can register plugin listeners (cold-start race).
             webView.post {
                 trigger(SHARE_RECEIVED_EVENT, JSObject())
@@ -238,8 +235,8 @@ class NativeUtils(private val activity: Activity) : Plugin(activity) {
         // Without this, activity.intent stays the old MAIN launcher intent under singleTask.
         activity.intent = intent
 
-        val uri = peekShareUri(intent) ?: return
-        pendingShareUri.set(uri)
+        val uris = takeShareUris(intent) ?: return
+        pendingShareBatches.add(uris)
         trigger(SHARE_RECEIVED_EVENT, JSObject())
     }
 
@@ -247,11 +244,9 @@ class NativeUtils(private val activity: Activity) : Plugin(activity) {
         super.onResume()
         // Safety net: if the frontend missed the first event (listener not ready yet),
         // re-advertise any still-unconsumed share when we come to the foreground.
-        val uri = peekShareUri(activity.intent) ?: return
-        pendingShareUri.compareAndSet(null, uri)
-        if (pendingShareUri.get() != null) {
-            trigger(SHARE_RECEIVED_EVENT, JSObject())
-        }
+        val uris = takeShareUris(activity.intent) ?: return
+        pendingShareBatches.add(uris)
+        trigger(SHARE_RECEIVED_EVENT, JSObject())
     }
 
     override fun onDestroy() {
@@ -267,7 +262,7 @@ class NativeUtils(private val activity: Activity) : Plugin(activity) {
         super.onDestroy()
     }
 
-    private fun startUriCopy(uri: Uri, channel: Channel) {
+    private fun startUriCopy(uris: List<Uri>, channel: Channel) {
         val path = listOf(
             activity.cacheDir.absolutePath,
             "file_cache",
@@ -275,14 +270,46 @@ class NativeUtils(private val activity: Activity) : Plugin(activity) {
         ).joinToString(File.separator)
 
         val tempFolder = File(path)
-
         val job = scope.launch(start = CoroutineStart.LAZY) {
             try {
                 tempFolder.parentFile?.mkdirs()
                     ?: throw IOException("Unable to create parent folders for ${tempFolder.absolutePath}")
 
-                copyUri(activity, uri, tempFolder).collect {
-                    channel.send(it.toJSObject())
+                if (uris.size == 1) {
+                    copyUri(activity, uris.single(), tempFolder).collect {
+                        channel.send(it.toJSObject())
+                    }
+                } else {
+                    val totalBytes = uris.sumOf { resolveContentLength(activity, it) }
+                    channel.send(CopyProgress(0, totalBytes, tempFolder.absolutePath).toJSObject())
+
+                    var copiedBytes = 0L
+                    val cachedPaths = mutableListOf<String>()
+                    uris.forEachIndexed { index, uri ->
+                        var fileBytes = 0L
+                        copyUri(activity, uri, tempFolder.resolve(index.toString())).collect { progress ->
+                            fileBytes = progress.copiedBytes
+                            progress.cachedPath?.takeIf { progress.completed }?.let(cachedPaths::add)
+                            channel.send(
+                                CopyProgress(
+                                    copiedBytes + progress.copiedBytes,
+                                    totalBytes,
+                                    null,
+                                ).toJSObject()
+                            )
+                        }
+                        copiedBytes += fileBytes
+                    }
+
+                    channel.send(
+                        CopyProgress(
+                            copiedBytes,
+                            if (totalBytes > 0) totalBytes else copiedBytes,
+                            null,
+                            cachedPaths,
+                            completed = true,
+                        ).toJSObject()
+                    )
                 }
             } catch (e: Exception) {
                 tempFolder.deleteRecursively()
@@ -304,59 +331,62 @@ class NativeUtils(private val activity: Activity) : Plugin(activity) {
     }
 
     @Synchronized
-    private fun takePendingOrIntentShare(): Uri? {
-        pendingShareUri.getAndSet(null)?.let { uri ->
-            markShareConsumed(uri)
-            return uri
-        }
-        return takeAndMarkShareUri(activity.intent)
+    private fun takePendingOrIntentShare(): List<Uri>? {
+        return pendingShareBatches.poll() ?: takeShareUris(activity.intent)
     }
 
-    private fun peekShareUri(intent: Intent?): Uri? {
-        if (intent == null || intent.action != Intent.ACTION_SEND) {
+    private fun peekShareUris(intent: Intent?): List<Uri>? {
+        if (intent == null ||
+            (intent.action != Intent.ACTION_SEND && intent.action != Intent.ACTION_SEND_MULTIPLE)
+        ) {
             return null
         }
-        val uri = extractShareUri(intent) ?: return null
-        if (consumedShareUris.contains(uri.toString())) {
-            return null
-        }
-        return uri
+        return extractShareUris(intent).takeIf { it.isNotEmpty() }
     }
 
-    private fun takeAndMarkShareUri(intent: Intent?): Uri? {
-        val uri = peekShareUri(intent) ?: return null
-        markShareConsumed(uri)
-        return uri
+    private fun takeShareUris(intent: Intent?): List<Uri>? {
+        val uris = peekShareUris(intent) ?: return null
+        intent?.action = null
+        return uris
     }
 
-    private fun markShareConsumed(uri: Uri) {
-        consumedShareUris.add(uri.toString())
-    }
-
-    private fun extractShareUri(intent: Intent): Uri? {
-        parcelableStreamExtra(intent)?.let { return it }
+    private fun extractShareUris(intent: Intent): List<Uri> {
+        val uris = mutableListOf<Uri>()
+        parcelableStreamExtras(intent)?.let(uris::addAll)
 
         when (val stream = intent.extras?.get(Intent.EXTRA_STREAM)) {
-            is Uri -> return stream
-            is String -> if (stream.isNotBlank()) return Uri.parse(stream)
+            is Uri -> uris.add(stream)
+            is String -> if (stream.isNotBlank()) uris.add(Uri.parse(stream))
+            is List<*> -> uris.addAll(stream.filterIsInstance<Uri>())
         }
 
         val clip = intent.clipData
-        if (clip != null && clip.itemCount > 0) {
-            clip.getItemAt(0)?.uri?.let { return it }
+        if (clip != null) {
+            repeat(clip.itemCount) { index ->
+                clip.getItemAt(index)?.uri?.let(uris::add)
+            }
         }
 
-        intent.data?.let { return it }
+        intent.data?.let(uris::add)
 
-        return null
+        return uris.distinct().filter { it.scheme == ContentResolver.SCHEME_CONTENT }
     }
 
     @Suppress("DEPRECATION")
-    private fun parcelableStreamExtra(intent: Intent): Uri? {
-        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            intent.getParcelableExtra(Intent.EXTRA_STREAM, Uri::class.java)
+    private fun parcelableStreamExtras(intent: Intent): List<Uri>? {
+        return if (intent.action == Intent.ACTION_SEND_MULTIPLE) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                intent.getParcelableArrayListExtra(Intent.EXTRA_STREAM, Uri::class.java)
+            } else {
+                intent.getParcelableArrayListExtra(Intent.EXTRA_STREAM)
+            }
         } else {
-            intent.getParcelableExtra(Intent.EXTRA_STREAM) as? Uri
+            val uri = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                intent.getParcelableExtra(Intent.EXTRA_STREAM, Uri::class.java)
+            } else {
+                intent.getParcelableExtra(Intent.EXTRA_STREAM) as? Uri
+            }
+            uri?.let(::listOf)
         }
     }
 }


### PR DESCRIPTION
## What changed

- Added Android `ACTION_SEND_MULTIPLE` support while retaining `ACTION_SEND`.
- Accepts arbitrary and mixed MIME types through the existing `*/*` share target.
- Extracts granted `content://` URIs from `EXTRA_STREAM`, `ClipData`, and intent data.
- Stages each shared item in Android private cache and loads the completed batch into the Send tab.
- Handles cold start, warm start, repeated sharing of the same URI, and back-to-back pending batches.

## Root cause

The frontend waited for mobile plugin-listener registration before its first consume attempt. On the tested Samsung device, that listener did not reliably wake the frontend, so Android delivered the intent and opened the Send tab but the pending URI was never consumed.

The existing finite retry/settled behavior also stopped checking after the first successful share, which broke warm-start delivery. Multiple-file sharing additionally lacked the manifest action, batch URI extraction, and a batch-safe completion payload.

## Implementation

- Native intent delivery is captured into a queue so a newer warm intent cannot overwrite an unconsumed batch.
- A lightweight idempotent frontend poll backs up the native event listener across Android lifecycle timing differences.
- Cache-copy completion returns the full staged-path batch to the existing sender selection flow.
- The Send tab opens only after cache staging and file selection succeed.
- Shared inputs are restricted to Android’s supported `content://` URI contract.
- Single-file picker and share behavior remain compatible with the existing cache-copy channel.

## Physical-device validation

User-confirmed on a **Samsung Galaxy S24+ (SM-S926U1), Android 16, API 36**:

- One image with the app fully stopped.
- One image with the app already running.
- The same image shared twice during one warm session.
- Two images shared together.
- One non-image `audio/mp4` document.

### Multi-image share validation

| Two images selected in Android | Both images loaded into Send |
| --- | --- |
| <img width="360" alt="Two images selected in Android" src="https://github.com/user-attachments/assets/fb739b6f-a557-4fe4-8b4f-b1208e944b9e"> | <img width="360" alt="Both images loaded into Send" src="https://github.com/user-attachments/assets/cfd7b034-1d60-45f0-afea-1bbec685c44c"> |

## Automated validation

- `pnpm run lint` — pass.
- `pnpm run format` — pass.
- `pnpm exec tsc -b --pretty false` — pass.
- Android debug APK build for `aarch64` — pass.
- GitHub frontend lint — pass.
- GitHub lockfile guard — pass.
- GitHub Rust E2E transfer tests — pass.

`pnpm test:lib` currently passes 20/22 tests under local Node 26. The two existing relay test modules fail before their assertions because compiled Node execution does not provide `import.meta.env`; this is unrelated to the Android share changes.

## Scope

This keeps Android private-cache staging and the existing cross-platform sender boundary. Direct `ContentResolver`/file-descriptor streaming and large-file staging changes remain out of scope and are tracked separately in #251.