### PR TITLE
Trust OS CAs for custom relays and harden web HTTP UX

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -2052,6 +2052,7 @@ dependencies = [
  "reqwest",
  "rustls",
  "rustls-pki-types",
+ "rustls-platform-verifier 0.7.0",
  "serde",
  "serde_bytes",
  "strum",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -52,7 +52,7 @@ rand = "0.10"
 serde_json = "1.0.108"
 tempfile = "3.8.1"
 tokio = { version = "1.34.0", features = ["full"] }
-iroh = "1.0.0"
+iroh = { version = "1.0.0", features = ["platform-verifier"] }
 iroh-blobs = { version = "0.103" }
 data-encoding = "2.8.0"
 

--- a/engine/examples/probe_custom_relay.rs
+++ b/engine/examples/probe_custom_relay.rs
@@ -1,0 +1,34 @@
+//! Probe a custom HTTPS relay using OS CA trust (`CaTlsConfig::system`).
+//!
+//! Usage:
+//!   cargo run --example probe_custom_relay --manifest-path engine/Cargo.toml -- \
+//!     https://relay.example.com
+
+#[tokio::main]
+async fn main() {
+    let url = std::env::args()
+        .nth(1)
+        .unwrap_or_else(|| "https://relay.example.com".to_string());
+
+    println!("probing custom relay: {url}");
+
+    let arg = protocol::RelayConfigArg {
+        mode: "custom".to_string(),
+        urls: vec![url],
+        auth_token: None,
+        fallback: Some("strict".to_string()),
+    };
+
+    match protocol::verify_relays(arg).await {
+        Ok(res) => {
+            println!(
+                "OK connected via {:?} latency_ms={}",
+                res.url, res.latency_ms
+            );
+        }
+        Err(err) => {
+            eprintln!("FAIL: {err}");
+            std::process::exit(1);
+        }
+    }
+}

--- a/engine/native/Cargo.toml
+++ b/engine/native/Cargo.toml
@@ -17,7 +17,7 @@ anyhow = "1.0.75"
 data-encoding = "2.8.0"
 dirs = "6.0.0"
 iroh-blobs = { version = "0.103" }
-iroh = "1.0.0"
+iroh = { version = "1.0.0", features = ["platform-verifier"] }
 n0-future = "0.3"
 num_cpus = "1.16.0"
 rand = "0.10"

--- a/engine/native/src/node.rs
+++ b/engine/native/src/node.rs
@@ -1208,7 +1208,7 @@ async fn build_runtime(
             pkarr_relay_url,
             dns_origin,
         } => {
-            let mut builder = Endpoint::builder(presets::Minimal)
+            let mut builder = protocol::with_system_ca(Endpoint::builder(presets::Minimal))
                 .address_lookup(PkarrPublisher::builder(pkarr_relay_url.clone()))
                 .address_lookup(PkarrResolver::builder(pkarr_relay_url.clone()));
             if let Some(origin) = dns_origin {
@@ -1217,7 +1217,8 @@ async fn build_runtime(
             builder
         }
         DiscoveryModeOption::Default => {
-            Endpoint::builder(presets::N0).address_lookup(PkarrPublisher::n0_dns())
+            protocol::with_system_ca(Endpoint::builder(presets::N0))
+                .address_lookup(PkarrPublisher::n0_dns())
         }
     };
 

--- a/engine/native/src/receive.rs
+++ b/engine/native/src/receive.rs
@@ -39,7 +39,7 @@ pub async fn download(
     let addr = ticket.addr().clone();
     let secret_key = get_or_create_secret()?;
 
-    let mut builder = Endpoint::builder(presets::Minimal)
+    let mut builder = protocol::with_system_ca(Endpoint::builder(presets::Minimal))
         .alpns(vec![])
         .secret_key(secret_key)
         .relay_mode(options.relay_mode.clone().into());

--- a/engine/native/src/send.rs
+++ b/engine/native/src/send.rs
@@ -41,10 +41,11 @@ pub async fn start_share_items(
     // the control endpoint is online, or the relay rejects duplicate endpoint ids.
     let secret_key = get_or_create_secret()?;
     let relay_mode: RelayMode = options.relay_mode.clone().into();
-    let mut builder = match &options.discovery_mode {
+    let builder = match &options.discovery_mode {
         DiscoveryModeOption::Custom { .. } => Endpoint::builder(presets::Minimal),
         DiscoveryModeOption::Default => Endpoint::builder(presets::N0),
-    }
+    };
+    let mut builder = protocol::with_system_ca(builder)
     .alpns(vec![iroh_blobs::ALPN.to_vec(), METADATA_ALPN.to_vec()])
     .secret_key(secret_key)
     .relay_mode(relay_mode.clone());

--- a/engine/protocol/Cargo.toml
+++ b/engine/protocol/Cargo.toml
@@ -24,7 +24,7 @@ url = "2"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 iroh-blobs = { version = "0.103" }
-iroh = "1.0.0"
+iroh = { version = "1.0.0", features = ["platform-verifier"] }
 tokio = { version = "1.34.0", features = ["full"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/engine/protocol/src/discovery.rs
+++ b/engine/protocol/src/discovery.rs
@@ -178,7 +178,7 @@ pub async fn verify_discovery(
 
     let secret_key = get_or_create_secret().map_err(|e| e.to_string())?;
 
-    let endpoint = Endpoint::builder(presets::Minimal)
+    let endpoint = crate::tls_config::with_system_ca(Endpoint::builder(presets::Minimal))
         .secret_key(secret_key)
         .relay_mode(RelayMode::Default)
         .address_lookup(PkarrPublisher::builder(pkarr_relay_url.clone()))

--- a/engine/protocol/src/lib.rs
+++ b/engine/protocol/src/lib.rs
@@ -7,6 +7,7 @@ pub mod receive;
 pub mod relay;
 pub mod send;
 pub mod time_compat;
+pub mod tls_config;
 pub mod types;
 
 pub use control::{ControlMessage, PairingTicket, CONTROL_ALPN, RememberVote, InviteResponse};
@@ -31,6 +32,7 @@ pub use discovery::{
 };
 #[cfg(not(target_arch = "wasm32"))]
 pub use discovery::verify_discovery;
+pub use tls_config::with_system_ca;
 pub use control::{read_message, write_message};
 pub use send::{run_share_on_endpoint, run_share_session, MetadataProtocol, ShareSessionOutcome, METADATA_ALPN};
 pub use types::*;

--- a/engine/protocol/src/receive.rs
+++ b/engine/protocol/src/receive.rs
@@ -260,10 +260,11 @@ pub async fn fetch_metadata(
     let secret_key = get_or_create_secret()?;
 
     let discovery_mode = options.discovery_mode.clone();
-    let mut builder = match &discovery_mode {
+    let builder = match &discovery_mode {
         DiscoveryModeOption::Custom { .. } => Endpoint::builder(presets::Minimal),
         DiscoveryModeOption::Default => Endpoint::builder(presets::N0),
-    }
+    };
+    let mut builder = crate::tls_config::with_system_ca(builder)
     // METADATA_ALPN only to indicate a metadata fetch
     .alpns(vec![METADATA_ALPN.to_vec()])
     .secret_key(secret_key)

--- a/engine/protocol/src/relay.rs
+++ b/engine/protocol/src/relay.rs
@@ -175,7 +175,7 @@ async fn probe_relay_mode(relay_mode: RelayModeOption) -> Result<Option<String>,
     }
 
     let secret_key = get_or_create_secret().map_err(|e| e.to_string())?;
-    let endpoint = Endpoint::builder(presets::Minimal)
+    let endpoint = crate::tls_config::with_system_ca(Endpoint::builder(presets::Minimal))
         .secret_key(secret_key)
         .relay_mode(relay_mode.into())
         .bind()
@@ -339,7 +339,7 @@ pub async fn verify_relays(relay: RelayConfigArg) -> Result<VerifyRelaysResponse
 
     let secret_key = get_or_create_secret().map_err(|e| e.to_string())?;
 
-    let endpoint = Endpoint::builder(presets::Minimal)
+    let endpoint = crate::tls_config::with_system_ca(Endpoint::builder(presets::Minimal))
         .secret_key(secret_key)
         .relay_mode(relay_mode.into())
         .bind()

--- a/engine/protocol/src/tls_config.rs
+++ b/engine/protocol/src/tls_config.rs
@@ -1,0 +1,20 @@
+//! TLS trust helpers for iroh endpoint builders.
+//!
+//! Native builds use the OS certificate store (`CaTlsConfig::system`) so private
+//! CAs installed via the system trust store work with custom HTTPS relays.
+//! Wasm leaves the builder unchanged (browser / embedded roots).
+
+use iroh::endpoint::Builder;
+
+/// Apply OS CA trust on native; no-op on wasm32.
+pub fn with_system_ca(builder: Builder) -> Builder {
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        use iroh::tls::CaTlsConfig;
+        builder.ca_tls_config(CaTlsConfig::system())
+    }
+    #[cfg(target_arch = "wasm32")]
+    {
+        builder
+    }
+}

--- a/engine/protocol/src/tls_config.rs
+++ b/engine/protocol/src/tls_config.rs
@@ -1,19 +1,20 @@
 //! TLS trust helpers for iroh endpoint builders.
 //!
-//! Native builds use the OS certificate store (`CaTlsConfig::system`) so private
-//! CAs installed via the system trust store work with custom HTTPS relays.
-//! Wasm leaves the builder unchanged (browser / embedded roots).
+//! Desktop native builds use the OS certificate store (`CaTlsConfig::system`) so
+//! private CAs installed via the system trust store work with custom HTTPS relays.
+//! Wasm and Android leave the builder unchanged (embedded Mozilla roots): Android
+//! needs `rustls-platform-verifier` JNI/Gradle setup before OS trust is safe.
 
 use iroh::endpoint::Builder;
 
-/// Apply OS CA trust on native; no-op on wasm32.
+/// Apply OS CA trust on desktop native; no-op on wasm32 and Android.
 pub fn with_system_ca(builder: Builder) -> Builder {
-    #[cfg(not(target_arch = "wasm32"))]
+    #[cfg(not(any(target_arch = "wasm32", target_os = "android")))]
     {
         use iroh::tls::CaTlsConfig;
         builder.ca_tls_config(CaTlsConfig::system())
     }
-    #[cfg(target_arch = "wasm32")]
+    #[cfg(any(target_arch = "wasm32", target_os = "android"))]
     {
         builder
     }

--- a/engine/wasm-io/src/receive.rs
+++ b/engine/wasm-io/src/receive.rs
@@ -1,5 +1,5 @@
 use protocol::{
-    download_to_store, get_or_create_secret, AppHandle, ReceiveOptions,
+    download_to_store, get_or_create_secret, with_system_ca, AppHandle, ReceiveOptions,
 };
 use iroh::endpoint::presets;
 use iroh::Endpoint;
@@ -19,10 +19,12 @@ pub async fn download_files(
     let addr = ticket.addr().clone();
     let secret_key = get_or_create_secret()?;
 
-    let builder = Endpoint::builder(presets::Minimal)
-        .alpns(vec![])
-        .secret_key(secret_key)
-        .relay_mode(options.relay_mode.clone().into());
+    let builder = with_system_ca(
+        Endpoint::builder(presets::Minimal)
+            .alpns(vec![])
+            .secret_key(secret_key)
+            .relay_mode(options.relay_mode.clone().into()),
+    );
 
     anyhow::ensure!(
         ticket.addr().relay_urls().count() > 0,

--- a/engine/wasm-io/src/send.rs
+++ b/engine/wasm-io/src/send.rs
@@ -1,6 +1,6 @@
 use protocol::{
-    get_or_create_secret, run_share_session, AddrInfoOptions, AppHandle, FileMetadata, SendOptions,
-    METADATA_ALPN,
+    get_or_create_secret, run_share_session, with_system_ca, AddrInfoOptions, AppHandle,
+    FileMetadata, SendOptions, METADATA_ALPN,
 };
 use iroh::endpoint::presets;
 use iroh::{endpoint::RelayMode, Endpoint};
@@ -25,10 +25,12 @@ pub async fn start_share_bytes(
     let relay_mode: RelayMode = options.relay_mode.clone().into();
     let ticket_type = AddrInfoOptions::Relay;
 
-    let builder = Endpoint::builder(presets::N0)
-        .alpns(vec![iroh_blobs::ALPN.to_vec(), METADATA_ALPN.to_vec()])
-        .secret_key(secret_key)
-        .relay_mode(relay_mode.clone());
+    let builder = with_system_ca(
+        Endpoint::builder(presets::N0)
+            .alpns(vec![iroh_blobs::ALPN.to_vec(), METADATA_ALPN.to_vec()])
+            .secret_key(secret_key)
+            .relay_mode(relay_mode.clone()),
+    );
 
     let (progress_tx, progress_rx) = mpsc::channel(64);
     let endpoint = builder.bind().await?;
@@ -86,10 +88,12 @@ pub async fn start_share_items_bytes(
     let relay_mode: RelayMode = options.relay_mode.clone().into();
     let ticket_type = AddrInfoOptions::Relay;
 
-    let builder = Endpoint::builder(presets::N0)
-        .alpns(vec![iroh_blobs::ALPN.to_vec(), METADATA_ALPN.to_vec()])
-        .secret_key(secret_key)
-        .relay_mode(relay_mode.clone());
+    let builder = with_system_ca(
+        Endpoint::builder(presets::N0)
+            .alpns(vec![iroh_blobs::ALPN.to_vec(), METADATA_ALPN.to_vec()])
+            .secret_key(secret_key)
+            .relay_mode(relay_mode.clone()),
+    );
 
     let (progress_tx, progress_rx) = mpsc::channel(64);
     let endpoint = builder.bind().await?;

--- a/frontend/src/components/sender/DragDrop.tsx
+++ b/frontend/src/components/sender/DragDrop.tsx
@@ -67,6 +67,7 @@ export function DragDrop({
 				onAddFolders={addMoreFolders}
 				onRemoveSelectedPath={onRemoveSelectedPath}
 				onClearSelection={onClearSelection}
+				onEmptyClick={browseFile}
 				dropzoneDragProps={dropzoneDragProps}
 			/>
 

--- a/frontend/src/components/sender/Dropzone.tsx
+++ b/frontend/src/components/sender/Dropzone.tsx
@@ -39,6 +39,7 @@ export function Dropzone({
 	onAddFolders,
 	onRemoveSelectedPath,
 	onClearSelection,
+	onEmptyClick,
 	dropzoneDragProps,
 }: DropzoneProps) {
 	const { t } = useTranslation()
@@ -260,6 +261,20 @@ export function Dropzone({
 				transition={{ duration: 0.3, ease: 'easeInOut' }}
 				style={getDropzoneStyles()}
 				className="relative border-2 border-dashed rounded-lg text-center cursor-pointer transition-all duration-200 bg-accent text-accent-foreground h-fit min-h-64 border-border overflow-hidden"
+				role={!hasSelection ? 'button' : undefined}
+				tabIndex={!hasSelection && !isLoading ? 0 : undefined}
+				aria-label={!hasSelection ? t('common:sender.orBrowse') : undefined}
+				onClick={() => {
+					if (hasSelection || isLoading || !onEmptyClick) return
+					void onEmptyClick()
+				}}
+				onKeyDown={(event) => {
+					if (hasSelection || isLoading || !onEmptyClick) return
+					if (event.key === 'Enter' || event.key === ' ') {
+						event.preventDefault()
+						void onEmptyClick()
+					}
+				}}
 				{...dropzoneDragProps}
 			>
 				{hasSelection && !isLoading ? (

--- a/frontend/src/components/sender/ShareLinkPanel.tsx
+++ b/frontend/src/components/sender/ShareLinkPanel.tsx
@@ -3,6 +3,7 @@ import { useEffect, useRef, useState } from 'react'
 import { useTranslation } from '../../i18n/react-i18next-compat'
 import { IS_MOBILE, IS_WEB } from '../../lib/platform'
 import { buildReceiveLink } from '../../lib/receive-link'
+import { randomUUID, copyTextToClipboard } from '../../lib/utils'
 import { useAppSettingStore } from '../../store/app-setting'
 import type { TransferProgress } from '../../types/transfer'
 import { PulseAnimation } from '../common/PulseAnimation'
@@ -175,7 +176,7 @@ function TicketDisplay({
 	const handleBroadcastChange = (next: boolean) => {
 		onSetBroadcast(next)
 		if (next) {
-			const toastId = crypto.randomUUID()
+			const toastId = randomUUID()
 			toastManager.add({
 				title: t('common:sender.broadcastMode.on.label'),
 				id: toastId,
@@ -212,7 +213,7 @@ function TicketDisplay({
 			if (canNativeShare) {
 				await navigator.share({ url })
 			} else {
-				await navigator.clipboard.writeText(url)
+				await copyTextToClipboard(url)
 				setLinkCopySuccess(true)
 				if (linkCopyTimer.current) clearTimeout(linkCopyTimer.current)
 				linkCopyTimer.current = setTimeout(

--- a/frontend/src/components/settings/devices/devices-settings.tsx
+++ b/frontend/src/components/settings/devices/devices-settings.tsx
@@ -24,6 +24,7 @@ import {
 } from '@/lib/pairing-api'
 import { getPairedSendCounts } from '@/lib/paired-send-counts'
 import { deviceTypeIcon } from '@/lib/device-icon'
+import { copyTextToClipboard } from '@/lib/utils'
 import { DevicePairingStatus } from '../../pairing/DevicePairingStatus'
 import { PairedDevicesSearchField } from '../../pairing/PairedDevicesSearchField'
 
@@ -272,7 +273,7 @@ export function DevicesSettings() {
 		try {
 			const code = pairingCode ?? pairingTicket
 			if (code) {
-				await navigator.clipboard.writeText(code)
+				await copyTextToClipboard(code)
 				setCopied(true)
 				window.setTimeout(() => setCopied(false), 2000)
 				// Open the pairing window in the background — never block copy.
@@ -289,7 +290,7 @@ export function DevicesSettings() {
 			// Code not hydrated yet: generate + open host, then copy.
 			const ticket = await openHostPairing()
 			if (!ticket) return
-			await navigator.clipboard.writeText(ticket)
+			await copyTextToClipboard(ticket)
 			setCopied(true)
 			window.setTimeout(() => setCopied(false), 2000)
 		} catch (error) {

--- a/frontend/src/components/settings/relay/relay-settings.tsx
+++ b/frontend/src/components/settings/relay/relay-settings.tsx
@@ -19,7 +19,7 @@ import {
 } from '../../../lib/relay-url-validation'
 import { getRelayRegion } from '../../../lib/relay'
 import type { VerifyRelaysResponse } from '../../../lib/relay'
-import { cn } from '../../../lib/utils'
+import { cn, randomUUID } from '../../../lib/utils'
 import { Button } from '../../ui/button'
 import {
 	Frame,
@@ -72,13 +72,11 @@ export function RelaySettings() {
 	const [showAuthToken, setShowAuthToken] = useState(
 		() => relayAuthToken.trim().length > 0
 	)
-	const urlRowIdsRef = useRef<string[]>(
-		relayUrls.map(() => crypto.randomUUID())
-	)
+	const urlRowIdsRef = useRef<string[]>(relayUrls.map(() => randomUUID()))
 
 	useEffect(() => {
 		while (urlRowIdsRef.current.length < relayUrls.length) {
-			urlRowIdsRef.current.push(crypto.randomUUID())
+			urlRowIdsRef.current.push(randomUUID())
 		}
 		if (urlRowIdsRef.current.length > relayUrls.length) {
 			urlRowIdsRef.current = urlRowIdsRef.current.slice(0, relayUrls.length)

--- a/frontend/src/hooks/useSender.ts
+++ b/frontend/src/hooks/useSender.ts
@@ -25,6 +25,7 @@ import {
 	usePairedDeviceEvents,
 } from '@/hooks/usePairedDeviceEvents'
 import { toastManager } from '../components/ui/toast'
+import { copyTextToClipboard } from '../lib/utils'
 
 export type PairedInviteStatus = 'sending' | 'sent' | 'failed'
 
@@ -997,7 +998,7 @@ export function useSender(): UseSenderReturn {
 	const copyTicket = async () => {
 		if (ticket) {
 			try {
-				await navigator.clipboard.writeText(ticket)
+				await copyTextToClipboard(ticket)
 				setCopySuccess(true)
 				setTimeout(() => setCopySuccess(false), 2000)
 			} catch (error) {

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -5,6 +5,77 @@ export function cn(...inputs: ClassValue[]) {
 	return twMerge(clsx(inputs))
 }
 
+/**
+ * UUID v4 that works outside secure contexts.
+ * `crypto.randomUUID` is missing on plain HTTP for non-localhost hosts
+ * (e.g. http://app.example.internal on a LAN hostname).
+ */
+export function randomUUID(): string {
+	const cryptoObj = globalThis.crypto
+	if (typeof cryptoObj?.randomUUID === 'function') {
+		return cryptoObj.randomUUID()
+	}
+
+	const bytes = new Uint8Array(16)
+	if (typeof cryptoObj?.getRandomValues === 'function') {
+		cryptoObj.getRandomValues(bytes)
+	} else {
+		for (let i = 0; i < bytes.length; i++) {
+			bytes[i] = Math.floor(Math.random() * 256)
+		}
+	}
+	bytes[6] = (bytes[6] & 0x0f) | 0x40
+	bytes[8] = (bytes[8] & 0x3f) | 0x80
+	const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('')
+	return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`
+}
+
+/**
+ * Copy text to the clipboard outside secure contexts.
+ * `navigator.clipboard` is missing on plain HTTP for non-localhost hosts.
+ */
+export async function copyTextToClipboard(text: string): Promise<void> {
+	const clipboard = globalThis.navigator?.clipboard
+	if (clipboard && typeof clipboard.writeText === 'function') {
+		await clipboard.writeText(text)
+		return
+	}
+
+	if (typeof document === 'undefined') {
+		throw new Error('Clipboard API unavailable')
+	}
+
+	const textarea = document.createElement('textarea')
+	textarea.value = text
+	textarea.setAttribute('readonly', '')
+	textarea.style.position = 'fixed'
+	textarea.style.top = '0'
+	textarea.style.left = '0'
+	textarea.style.width = '1px'
+	textarea.style.height = '1px'
+	textarea.style.padding = '0'
+	textarea.style.border = 'none'
+	textarea.style.outline = 'none'
+	textarea.style.boxShadow = 'none'
+	textarea.style.background = 'transparent'
+	textarea.style.opacity = '0'
+	document.body.appendChild(textarea)
+	textarea.focus()
+	textarea.select()
+	textarea.setSelectionRange(0, text.length)
+
+	let copied = false
+	try {
+		copied = document.execCommand('copy')
+	} finally {
+		textarea.remove()
+	}
+
+	if (!copied) {
+		throw new Error('Clipboard copy failed')
+	}
+}
+
 interface FileSizeFormatOptions {
 	zeroValue?: string
 	precision?: number

--- a/frontend/src/types/sender.ts
+++ b/frontend/src/types/sender.ts
@@ -75,6 +75,8 @@ export interface DropzoneProps {
 	onAddFolders: () => Promise<void>
 	onRemoveSelectedPath: (path: string) => void
 	onClearSelection: () => void
+	/** Open the file picker when the empty dropzone is clicked. */
+	onEmptyClick?: () => void | Promise<void>
 	dropzoneDragProps?: DropzoneDragProps
 }
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3699,6 +3699,7 @@ dependencies = [
  "reqwest",
  "rustls",
  "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_bytes",
  "strum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -31,7 +31,7 @@ serde_json = "1.0"
 tokio = { version = "1.0", features = ["full"] }
 anyhow = "1.0"
 n0-watcher = "1.0"
-iroh = "1.0.0"
+iroh = { version = "1.0.0", features = ["platform-verifier"] }
 iroh-blobs = { version = "0.103" }
 engine = { path = "../engine" }
 tracing = "0.1"

--- a/wasm-bridge/Cargo.lock
+++ b/wasm-bridge/Cargo.lock
@@ -1797,6 +1797,7 @@ dependencies = [
  "reqwest",
  "rustls",
  "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_bytes",
  "strum",
@@ -3261,6 +3262,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing",
+ "url",
  "web-time",
 ]
 

--- a/wasm-bridge/src/lib.rs
+++ b/wasm-bridge/src/lib.rs
@@ -7,7 +7,8 @@ use wasm_io::{
 };
 use protocol::{
     get_relay_status as engine_get_relay_status, resolve_relay_mode_with_fallback,
-    set_wasm_secret_key, verify_relays as engine_verify_relays, RelayConfigArg,
+    set_wasm_secret_key, verify_relays as engine_verify_relays, with_system_ca,
+    RelayConfigArg,
 };
 use std::str::FromStr;
 use std::sync::{Arc, Mutex, OnceLock};
@@ -376,7 +377,7 @@ pub async fn smoke_test_endpoint() -> Result<String, JsValue> {
     use iroh::endpoint::presets;
     use iroh::Endpoint;
 
-    let endpoint = Endpoint::builder(presets::N0)
+    let endpoint = with_system_ca(Endpoint::builder(presets::N0))
         .bind()
         .await
         .map_err(|e| JsValue::from_str(&format!("endpoint bind failed: {e}")))?;


### PR DESCRIPTION
## Description

Private HTTPS relays (and custom discovery) currently fail on desktop because iroh defaults to embedded Mozilla roots and ignores the OS trust store. This wires `CaTlsConfig::system()` through native endpoint builders (`platform-verifier`) so OS-installed private CAs work.

Separately, hosting the web app on plain HTTP (non-localhost LAN hostnames) breaks several secure-context-only APIs. This adds:

- `randomUUID()` fallback (`crypto.randomUUID` missing)
- `copyTextToClipboard()` fallback (`navigator.clipboard` missing)
- empty dropzone click → file picker (looked clickable but had no handler)

Includes `engine/examples/probe_custom_relay.rs` to verify custom-relay TLS trust.

## Checklist

- [x] I have run **`npm run lint`** before raising this PR
- [x] I have run **`npm run format`** before raising this PR

## Test plan

- [ ] Desktop: point Settings → Infra at a custom HTTPS relay signed by a private CA installed in the OS trust store → Test connection succeeds
- [ ] `cargo run --example probe_custom_relay --manifest-path engine/Cargo.toml -- https://your-relay.example`
- [ ] Web over plain HTTP (non-localhost): open Settings → Infra (no `crypto.randomUUID` crash)
- [ ] Web over plain HTTP: copy ticket/link succeeds
- [ ] Web: click empty drag-and-drop zone opens file picker; Browse File/Folder still work


Made with [Cursor](https://cursor.com)