### PR TITLE
fix(windows): remove unnecessary OS-trust wrap from the public path

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -3589,6 +3589,7 @@ dependencies = [
  "iroh",
  "iroh-blobs",
  "n0-future",
+ "rustls",
  "serde",
  "serde_json",
  "tokio",

--- a/engine/examples/probe_custom_relay.rs
+++ b/engine/examples/probe_custom_relay.rs
@@ -1,4 +1,4 @@
-//! Probe a custom HTTPS relay using OS CA trust (`CaTlsConfig::system`).
+//! Probe a custom HTTPS relay using OS CA trust (DotTolerant system verifier).
 //!
 //! Usage:
 //!   cargo run --example probe_custom_relay --manifest-path engine/Cargo.toml -- \

--- a/engine/native/src/node.rs
+++ b/engine/native/src/node.rs
@@ -1203,21 +1203,27 @@ async fn build_runtime(
     // endpoint id) and resolve (to reach them). Custom mode uses a self-hosted
     // pkarr relay via HTTPS; optional dns_origin also enables real-DNS resolve.
     // Default keeps iroh's n0 discovery.
+    //
+    // OS CA trust only for custom discovery/relay — n0 trailing-dot hostnames
+    // break Windows CERT_CHAIN_POLICY_SSL literal name matching.
+    let custom_infra = matches!(discovery_mode, DiscoveryModeOption::Custom { .. })
+        || matches!(relay_mode, RelayMode::Custom(_));
     let builder = match &discovery_mode {
         DiscoveryModeOption::Custom {
             pkarr_relay_url,
             dns_origin,
         } => {
-            let mut builder = protocol::with_system_ca(Endpoint::builder(presets::Minimal))
-                .address_lookup(PkarrPublisher::builder(pkarr_relay_url.clone()))
-                .address_lookup(PkarrResolver::builder(pkarr_relay_url.clone()));
+            let mut builder =
+                protocol::with_system_ca_if_custom(Endpoint::builder(presets::Minimal), custom_infra)
+                    .address_lookup(PkarrPublisher::builder(pkarr_relay_url.clone()))
+                    .address_lookup(PkarrResolver::builder(pkarr_relay_url.clone()));
             if let Some(origin) = dns_origin {
                 builder = builder.address_lookup(DnsAddressLookup::builder(origin.clone()));
             }
             builder
         }
         DiscoveryModeOption::Default => {
-            protocol::with_system_ca(Endpoint::builder(presets::N0))
+            protocol::with_system_ca_if_custom(Endpoint::builder(presets::N0), custom_infra)
                 .address_lookup(PkarrPublisher::n0_dns())
         }
     };

--- a/engine/native/src/receive.rs
+++ b/engine/native/src/receive.rs
@@ -39,10 +39,13 @@ pub async fn download(
     let addr = ticket.addr().clone();
     let secret_key = get_or_create_secret()?;
 
-    let mut builder = protocol::with_system_ca(Endpoint::builder(presets::Minimal))
-        .alpns(vec![])
-        .secret_key(secret_key)
-        .relay_mode(options.relay_mode.clone().into());
+    let custom_infra =
+        protocol::uses_custom_infra(&options.discovery_mode, &options.relay_mode);
+    let mut builder =
+        protocol::with_system_ca_if_custom(Endpoint::builder(presets::Minimal), custom_infra)
+            .alpns(vec![])
+            .secret_key(secret_key)
+            .relay_mode(options.relay_mode.clone().into());
 
     if ticket.addr().relay_urls().count() == 0 && ticket.addr().ip_addrs().count() == 0 {
         builder = match &options.discovery_mode {

--- a/engine/native/src/send.rs
+++ b/engine/native/src/send.rs
@@ -45,10 +45,12 @@ pub async fn start_share_items(
         DiscoveryModeOption::Custom { .. } => Endpoint::builder(presets::Minimal),
         DiscoveryModeOption::Default => Endpoint::builder(presets::N0),
     };
-    let mut builder = protocol::with_system_ca(builder)
-    .alpns(vec![iroh_blobs::ALPN.to_vec(), METADATA_ALPN.to_vec()])
-    .secret_key(secret_key)
-    .relay_mode(relay_mode.clone());
+    let custom_infra =
+        protocol::uses_custom_infra(&options.discovery_mode, &options.relay_mode);
+    let mut builder = protocol::with_system_ca_if_custom(builder, custom_infra)
+        .alpns(vec![iroh_blobs::ALPN.to_vec(), METADATA_ALPN.to_vec()])
+        .secret_key(secret_key)
+        .relay_mode(relay_mode.clone());
 
     match &options.discovery_mode {
         // Self-hosted discovery: publish our home relay to the custom pkarr relay so

--- a/engine/protocol/Cargo.toml
+++ b/engine/protocol/Cargo.toml
@@ -25,6 +25,9 @@ url = "2"
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 iroh-blobs = { version = "0.103" }
 iroh = { version = "1.0.3", features = ["platform-verifier"] }
+# Pin to the same rustls iroh resolves so dyn ServerCertVerifier types unify.
+# default-features = false avoids an extra aws-lc-sys build; ring comes via iroh.
+rustls = { version = "=0.23.36", default-features = false, features = ["std"] }
 tokio = { version = "1.34.0", features = ["full"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/engine/protocol/src/discovery.rs
+++ b/engine/protocol/src/discovery.rs
@@ -178,13 +178,18 @@ pub async fn verify_discovery(
 
     let secret_key = get_or_create_secret().map_err(|e| e.to_string())?;
 
-    let endpoint = crate::tls_config::with_system_ca(Endpoint::builder(presets::Minimal))
-        .secret_key(secret_key)
-        .relay_mode(RelayMode::Default)
-        .address_lookup(PkarrPublisher::builder(pkarr_relay_url.clone()))
-        .bind()
-        .await
-        .map_err(|e| format!("Failed to bind endpoint: {e}"))?;
+    // Custom discovery always needs OS trust for private-CA pkarr HTTPS.
+    // DotTolerant wrapping also covers the default n0 relay probe path on Windows.
+    let endpoint = crate::tls_config::with_system_ca_if_custom(
+        Endpoint::builder(presets::Minimal),
+        true,
+    )
+    .secret_key(secret_key)
+    .relay_mode(RelayMode::Default)
+    .address_lookup(PkarrPublisher::builder(pkarr_relay_url.clone()))
+    .bind()
+    .await
+    .map_err(|e| format!("Failed to bind endpoint: {e}"))?;
 
     let started = Instant::now();
 

--- a/engine/protocol/src/lib.rs
+++ b/engine/protocol/src/lib.rs
@@ -32,7 +32,7 @@ pub use discovery::{
 };
 #[cfg(not(target_arch = "wasm32"))]
 pub use discovery::verify_discovery;
-pub use tls_config::with_system_ca;
+pub use tls_config::{uses_custom_infra, with_system_ca_if_custom};
 pub use control::{read_message, write_message};
 pub use send::{run_share_on_endpoint, run_share_session, MetadataProtocol, ShareSessionOutcome, METADATA_ALPN};
 pub use types::*;

--- a/engine/protocol/src/receive.rs
+++ b/engine/protocol/src/receive.rs
@@ -264,11 +264,13 @@ pub async fn fetch_metadata(
         DiscoveryModeOption::Custom { .. } => Endpoint::builder(presets::Minimal),
         DiscoveryModeOption::Default => Endpoint::builder(presets::N0),
     };
-    let mut builder = crate::tls_config::with_system_ca(builder)
-    // METADATA_ALPN only to indicate a metadata fetch
-    .alpns(vec![METADATA_ALPN.to_vec()])
-    .secret_key(secret_key)
-    .relay_mode(options.relay_mode.into());
+    let custom_infra =
+        crate::tls_config::uses_custom_infra(&discovery_mode, &options.relay_mode);
+    let mut builder = crate::tls_config::with_system_ca_if_custom(builder, custom_infra)
+        // METADATA_ALPN only to indicate a metadata fetch
+        .alpns(vec![METADATA_ALPN.to_vec()])
+        .secret_key(secret_key)
+        .relay_mode(options.relay_mode.into());
 
     #[cfg(not(target_arch = "wasm32"))]
     {

--- a/engine/protocol/src/relay.rs
+++ b/engine/protocol/src/relay.rs
@@ -175,12 +175,14 @@ async fn probe_relay_mode(relay_mode: RelayModeOption) -> Result<Option<String>,
     }
 
     let secret_key = get_or_create_secret().map_err(|e| e.to_string())?;
-    let endpoint = crate::tls_config::with_system_ca(Endpoint::builder(presets::Minimal))
-        .secret_key(secret_key)
-        .relay_mode(relay_mode.into())
-        .bind()
-        .await
-        .map_err(|e| format!("Failed to bind endpoint: {e}"))?;
+    let custom_infra = matches!(relay_mode, RelayModeOption::Custom { .. });
+    let endpoint =
+        crate::tls_config::with_system_ca_if_custom(Endpoint::builder(presets::Minimal), custom_infra)
+            .secret_key(secret_key)
+            .relay_mode(relay_mode.into())
+            .bind()
+            .await
+            .map_err(|e| format!("Failed to bind endpoint: {e}"))?;
 
     let online_result = timeout(RELAY_PROBE_TIMEOUT, endpoint.online()).await;
 
@@ -338,13 +340,15 @@ pub async fn verify_relays(relay: RelayConfigArg) -> Result<VerifyRelaysResponse
     }
 
     let secret_key = get_or_create_secret().map_err(|e| e.to_string())?;
+    let custom_infra = matches!(relay_mode, RelayModeOption::Custom { .. });
 
-    let endpoint = crate::tls_config::with_system_ca(Endpoint::builder(presets::Minimal))
-        .secret_key(secret_key)
-        .relay_mode(relay_mode.into())
-        .bind()
-        .await
-        .map_err(|e| format!("Failed to bind endpoint: {e}"))?;
+    let endpoint =
+        crate::tls_config::with_system_ca_if_custom(Endpoint::builder(presets::Minimal), custom_infra)
+            .secret_key(secret_key)
+            .relay_mode(relay_mode.into())
+            .bind()
+            .await
+            .map_err(|e| format!("Failed to bind endpoint: {e}"))?;
 
     let started = Instant::now();
 

--- a/engine/protocol/src/tls_config.rs
+++ b/engine/protocol/src/tls_config.rs
@@ -1,21 +1,257 @@
 //! TLS trust helpers for iroh endpoint builders.
 //!
-//! Desktop native builds use the OS certificate store (`CaTlsConfig::system`) so
-//! private CAs installed via the system trust store work with custom HTTPS relays.
-//! Wasm and Android leave the builder unchanged (embedded Mozilla roots): Android
-//! needs `rustls-platform-verifier` JNI/Gradle setup before OS trust is safe.
+//! OS trust is applied ONLY for user-configured self-hosted HTTPS infra
+//! (custom relay / custom pkarr). n0's public infra is covered by iroh's
+//! embedded Mozilla roots, and its relay hostnames are FQDNs with a trailing
+//! root label ("use1-1.relay.n0.iroh.link.") that the Windows platform
+//! verifier rejects with NotValidForName, because CERT_CHAIN_POLICY_SSL
+//! matches pwszServerName literally against the certificate SANs.
+//!
+//! When OS trust is used, the platform verifier is wrapped so a trailing
+//! root label is stripped before name matching (DNS-equivalent, no weaker).
 
 use iroh::endpoint::Builder;
+#[cfg(not(any(target_arch = "wasm32", target_os = "android")))]
+use std::sync::Arc;
 
-/// Apply OS CA trust on desktop native; no-op on wasm32 and Android.
-pub fn with_system_ca(builder: Builder) -> Builder {
+use crate::types::{DiscoveryModeOption, RelayModeOption};
+
+/// True when the user configured self-hosted discovery and/or relay HTTPS.
+pub fn uses_custom_infra(discovery: &DiscoveryModeOption, relay: &RelayModeOption) -> bool {
+    matches!(discovery, DiscoveryModeOption::Custom { .. })
+        || matches!(relay, RelayModeOption::Custom { .. })
+}
+
+/// Apply OS CA trust only when `custom_infra` is set; otherwise keep iroh's
+/// embedded Mozilla roots (pre-0.6.2 default-path behaviour).
+///
+/// On wasm32 and Android this is always a no-op (embedded roots).
+pub fn with_system_ca_if_custom(builder: Builder, custom_infra: bool) -> Builder {
+    if !custom_infra {
+        return builder;
+    }
     #[cfg(not(any(target_arch = "wasm32", target_os = "android")))]
     {
-        use iroh::tls::CaTlsConfig;
-        builder.ca_tls_config(CaTlsConfig::system())
+        apply_dot_tolerant_system_ca(builder)
     }
     #[cfg(any(target_arch = "wasm32", target_os = "android"))]
     {
         builder
+    }
+}
+
+#[cfg(not(any(target_arch = "wasm32", target_os = "android")))]
+fn apply_dot_tolerant_system_ca(builder: Builder) -> Builder {
+    use iroh::tls::CaTlsConfig;
+
+    let ca = CaTlsConfig::custom_server_cert_verifier(Arc::new(|provider| {
+        let inner = CaTlsConfig::system().server_cert_verifier(provider)?;
+        Ok(Arc::new(DotTolerant(inner)) as Arc<dyn rustls::client::danger::ServerCertVerifier>)
+    }));
+    builder.ca_tls_config(ca)
+}
+
+/// Strips a trailing DNS root label before delegating to the inner verifier.
+///
+/// Windows' CERT_CHAIN_POLICY_SSL matches the reference name literally against
+/// certificate SANs; `host.example.com.` does not match `host.example.com` or
+/// `*.example.com`. Other platforms already normalize this.
+#[cfg(not(any(target_arch = "wasm32", target_os = "android")))]
+#[derive(Debug)]
+struct DotTolerant(Arc<dyn rustls::client::danger::ServerCertVerifier>);
+
+#[cfg(not(any(target_arch = "wasm32", target_os = "android")))]
+impl rustls::client::danger::ServerCertVerifier for DotTolerant {
+    fn verify_server_cert(
+        &self,
+        end_entity: &rustls::pki_types::CertificateDer<'_>,
+        intermediates: &[rustls::pki_types::CertificateDer<'_>],
+        server_name: &rustls::pki_types::ServerName<'_>,
+        ocsp_response: &[u8],
+        now: rustls::pki_types::UnixTime,
+    ) -> Result<rustls::client::danger::ServerCertVerified, rustls::Error> {
+        if let Some(normalized) = strip_trailing_root_label(server_name) {
+            return self.0.verify_server_cert(
+                end_entity,
+                intermediates,
+                &normalized,
+                ocsp_response,
+                now,
+            );
+        }
+        self.0
+            .verify_server_cert(end_entity, intermediates, server_name, ocsp_response, now)
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        message: &[u8],
+        cert: &rustls::pki_types::CertificateDer<'_>,
+        dss: &rustls::DigitallySignedStruct,
+    ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+        self.0.verify_tls12_signature(message, cert, dss)
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        message: &[u8],
+        cert: &rustls::pki_types::CertificateDer<'_>,
+        dss: &rustls::DigitallySignedStruct,
+    ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+        self.0.verify_tls13_signature(message, cert, dss)
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<rustls::SignatureScheme> {
+        self.0.supported_verify_schemes()
+    }
+
+    fn requires_raw_public_keys(&self) -> bool {
+        self.0.requires_raw_public_keys()
+    }
+
+    fn root_hint_subjects(&self) -> Option<&[rustls::DistinguishedName]> {
+        self.0.root_hint_subjects()
+    }
+}
+
+#[cfg(not(any(target_arch = "wasm32", target_os = "android")))]
+fn strip_trailing_root_label(
+    server_name: &rustls::pki_types::ServerName<'_>,
+) -> Option<rustls::pki_types::ServerName<'static>> {
+    use rustls::pki_types::ServerName;
+
+    if let ServerName::DnsName(dns) = server_name {
+        let name = dns.as_ref();
+        if let Some(stripped) = name.strip_suffix('.') {
+            if !stripped.is_empty() {
+                return ServerName::try_from(stripped.to_owned()).ok();
+            }
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use super::*;
+    use crate::types::{DiscoveryModeOption, RelayModeOption};
+
+    #[test]
+    fn uses_custom_infra_defaults_false() {
+        assert!(!uses_custom_infra(
+            &DiscoveryModeOption::Default,
+            &RelayModeOption::Default
+        ));
+        assert!(!uses_custom_infra(
+            &DiscoveryModeOption::Default,
+            &RelayModeOption::Disabled
+        ));
+    }
+
+    #[test]
+    fn uses_custom_infra_true_for_custom_discovery_or_relay() {
+        let pkarr = url::Url::parse("https://pkarr.example.com").unwrap();
+        let relay_url =
+            iroh::RelayUrl::from_str("https://relay.example.com").unwrap();
+
+        assert!(uses_custom_infra(
+            &DiscoveryModeOption::Custom {
+                pkarr_relay_url: pkarr.clone(),
+                dns_origin: None,
+            },
+            &RelayModeOption::Default
+        ));
+        assert!(uses_custom_infra(
+            &DiscoveryModeOption::Default,
+            &RelayModeOption::Custom {
+                urls: vec![relay_url],
+                auth_token: None,
+            }
+        ));
+    }
+
+    #[cfg(not(any(target_arch = "wasm32", target_os = "android")))]
+    #[test]
+    fn strip_trailing_root_label_normalizes_fqdn() {
+        use rustls::pki_types::ServerName;
+
+        let with_dot = ServerName::try_from("host.example.com.").expect("valid FQDN");
+        let stripped = strip_trailing_root_label(&with_dot).expect("should strip");
+        assert_eq!(stripped.to_str(), "host.example.com");
+
+        let plain = ServerName::try_from("host.example.com").expect("valid name");
+        assert!(strip_trailing_root_label(&plain).is_none());
+    }
+
+    #[cfg(not(any(target_arch = "wasm32", target_os = "android")))]
+    #[test]
+    fn dot_tolerant_passes_stripped_name_to_inner() {
+        use std::sync::{Arc, Mutex};
+
+        use rustls::client::danger::{
+            HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier,
+        };
+        use rustls::pki_types::{CertificateDer, ServerName, UnixTime};
+        use rustls::{DigitallySignedStruct, Error as TlsError, SignatureScheme};
+
+        #[derive(Debug)]
+        struct Recording(Mutex<Option<String>>);
+
+        impl ServerCertVerifier for Recording {
+            fn verify_server_cert(
+                &self,
+                _end_entity: &CertificateDer<'_>,
+                _intermediates: &[CertificateDer<'_>],
+                server_name: &ServerName<'_>,
+                _ocsp_response: &[u8],
+                _now: UnixTime,
+            ) -> Result<ServerCertVerified, TlsError> {
+                *self.0.lock().unwrap() = Some(server_name.to_str().into_owned());
+                Ok(ServerCertVerified::assertion())
+            }
+
+            fn verify_tls12_signature(
+                &self,
+                _message: &[u8],
+                _cert: &CertificateDer<'_>,
+                _dss: &DigitallySignedStruct,
+            ) -> Result<HandshakeSignatureValid, TlsError> {
+                Ok(HandshakeSignatureValid::assertion())
+            }
+
+            fn verify_tls13_signature(
+                &self,
+                _message: &[u8],
+                _cert: &CertificateDer<'_>,
+                _dss: &DigitallySignedStruct,
+            ) -> Result<HandshakeSignatureValid, TlsError> {
+                Ok(HandshakeSignatureValid::assertion())
+            }
+
+            fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
+                vec![]
+            }
+        }
+
+        let inner = Arc::new(Recording(Mutex::new(None)));
+        let wrapper = DotTolerant(inner.clone());
+        let name = ServerName::try_from("host.example.com.").unwrap();
+        let empty = CertificateDer::from(Vec::new());
+        wrapper
+            .verify_server_cert(
+                &empty,
+                &[],
+                &name,
+                &[],
+                UnixTime::since_unix_epoch(std::time::Duration::from_secs(0)),
+            )
+            .unwrap();
+
+        assert_eq!(
+            inner.0.lock().unwrap().as_deref(),
+            Some("host.example.com")
+        );
     }
 }

--- a/engine/wasm-io/src/receive.rs
+++ b/engine/wasm-io/src/receive.rs
@@ -1,5 +1,6 @@
 use protocol::{
-    download_to_store, get_or_create_secret, with_system_ca, AppHandle, ReceiveOptions,
+    download_to_store, get_or_create_secret, uses_custom_infra, with_system_ca_if_custom,
+    AppHandle, ReceiveOptions,
 };
 use iroh::endpoint::presets;
 use iroh::Endpoint;
@@ -19,11 +20,13 @@ pub async fn download_files(
     let addr = ticket.addr().clone();
     let secret_key = get_or_create_secret()?;
 
-    let builder = with_system_ca(
+    let custom_infra = uses_custom_infra(&options.discovery_mode, &options.relay_mode);
+    let builder = with_system_ca_if_custom(
         Endpoint::builder(presets::Minimal)
             .alpns(vec![])
             .secret_key(secret_key)
             .relay_mode(options.relay_mode.clone().into()),
+        custom_infra,
     );
 
     anyhow::ensure!(

--- a/engine/wasm-io/src/send.rs
+++ b/engine/wasm-io/src/send.rs
@@ -1,6 +1,6 @@
 use protocol::{
-    get_or_create_secret, run_share_session, with_system_ca, AddrInfoOptions, AppHandle,
-    FileMetadata, SendOptions, METADATA_ALPN,
+    get_or_create_secret, run_share_session, uses_custom_infra, with_system_ca_if_custom,
+    AddrInfoOptions, AppHandle, FileMetadata, SendOptions, METADATA_ALPN,
 };
 use iroh::endpoint::presets;
 use iroh::{endpoint::RelayMode, Endpoint};
@@ -25,11 +25,13 @@ pub async fn start_share_bytes(
     let relay_mode: RelayMode = options.relay_mode.clone().into();
     let ticket_type = AddrInfoOptions::Relay;
 
-    let builder = with_system_ca(
+    let custom_infra = uses_custom_infra(&options.discovery_mode, &options.relay_mode);
+    let builder = with_system_ca_if_custom(
         Endpoint::builder(presets::N0)
             .alpns(vec![iroh_blobs::ALPN.to_vec(), METADATA_ALPN.to_vec()])
             .secret_key(secret_key)
             .relay_mode(relay_mode.clone()),
+        custom_infra,
     );
 
     let (progress_tx, progress_rx) = mpsc::channel(64);
@@ -88,11 +90,13 @@ pub async fn start_share_items_bytes(
     let relay_mode: RelayMode = options.relay_mode.clone().into();
     let ticket_type = AddrInfoOptions::Relay;
 
-    let builder = with_system_ca(
+    let custom_infra = uses_custom_infra(&options.discovery_mode, &options.relay_mode);
+    let builder = with_system_ca_if_custom(
         Endpoint::builder(presets::N0)
             .alpns(vec![iroh_blobs::ALPN.to_vec(), METADATA_ALPN.to_vec()])
             .secret_key(secret_key)
             .relay_mode(relay_mode.clone()),
+        custom_infra,
     );
 
     let (progress_tx, progress_rx) = mpsc::channel(64);

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -177,7 +177,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -188,7 +188,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1496,7 +1496,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1624,7 +1624,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1951,7 +1951,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2395,8 +2395,8 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.1.3",
- "windows-result 0.3.4",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
 ]
 
 [[package]]
@@ -3154,7 +3154,7 @@ dependencies = [
  "tokio",
  "tower-service",
  "tracing",
- "windows-registry 0.5.3",
+ "windows-registry 0.6.1",
 ]
 
 [[package]]
@@ -4668,7 +4668,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4763,7 +4763,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -5910,7 +5910,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6418,14 +6418,14 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.23.41"
+version = "0.23.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
+checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -6477,7 +6477,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6621,7 +6621,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6717,6 +6717,7 @@ dependencies = [
  "iroh",
  "iroh-blobs",
  "n0-future",
+ "rustls",
  "serde",
  "serde_json",
  "tokio",
@@ -7081,7 +7082,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7906,10 +7907,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8423,7 +8424,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8955,7 +8956,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/wasm-bridge/src/lib.rs
+++ b/wasm-bridge/src/lib.rs
@@ -7,7 +7,7 @@ use wasm_io::{
 };
 use protocol::{
     get_relay_status as engine_get_relay_status, resolve_relay_mode_with_fallback,
-    set_wasm_secret_key, verify_relays as engine_verify_relays, with_system_ca,
+    set_wasm_secret_key, verify_relays as engine_verify_relays, with_system_ca_if_custom,
     RelayConfigArg,
 };
 use std::str::FromStr;
@@ -377,7 +377,7 @@ pub async fn smoke_test_endpoint() -> Result<String, JsValue> {
     use iroh::endpoint::presets;
     use iroh::Endpoint;
 
-    let endpoint = with_system_ca(Endpoint::builder(presets::N0))
+    let endpoint = with_system_ca_if_custom(Endpoint::builder(presets::N0), false)
         .bind()
         .await
         .map_err(|e| JsValue::from_str(&format!("endpoint bind failed: {e}")))?;


### PR DESCRIPTION
## Summary
- Fix Windows-only regression from enabling OS CA trust (`platform-verifier`): default n0 relay hostnames use a trailing DNS root label (`*.relay.n0.iroh.link.`), which Windows `CERT_CHAIN_POLICY_SSL` rejects literally as `NotValidForName`, breaking relay probes, pairing, and one-shot shares.
- Apply `CaTlsConfig::system()` only for custom relay/discovery infra; default path keeps iroh’s embedded Mozilla roots (0.6.0 behavior).
- When OS trust is used, wrap the platform verifier with `DotTolerant` so a trailing `.` is stripped before name matching (DNS-equivalent), so custom FQDNs don’t hit the same Windows bug.
