### PR TITLE
build(flatpak): pin manifest to actual v0.6.2 tip and regen sources

### DIFF
--- a/flatpak/cargo-sources.json
+++ b/flatpak/cargo-sources.json
@@ -1,11838 +1,11851 @@
 [
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/adler2/adler2-2.0.1.crate",
-		"sha256": "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa",
-		"dest": "cargo/vendor/adler2-2.0.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa\", \"files\": {}}",
-		"dest": "cargo/vendor/adler2-2.0.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/aead/aead-0.5.2.crate",
-		"sha256": "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0",
-		"dest": "cargo/vendor/aead-0.5.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0\", \"files\": {}}",
-		"dest": "cargo/vendor/aead-0.5.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/aes/aes-0.8.4.crate",
-		"sha256": "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0",
-		"dest": "cargo/vendor/aes-0.8.4"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0\", \"files\": {}}",
-		"dest": "cargo/vendor/aes-0.8.4",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/aes-gcm/aes-gcm-0.10.3.crate",
-		"sha256": "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1",
-		"dest": "cargo/vendor/aes-gcm-0.10.3"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1\", \"files\": {}}",
-		"dest": "cargo/vendor/aes-gcm-0.10.3",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/aho-corasick/aho-corasick-1.1.4.crate",
-		"sha256": "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301",
-		"dest": "cargo/vendor/aho-corasick-1.1.4"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301\", \"files\": {}}",
-		"dest": "cargo/vendor/aho-corasick-1.1.4",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/aligned/aligned-0.4.3.crate",
-		"sha256": "ee4508988c62edf04abd8d92897fca0c2995d907ce1dfeaf369dac3716a40685",
-		"dest": "cargo/vendor/aligned-0.4.3"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"ee4508988c62edf04abd8d92897fca0c2995d907ce1dfeaf369dac3716a40685\", \"files\": {}}",
-		"dest": "cargo/vendor/aligned-0.4.3",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/aligned-vec/aligned-vec-0.6.4.crate",
-		"sha256": "dc890384c8602f339876ded803c97ad529f3842aba97f6392b3dba0dd171769b",
-		"dest": "cargo/vendor/aligned-vec-0.6.4"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"dc890384c8602f339876ded803c97ad529f3842aba97f6392b3dba0dd171769b\", \"files\": {}}",
-		"dest": "cargo/vendor/aligned-vec-0.6.4",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/alloc-no-stdlib/alloc-no-stdlib-2.0.4.crate",
-		"sha256": "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3",
-		"dest": "cargo/vendor/alloc-no-stdlib-2.0.4"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3\", \"files\": {}}",
-		"dest": "cargo/vendor/alloc-no-stdlib-2.0.4",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/alloc-stdlib/alloc-stdlib-0.2.4.crate",
-		"sha256": "0e76a019e91224d279006ff972f1e984179a6e9feb050adba6ce8274aef23195",
-		"dest": "cargo/vendor/alloc-stdlib-0.2.4"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"0e76a019e91224d279006ff972f1e984179a6e9feb050adba6ce8274aef23195\", \"files\": {}}",
-		"dest": "cargo/vendor/alloc-stdlib-0.2.4",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/allocator-api2/allocator-api2-0.2.21.crate",
-		"sha256": "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923",
-		"dest": "cargo/vendor/allocator-api2-0.2.21"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923\", \"files\": {}}",
-		"dest": "cargo/vendor/allocator-api2-0.2.21",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/android_system_properties/android_system_properties-0.1.5.crate",
-		"sha256": "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311",
-		"dest": "cargo/vendor/android_system_properties-0.1.5"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311\", \"files\": {}}",
-		"dest": "cargo/vendor/android_system_properties-0.1.5",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/anstream/anstream-1.0.0.crate",
-		"sha256": "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d",
-		"dest": "cargo/vendor/anstream-1.0.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d\", \"files\": {}}",
-		"dest": "cargo/vendor/anstream-1.0.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/anstyle/anstyle-1.0.14.crate",
-		"sha256": "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000",
-		"dest": "cargo/vendor/anstyle-1.0.14"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000\", \"files\": {}}",
-		"dest": "cargo/vendor/anstyle-1.0.14",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/anstyle-parse/anstyle-parse-1.0.0.crate",
-		"sha256": "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e",
-		"dest": "cargo/vendor/anstyle-parse-1.0.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e\", \"files\": {}}",
-		"dest": "cargo/vendor/anstyle-parse-1.0.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/anstyle-query/anstyle-query-1.1.5.crate",
-		"sha256": "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc",
-		"dest": "cargo/vendor/anstyle-query-1.1.5"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc\", \"files\": {}}",
-		"dest": "cargo/vendor/anstyle-query-1.1.5",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/anstyle-wincon/anstyle-wincon-3.0.11.crate",
-		"sha256": "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d",
-		"dest": "cargo/vendor/anstyle-wincon-3.0.11"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d\", \"files\": {}}",
-		"dest": "cargo/vendor/anstyle-wincon-3.0.11",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/anyhow/anyhow-1.0.103.crate",
-		"sha256": "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3",
-		"dest": "cargo/vendor/anyhow-1.0.103"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3\", \"files\": {}}",
-		"dest": "cargo/vendor/anyhow-1.0.103",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/arbitrary/arbitrary-1.4.2.crate",
-		"sha256": "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1",
-		"dest": "cargo/vendor/arbitrary-1.4.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1\", \"files\": {}}",
-		"dest": "cargo/vendor/arbitrary-1.4.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/arc-swap/arc-swap-1.9.2.crate",
-		"sha256": "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b",
-		"dest": "cargo/vendor/arc-swap-1.9.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b\", \"files\": {}}",
-		"dest": "cargo/vendor/arc-swap-1.9.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/arg_enum_proc_macro/arg_enum_proc_macro-0.3.4.crate",
-		"sha256": "0ae92a5119aa49cdbcf6b9f893fe4e1d98b04ccbf82ee0584ad948a44a734dea",
-		"dest": "cargo/vendor/arg_enum_proc_macro-0.3.4"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"0ae92a5119aa49cdbcf6b9f893fe4e1d98b04ccbf82ee0584ad948a44a734dea\", \"files\": {}}",
-		"dest": "cargo/vendor/arg_enum_proc_macro-0.3.4",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/arrayref/arrayref-0.3.9.crate",
-		"sha256": "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb",
-		"dest": "cargo/vendor/arrayref-0.3.9"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb\", \"files\": {}}",
-		"dest": "cargo/vendor/arrayref-0.3.9",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/arrayvec/arrayvec-0.7.8.crate",
-		"sha256": "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56",
-		"dest": "cargo/vendor/arrayvec-0.7.8"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56\", \"files\": {}}",
-		"dest": "cargo/vendor/arrayvec-0.7.8",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/as-slice/as-slice-0.2.1.crate",
-		"sha256": "516b6b4f0e40d50dcda9365d53964ec74560ad4284da2e7fc97122cd83174516",
-		"dest": "cargo/vendor/as-slice-0.2.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"516b6b4f0e40d50dcda9365d53964ec74560ad4284da2e7fc97122cd83174516\", \"files\": {}}",
-		"dest": "cargo/vendor/as-slice-0.2.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/ashpd/ashpd-0.11.1.crate",
-		"sha256": "d2f3f79755c74fd155000314eb349864caa787c6592eace6c6882dad873d9c39",
-		"dest": "cargo/vendor/ashpd-0.11.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"d2f3f79755c74fd155000314eb349864caa787c6592eace6c6882dad873d9c39\", \"files\": {}}",
-		"dest": "cargo/vendor/ashpd-0.11.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/asn1-rs/asn1-rs-0.7.2.crate",
-		"sha256": "b7f43a50ac4fdca5df8e885c21b835997f0a1cdee65494a6847694a98652d9d8",
-		"dest": "cargo/vendor/asn1-rs-0.7.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"b7f43a50ac4fdca5df8e885c21b835997f0a1cdee65494a6847694a98652d9d8\", \"files\": {}}",
-		"dest": "cargo/vendor/asn1-rs-0.7.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/asn1-rs-derive/asn1-rs-derive-0.6.0.crate",
-		"sha256": "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c",
-		"dest": "cargo/vendor/asn1-rs-derive-0.6.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c\", \"files\": {}}",
-		"dest": "cargo/vendor/asn1-rs-derive-0.6.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/asn1-rs-impl/asn1-rs-impl-0.2.0.crate",
-		"sha256": "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7",
-		"dest": "cargo/vendor/asn1-rs-impl-0.2.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7\", \"files\": {}}",
-		"dest": "cargo/vendor/asn1-rs-impl-0.2.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/async-broadcast/async-broadcast-0.7.2.crate",
-		"sha256": "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532",
-		"dest": "cargo/vendor/async-broadcast-0.7.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532\", \"files\": {}}",
-		"dest": "cargo/vendor/async-broadcast-0.7.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/async-channel/async-channel-2.5.0.crate",
-		"sha256": "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2",
-		"dest": "cargo/vendor/async-channel-2.5.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2\", \"files\": {}}",
-		"dest": "cargo/vendor/async-channel-2.5.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/async-executor/async-executor-1.14.0.crate",
-		"sha256": "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a",
-		"dest": "cargo/vendor/async-executor-1.14.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a\", \"files\": {}}",
-		"dest": "cargo/vendor/async-executor-1.14.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/async-io/async-io-2.6.0.crate",
-		"sha256": "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc",
-		"dest": "cargo/vendor/async-io-2.6.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc\", \"files\": {}}",
-		"dest": "cargo/vendor/async-io-2.6.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/async-lock/async-lock-3.4.2.crate",
-		"sha256": "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311",
-		"dest": "cargo/vendor/async-lock-3.4.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311\", \"files\": {}}",
-		"dest": "cargo/vendor/async-lock-3.4.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/async-process/async-process-2.5.0.crate",
-		"sha256": "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75",
-		"dest": "cargo/vendor/async-process-2.5.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75\", \"files\": {}}",
-		"dest": "cargo/vendor/async-process-2.5.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/async-recursion/async-recursion-1.1.1.crate",
-		"sha256": "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11",
-		"dest": "cargo/vendor/async-recursion-1.1.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11\", \"files\": {}}",
-		"dest": "cargo/vendor/async-recursion-1.1.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/async-signal/async-signal-0.2.14.crate",
-		"sha256": "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485",
-		"dest": "cargo/vendor/async-signal-0.2.14"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485\", \"files\": {}}",
-		"dest": "cargo/vendor/async-signal-0.2.14",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/async-task/async-task-4.7.1.crate",
-		"sha256": "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de",
-		"dest": "cargo/vendor/async-task-4.7.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de\", \"files\": {}}",
-		"dest": "cargo/vendor/async-task-4.7.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/async-trait/async-trait-0.1.89.crate",
-		"sha256": "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb",
-		"dest": "cargo/vendor/async-trait-0.1.89"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb\", \"files\": {}}",
-		"dest": "cargo/vendor/async-trait-0.1.89",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/async_io_stream/async_io_stream-0.3.3.crate",
-		"sha256": "b6d7b9decdf35d8908a7e3ef02f64c5e9b1695e230154c0e8de3969142d9b94c",
-		"dest": "cargo/vendor/async_io_stream-0.3.3"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"b6d7b9decdf35d8908a7e3ef02f64c5e9b1695e230154c0e8de3969142d9b94c\", \"files\": {}}",
-		"dest": "cargo/vendor/async_io_stream-0.3.3",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/atk/atk-0.18.2.crate",
-		"sha256": "241b621213072e993be4f6f3a9e4b45f65b7e6faad43001be957184b7bb1824b",
-		"dest": "cargo/vendor/atk-0.18.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"241b621213072e993be4f6f3a9e4b45f65b7e6faad43001be957184b7bb1824b\", \"files\": {}}",
-		"dest": "cargo/vendor/atk-0.18.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/atk-sys/atk-sys-0.18.2.crate",
-		"sha256": "c5e48b684b0ca77d2bbadeef17424c2ea3c897d44d566a1617e7e8f30614d086",
-		"dest": "cargo/vendor/atk-sys-0.18.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"c5e48b684b0ca77d2bbadeef17424c2ea3c897d44d566a1617e7e8f30614d086\", \"files\": {}}",
-		"dest": "cargo/vendor/atk-sys-0.18.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/atomic-polyfill/atomic-polyfill-1.0.3.crate",
-		"sha256": "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4",
-		"dest": "cargo/vendor/atomic-polyfill-1.0.3"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4\", \"files\": {}}",
-		"dest": "cargo/vendor/atomic-polyfill-1.0.3",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/atomic-waker/atomic-waker-1.1.2.crate",
-		"sha256": "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0",
-		"dest": "cargo/vendor/atomic-waker-1.1.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0\", \"files\": {}}",
-		"dest": "cargo/vendor/atomic-waker-1.1.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/atomic_refcell/atomic_refcell-0.1.14.crate",
-		"sha256": "21e4227379beff4205943696e6c3e0cd809bacdf3f0edd6e3dd153e2269571a4",
-		"dest": "cargo/vendor/atomic_refcell-0.1.14"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"21e4227379beff4205943696e6c3e0cd809bacdf3f0edd6e3dd153e2269571a4\", \"files\": {}}",
-		"dest": "cargo/vendor/atomic_refcell-0.1.14",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/attohttpc/attohttpc-0.30.1.crate",
-		"sha256": "16e2cdb6d5ed835199484bb92bb8b3edd526effe995c61732580439c1a67e2e9",
-		"dest": "cargo/vendor/attohttpc-0.30.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"16e2cdb6d5ed835199484bb92bb8b3edd526effe995c61732580439c1a67e2e9\", \"files\": {}}",
-		"dest": "cargo/vendor/attohttpc-0.30.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/autocfg/autocfg-1.5.1.crate",
-		"sha256": "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53",
-		"dest": "cargo/vendor/autocfg-1.5.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53\", \"files\": {}}",
-		"dest": "cargo/vendor/autocfg-1.5.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/av-scenechange/av-scenechange-0.14.1.crate",
-		"sha256": "0f321d77c20e19b92c39e7471cf986812cbb46659d2af674adc4331ef3f18394",
-		"dest": "cargo/vendor/av-scenechange-0.14.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"0f321d77c20e19b92c39e7471cf986812cbb46659d2af674adc4331ef3f18394\", \"files\": {}}",
-		"dest": "cargo/vendor/av-scenechange-0.14.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/av1-grain/av1-grain-0.2.5.crate",
-		"sha256": "8cfddb07216410377231960af4fcab838eaa12e013417781b78bd95ee22077f8",
-		"dest": "cargo/vendor/av1-grain-0.2.5"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"8cfddb07216410377231960af4fcab838eaa12e013417781b78bd95ee22077f8\", \"files\": {}}",
-		"dest": "cargo/vendor/av1-grain-0.2.5",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/avif-serialize/avif-serialize-0.8.9.crate",
-		"sha256": "e7178fe5f7d460b13895ebb9dcb28a3a6216d2df2574a0806cb51b555d297f38",
-		"dest": "cargo/vendor/avif-serialize-0.8.9"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"e7178fe5f7d460b13895ebb9dcb28a3a6216d2df2574a0806cb51b555d297f38\", \"files\": {}}",
-		"dest": "cargo/vendor/avif-serialize-0.8.9",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/aws-lc-rs/aws-lc-rs-1.17.1.crate",
-		"sha256": "4342d8937fc7e5dd9b1c60292261c0670c882a2cd1719cfc11b1af41731e32ad",
-		"dest": "cargo/vendor/aws-lc-rs-1.17.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"4342d8937fc7e5dd9b1c60292261c0670c882a2cd1719cfc11b1af41731e32ad\", \"files\": {}}",
-		"dest": "cargo/vendor/aws-lc-rs-1.17.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/aws-lc-sys/aws-lc-sys-0.42.0.crate",
-		"sha256": "6d9ceb1da931507a12f4fccea479dccd00da1943e1b4ae72d8e502d707361444",
-		"dest": "cargo/vendor/aws-lc-sys-0.42.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"6d9ceb1da931507a12f4fccea479dccd00da1943e1b4ae72d8e502d707361444\", \"files\": {}}",
-		"dest": "cargo/vendor/aws-lc-sys-0.42.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/backon/backon-1.6.0.crate",
-		"sha256": "cffb0e931875b666fc4fcb20fee52e9bbd1ef836fd9e9e04ec21555f9f85f7ef",
-		"dest": "cargo/vendor/backon-1.6.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"cffb0e931875b666fc4fcb20fee52e9bbd1ef836fd9e9e04ec21555f9f85f7ef\", \"files\": {}}",
-		"dest": "cargo/vendor/backon-1.6.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/bao-tree/bao-tree-0.16.0.crate",
-		"sha256": "06384416b1825e6e04fde63262fda2dc408f5b64c02d04e0d8b70ae72c17a52b",
-		"dest": "cargo/vendor/bao-tree-0.16.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"06384416b1825e6e04fde63262fda2dc408f5b64c02d04e0d8b70ae72c17a52b\", \"files\": {}}",
-		"dest": "cargo/vendor/bao-tree-0.16.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/base16ct/base16ct-1.0.0.crate",
-		"sha256": "fd307490d624467aa6f74b0eabb77633d1f758a7b25f12bceb0b22e08d9726f6",
-		"dest": "cargo/vendor/base16ct-1.0.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"fd307490d624467aa6f74b0eabb77633d1f758a7b25f12bceb0b22e08d9726f6\", \"files\": {}}",
-		"dest": "cargo/vendor/base16ct-1.0.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/base64/base64-0.21.7.crate",
-		"sha256": "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567",
-		"dest": "cargo/vendor/base64-0.21.7"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567\", \"files\": {}}",
-		"dest": "cargo/vendor/base64-0.21.7",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/base64/base64-0.22.1.crate",
-		"sha256": "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6",
-		"dest": "cargo/vendor/base64-0.22.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6\", \"files\": {}}",
-		"dest": "cargo/vendor/base64-0.22.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/base64ct/base64ct-1.8.3.crate",
-		"sha256": "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06",
-		"dest": "cargo/vendor/base64ct-1.8.3"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06\", \"files\": {}}",
-		"dest": "cargo/vendor/base64ct-1.8.3",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/binary-merge/binary-merge-0.1.2.crate",
-		"sha256": "597bb81c80a54b6a4381b23faba8d7774b144c94cbd1d6fe3f1329bd776554ab",
-		"dest": "cargo/vendor/binary-merge-0.1.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"597bb81c80a54b6a4381b23faba8d7774b144c94cbd1d6fe3f1329bd776554ab\", \"files\": {}}",
-		"dest": "cargo/vendor/binary-merge-0.1.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/bit-set/bit-set-0.8.0.crate",
-		"sha256": "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3",
-		"dest": "cargo/vendor/bit-set-0.8.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3\", \"files\": {}}",
-		"dest": "cargo/vendor/bit-set-0.8.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/bit-vec/bit-vec-0.8.0.crate",
-		"sha256": "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7",
-		"dest": "cargo/vendor/bit-vec-0.8.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7\", \"files\": {}}",
-		"dest": "cargo/vendor/bit-vec-0.8.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/bit-vec/bit-vec-0.9.1.crate",
-		"sha256": "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51",
-		"dest": "cargo/vendor/bit-vec-0.9.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51\", \"files\": {}}",
-		"dest": "cargo/vendor/bit-vec-0.9.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/bit_field/bit_field-0.10.3.crate",
-		"sha256": "1e4b40c7323adcfc0a41c4b88143ed58346ff65a288fc144329c5c45e05d70c6",
-		"dest": "cargo/vendor/bit_field-0.10.3"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"1e4b40c7323adcfc0a41c4b88143ed58346ff65a288fc144329c5c45e05d70c6\", \"files\": {}}",
-		"dest": "cargo/vendor/bit_field-0.10.3",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/bitflags/bitflags-1.3.2.crate",
-		"sha256": "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a",
-		"dest": "cargo/vendor/bitflags-1.3.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a\", \"files\": {}}",
-		"dest": "cargo/vendor/bitflags-1.3.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/bitflags/bitflags-2.13.0.crate",
-		"sha256": "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8",
-		"dest": "cargo/vendor/bitflags-2.13.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8\", \"files\": {}}",
-		"dest": "cargo/vendor/bitflags-2.13.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/bitstream-io/bitstream-io-4.10.0.crate",
-		"sha256": "7eff00be299a18769011411c9def0d827e8f2d7bf0c3dbf53633147a8867fd1f",
-		"dest": "cargo/vendor/bitstream-io-4.10.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"7eff00be299a18769011411c9def0d827e8f2d7bf0c3dbf53633147a8867fd1f\", \"files\": {}}",
-		"dest": "cargo/vendor/bitstream-io-4.10.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/blake3/blake3-1.8.5.crate",
-		"sha256": "0aa83c34e62843d924f905e0f5c866eb1dd6545fc4d719e803d9ba6030371fce",
-		"dest": "cargo/vendor/blake3-1.8.5"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"0aa83c34e62843d924f905e0f5c866eb1dd6545fc4d719e803d9ba6030371fce\", \"files\": {}}",
-		"dest": "cargo/vendor/blake3-1.8.5",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/block-buffer/block-buffer-0.10.4.crate",
-		"sha256": "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71",
-		"dest": "cargo/vendor/block-buffer-0.10.4"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71\", \"files\": {}}",
-		"dest": "cargo/vendor/block-buffer-0.10.4",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/block-buffer/block-buffer-0.12.1.crate",
-		"sha256": "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa",
-		"dest": "cargo/vendor/block-buffer-0.12.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa\", \"files\": {}}",
-		"dest": "cargo/vendor/block-buffer-0.12.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/block2/block2-0.6.2.crate",
-		"sha256": "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5",
-		"dest": "cargo/vendor/block2-0.6.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5\", \"files\": {}}",
-		"dest": "cargo/vendor/block2-0.6.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/blocking/blocking-1.6.2.crate",
-		"sha256": "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21",
-		"dest": "cargo/vendor/blocking-1.6.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21\", \"files\": {}}",
-		"dest": "cargo/vendor/blocking-1.6.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/brotli/brotli-8.0.4.crate",
-		"sha256": "5cc91aac060a7a1e25823bdccbfb6af1875b88f17c6daac97894eed8207166b3",
-		"dest": "cargo/vendor/brotli-8.0.4"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"5cc91aac060a7a1e25823bdccbfb6af1875b88f17c6daac97894eed8207166b3\", \"files\": {}}",
-		"dest": "cargo/vendor/brotli-8.0.4",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/brotli-decompressor/brotli-decompressor-5.0.3.crate",
-		"sha256": "3a32acac15fe1967bc3986b2a6347dffc965602354ea6f450ad07e8bfd253583",
-		"dest": "cargo/vendor/brotli-decompressor-5.0.3"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"3a32acac15fe1967bc3986b2a6347dffc965602354ea6f450ad07e8bfd253583\", \"files\": {}}",
-		"dest": "cargo/vendor/brotli-decompressor-5.0.3",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/bs58/bs58-0.5.1.crate",
-		"sha256": "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4",
-		"dest": "cargo/vendor/bs58-0.5.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4\", \"files\": {}}",
-		"dest": "cargo/vendor/bs58-0.5.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/built/built-0.8.1.crate",
-		"sha256": "5c0e531d93d39c34eef561e929e8a7f86d77a5af08aac4f6d6e39976c51858e9",
-		"dest": "cargo/vendor/built-0.8.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"5c0e531d93d39c34eef561e929e8a7f86d77a5af08aac4f6d6e39976c51858e9\", \"files\": {}}",
-		"dest": "cargo/vendor/built-0.8.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/bumpalo/bumpalo-3.20.3.crate",
-		"sha256": "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649",
-		"dest": "cargo/vendor/bumpalo-3.20.3"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649\", \"files\": {}}",
-		"dest": "cargo/vendor/bumpalo-3.20.3",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/bytemuck/bytemuck-1.25.0.crate",
-		"sha256": "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec",
-		"dest": "cargo/vendor/bytemuck-1.25.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec\", \"files\": {}}",
-		"dest": "cargo/vendor/bytemuck-1.25.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/byteorder/byteorder-1.5.0.crate",
-		"sha256": "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b",
-		"dest": "cargo/vendor/byteorder-1.5.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b\", \"files\": {}}",
-		"dest": "cargo/vendor/byteorder-1.5.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/byteorder-lite/byteorder-lite-0.1.0.crate",
-		"sha256": "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495",
-		"dest": "cargo/vendor/byteorder-lite-0.1.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495\", \"files\": {}}",
-		"dest": "cargo/vendor/byteorder-lite-0.1.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/bytes/bytes-1.11.1.crate",
-		"sha256": "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33",
-		"dest": "cargo/vendor/bytes-1.11.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33\", \"files\": {}}",
-		"dest": "cargo/vendor/bytes-1.11.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/cairo-rs/cairo-rs-0.18.5.crate",
-		"sha256": "8ca26ef0159422fb77631dc9d17b102f253b876fe1586b03b803e63a309b4ee2",
-		"dest": "cargo/vendor/cairo-rs-0.18.5"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"8ca26ef0159422fb77631dc9d17b102f253b876fe1586b03b803e63a309b4ee2\", \"files\": {}}",
-		"dest": "cargo/vendor/cairo-rs-0.18.5",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/cairo-sys-rs/cairo-sys-rs-0.18.2.crate",
-		"sha256": "685c9fa8e590b8b3d678873528d83411db17242a73fccaed827770ea0fedda51",
-		"dest": "cargo/vendor/cairo-sys-rs-0.18.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"685c9fa8e590b8b3d678873528d83411db17242a73fccaed827770ea0fedda51\", \"files\": {}}",
-		"dest": "cargo/vendor/cairo-sys-rs-0.18.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/camino/camino-1.2.4.crate",
-		"sha256": "5f2d30e4173c4026932d51d31d6b0613b1fd3014bf3f9f8943d4ba139c437ba0",
-		"dest": "cargo/vendor/camino-1.2.4"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"5f2d30e4173c4026932d51d31d6b0613b1fd3014bf3f9f8943d4ba139c437ba0\", \"files\": {}}",
-		"dest": "cargo/vendor/camino-1.2.4",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/cargo-platform/cargo-platform-0.1.9.crate",
-		"sha256": "e35af189006b9c0f00a064685c727031e3ed2d8020f7ba284d78cc2671bd36ea",
-		"dest": "cargo/vendor/cargo-platform-0.1.9"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"e35af189006b9c0f00a064685c727031e3ed2d8020f7ba284d78cc2671bd36ea\", \"files\": {}}",
-		"dest": "cargo/vendor/cargo-platform-0.1.9",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/cargo_metadata/cargo_metadata-0.19.2.crate",
-		"sha256": "dd5eb614ed4c27c5d706420e4320fbe3216ab31fa1c33cd8246ac36dae4479ba",
-		"dest": "cargo/vendor/cargo_metadata-0.19.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"dd5eb614ed4c27c5d706420e4320fbe3216ab31fa1c33cd8246ac36dae4479ba\", \"files\": {}}",
-		"dest": "cargo/vendor/cargo_metadata-0.19.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/cargo_toml/cargo_toml-0.22.3.crate",
-		"sha256": "374b7c592d9c00c1f4972ea58390ac6b18cbb6ab79011f3bdc90a0b82ca06b77",
-		"dest": "cargo/vendor/cargo_toml-0.22.3"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"374b7c592d9c00c1f4972ea58390ac6b18cbb6ab79011f3bdc90a0b82ca06b77\", \"files\": {}}",
-		"dest": "cargo/vendor/cargo_toml-0.22.3",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/cc/cc-1.2.66.crate",
-		"sha256": "f5d6cac793997bd970000024b2934968efe83b382de4fdcf4fcb46b6ee4ad996",
-		"dest": "cargo/vendor/cc-1.2.66"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"f5d6cac793997bd970000024b2934968efe83b382de4fdcf4fcb46b6ee4ad996\", \"files\": {}}",
-		"dest": "cargo/vendor/cc-1.2.66",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/cesu8/cesu8-1.1.0.crate",
-		"sha256": "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c",
-		"dest": "cargo/vendor/cesu8-1.1.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c\", \"files\": {}}",
-		"dest": "cargo/vendor/cesu8-1.1.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/cfb/cfb-0.7.3.crate",
-		"sha256": "d38f2da7a0a2c4ccf0065be06397cc26a81f4e528be095826eee9d4adbb8c60f",
-		"dest": "cargo/vendor/cfb-0.7.3"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"d38f2da7a0a2c4ccf0065be06397cc26a81f4e528be095826eee9d4adbb8c60f\", \"files\": {}}",
-		"dest": "cargo/vendor/cfb-0.7.3",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/cfg-expr/cfg-expr-0.15.8.crate",
-		"sha256": "d067ad48b8650848b989a59a86c6c36a995d02d2bf778d45c3c5d57bc2718f02",
-		"dest": "cargo/vendor/cfg-expr-0.15.8"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"d067ad48b8650848b989a59a86c6c36a995d02d2bf778d45c3c5d57bc2718f02\", \"files\": {}}",
-		"dest": "cargo/vendor/cfg-expr-0.15.8",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/cfg-expr/cfg-expr-0.20.8.crate",
-		"sha256": "fb693542bcafa528e198be0ebd9d3632ca5b7c93dbe7237460e199910835997c",
-		"dest": "cargo/vendor/cfg-expr-0.20.8"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"fb693542bcafa528e198be0ebd9d3632ca5b7c93dbe7237460e199910835997c\", \"files\": {}}",
-		"dest": "cargo/vendor/cfg-expr-0.20.8",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/cfg-if/cfg-if-1.0.4.crate",
-		"sha256": "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801",
-		"dest": "cargo/vendor/cfg-if-1.0.4"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801\", \"files\": {}}",
-		"dest": "cargo/vendor/cfg-if-1.0.4",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/cfg_aliases/cfg_aliases-0.2.1.crate",
-		"sha256": "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724",
-		"dest": "cargo/vendor/cfg_aliases-0.2.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724\", \"files\": {}}",
-		"dest": "cargo/vendor/cfg_aliases-0.2.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/chacha20/chacha20-0.10.1.crate",
-		"sha256": "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81",
-		"dest": "cargo/vendor/chacha20-0.10.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81\", \"files\": {}}",
-		"dest": "cargo/vendor/chacha20-0.10.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/chrono/chrono-0.4.45.crate",
-		"sha256": "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327",
-		"dest": "cargo/vendor/chrono-0.4.45"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327\", \"files\": {}}",
-		"dest": "cargo/vendor/chrono-0.4.45",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/cipher/cipher-0.4.4.crate",
-		"sha256": "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad",
-		"dest": "cargo/vendor/cipher-0.4.4"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad\", \"files\": {}}",
-		"dest": "cargo/vendor/cipher-0.4.4",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/clap/clap-4.6.1.crate",
-		"sha256": "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51",
-		"dest": "cargo/vendor/clap-4.6.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51\", \"files\": {}}",
-		"dest": "cargo/vendor/clap-4.6.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/clap_builder/clap_builder-4.6.0.crate",
-		"sha256": "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f",
-		"dest": "cargo/vendor/clap_builder-4.6.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f\", \"files\": {}}",
-		"dest": "cargo/vendor/clap_builder-4.6.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/clap_derive/clap_derive-4.6.1.crate",
-		"sha256": "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9",
-		"dest": "cargo/vendor/clap_derive-4.6.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9\", \"files\": {}}",
-		"dest": "cargo/vendor/clap_derive-4.6.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/clap_lex/clap_lex-1.1.0.crate",
-		"sha256": "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9",
-		"dest": "cargo/vendor/clap_lex-1.1.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9\", \"files\": {}}",
-		"dest": "cargo/vendor/clap_lex-1.1.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/cmake/cmake-0.1.58.crate",
-		"sha256": "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678",
-		"dest": "cargo/vendor/cmake-0.1.58"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678\", \"files\": {}}",
-		"dest": "cargo/vendor/cmake-0.1.58",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/cmov/cmov-0.5.4.crate",
-		"sha256": "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a",
-		"dest": "cargo/vendor/cmov-0.5.4"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a\", \"files\": {}}",
-		"dest": "cargo/vendor/cmov-0.5.4",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/cobs/cobs-0.3.0.crate",
-		"sha256": "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1",
-		"dest": "cargo/vendor/cobs-0.3.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1\", \"files\": {}}",
-		"dest": "cargo/vendor/cobs-0.3.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/color_quant/color_quant-1.1.0.crate",
-		"sha256": "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b",
-		"dest": "cargo/vendor/color_quant-1.1.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b\", \"files\": {}}",
-		"dest": "cargo/vendor/color_quant-1.1.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/colorchoice/colorchoice-1.0.5.crate",
-		"sha256": "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570",
-		"dest": "cargo/vendor/colorchoice-1.0.5"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570\", \"files\": {}}",
-		"dest": "cargo/vendor/colorchoice-1.0.5",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/combine/combine-4.6.7.crate",
-		"sha256": "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd",
-		"dest": "cargo/vendor/combine-4.6.7"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd\", \"files\": {}}",
-		"dest": "cargo/vendor/combine-4.6.7",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/concurrent-queue/concurrent-queue-2.5.0.crate",
-		"sha256": "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973",
-		"dest": "cargo/vendor/concurrent-queue-2.5.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973\", \"files\": {}}",
-		"dest": "cargo/vendor/concurrent-queue-2.5.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/console/console-0.15.11.crate",
-		"sha256": "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8",
-		"dest": "cargo/vendor/console-0.15.11"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8\", \"files\": {}}",
-		"dest": "cargo/vendor/console-0.15.11",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/const-oid/const-oid-0.10.2.crate",
-		"sha256": "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c",
-		"dest": "cargo/vendor/const-oid-0.10.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c\", \"files\": {}}",
-		"dest": "cargo/vendor/const-oid-0.10.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/constant_time_eq/constant_time_eq-0.4.2.crate",
-		"sha256": "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b",
-		"dest": "cargo/vendor/constant_time_eq-0.4.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b\", \"files\": {}}",
-		"dest": "cargo/vendor/constant_time_eq-0.4.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/convert_case/convert_case-0.4.0.crate",
-		"sha256": "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e",
-		"dest": "cargo/vendor/convert_case-0.4.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e\", \"files\": {}}",
-		"dest": "cargo/vendor/convert_case-0.4.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/convert_case/convert_case-0.10.0.crate",
-		"sha256": "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9",
-		"dest": "cargo/vendor/convert_case-0.10.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9\", \"files\": {}}",
-		"dest": "cargo/vendor/convert_case-0.10.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/cookie/cookie-0.18.1.crate",
-		"sha256": "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747",
-		"dest": "cargo/vendor/cookie-0.18.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747\", \"files\": {}}",
-		"dest": "cargo/vendor/cookie-0.18.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/cordyceps/cordyceps-0.3.4.crate",
-		"sha256": "688d7fbb8092b8de775ef2536f36c8c31f2bc4006ece2e8d8ad2d17d00ce0a2a",
-		"dest": "cargo/vendor/cordyceps-0.3.4"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"688d7fbb8092b8de775ef2536f36c8c31f2bc4006ece2e8d8ad2d17d00ce0a2a\", \"files\": {}}",
-		"dest": "cargo/vendor/cordyceps-0.3.4",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/core-foundation/core-foundation-0.9.4.crate",
-		"sha256": "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f",
-		"dest": "cargo/vendor/core-foundation-0.9.4"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f\", \"files\": {}}",
-		"dest": "cargo/vendor/core-foundation-0.9.4",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/core-foundation/core-foundation-0.10.1.crate",
-		"sha256": "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6",
-		"dest": "cargo/vendor/core-foundation-0.10.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6\", \"files\": {}}",
-		"dest": "cargo/vendor/core-foundation-0.10.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/core-foundation-sys/core-foundation-sys-0.8.7.crate",
-		"sha256": "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b",
-		"dest": "cargo/vendor/core-foundation-sys-0.8.7"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b\", \"files\": {}}",
-		"dest": "cargo/vendor/core-foundation-sys-0.8.7",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/core-graphics/core-graphics-0.24.0.crate",
-		"sha256": "fa95a34622365fa5bbf40b20b75dba8dfa8c94c734aea8ac9a5ca38af14316f1",
-		"dest": "cargo/vendor/core-graphics-0.24.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"fa95a34622365fa5bbf40b20b75dba8dfa8c94c734aea8ac9a5ca38af14316f1\", \"files\": {}}",
-		"dest": "cargo/vendor/core-graphics-0.24.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/core-graphics/core-graphics-0.25.0.crate",
-		"sha256": "064badf302c3194842cf2c5d61f56cc88e54a759313879cdf03abdd27d0c3b97",
-		"dest": "cargo/vendor/core-graphics-0.25.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"064badf302c3194842cf2c5d61f56cc88e54a759313879cdf03abdd27d0c3b97\", \"files\": {}}",
-		"dest": "cargo/vendor/core-graphics-0.25.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/core-graphics-types/core-graphics-types-0.2.0.crate",
-		"sha256": "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb",
-		"dest": "cargo/vendor/core-graphics-types-0.2.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb\", \"files\": {}}",
-		"dest": "cargo/vendor/core-graphics-types-0.2.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/cpufeatures/cpufeatures-0.2.17.crate",
-		"sha256": "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280",
-		"dest": "cargo/vendor/cpufeatures-0.2.17"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280\", \"files\": {}}",
-		"dest": "cargo/vendor/cpufeatures-0.2.17",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/cpufeatures/cpufeatures-0.3.0.crate",
-		"sha256": "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201",
-		"dest": "cargo/vendor/cpufeatures-0.3.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201\", \"files\": {}}",
-		"dest": "cargo/vendor/cpufeatures-0.3.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/crc32fast/crc32fast-1.5.0.crate",
-		"sha256": "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511",
-		"dest": "cargo/vendor/crc32fast-1.5.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511\", \"files\": {}}",
-		"dest": "cargo/vendor/crc32fast-1.5.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/critical-section/critical-section-1.2.0.crate",
-		"sha256": "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b",
-		"dest": "cargo/vendor/critical-section-1.2.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b\", \"files\": {}}",
-		"dest": "cargo/vendor/critical-section-1.2.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/crossbeam-channel/crossbeam-channel-0.5.16.crate",
-		"sha256": "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e",
-		"dest": "cargo/vendor/crossbeam-channel-0.5.16"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e\", \"files\": {}}",
-		"dest": "cargo/vendor/crossbeam-channel-0.5.16",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/crossbeam-deque/crossbeam-deque-0.8.7.crate",
-		"sha256": "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb",
-		"dest": "cargo/vendor/crossbeam-deque-0.8.7"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb\", \"files\": {}}",
-		"dest": "cargo/vendor/crossbeam-deque-0.8.7",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/crossbeam-epoch/crossbeam-epoch-0.9.20.crate",
-		"sha256": "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f",
-		"dest": "cargo/vendor/crossbeam-epoch-0.9.20"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f\", \"files\": {}}",
-		"dest": "cargo/vendor/crossbeam-epoch-0.9.20",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/crossbeam-utils/crossbeam-utils-0.8.22.crate",
-		"sha256": "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17",
-		"dest": "cargo/vendor/crossbeam-utils-0.8.22"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17\", \"files\": {}}",
-		"dest": "cargo/vendor/crossbeam-utils-0.8.22",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/crossterm/crossterm-0.29.0.crate",
-		"sha256": "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b",
-		"dest": "cargo/vendor/crossterm-0.29.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b\", \"files\": {}}",
-		"dest": "cargo/vendor/crossterm-0.29.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/crossterm_winapi/crossterm_winapi-0.9.1.crate",
-		"sha256": "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b",
-		"dest": "cargo/vendor/crossterm_winapi-0.9.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b\", \"files\": {}}",
-		"dest": "cargo/vendor/crossterm_winapi-0.9.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/crunchy/crunchy-0.2.4.crate",
-		"sha256": "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5",
-		"dest": "cargo/vendor/crunchy-0.2.4"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5\", \"files\": {}}",
-		"dest": "cargo/vendor/crunchy-0.2.4",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/crypto-common/crypto-common-0.1.7.crate",
-		"sha256": "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a",
-		"dest": "cargo/vendor/crypto-common-0.1.7"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a\", \"files\": {}}",
-		"dest": "cargo/vendor/crypto-common-0.1.7",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/crypto-common/crypto-common-0.2.2.crate",
-		"sha256": "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453",
-		"dest": "cargo/vendor/crypto-common-0.2.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453\", \"files\": {}}",
-		"dest": "cargo/vendor/crypto-common-0.2.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/cssparser/cssparser-0.29.6.crate",
-		"sha256": "f93d03419cb5950ccfd3daf3ff1c7a36ace64609a1a8746d493df1ca0afde0fa",
-		"dest": "cargo/vendor/cssparser-0.29.6"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"f93d03419cb5950ccfd3daf3ff1c7a36ace64609a1a8746d493df1ca0afde0fa\", \"files\": {}}",
-		"dest": "cargo/vendor/cssparser-0.29.6",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/cssparser/cssparser-0.36.0.crate",
-		"sha256": "dae61cf9c0abb83bd659dab65b7e4e38d8236824c85f0f804f173567bda257d2",
-		"dest": "cargo/vendor/cssparser-0.36.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"dae61cf9c0abb83bd659dab65b7e4e38d8236824c85f0f804f173567bda257d2\", \"files\": {}}",
-		"dest": "cargo/vendor/cssparser-0.36.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/cssparser-macros/cssparser-macros-0.6.1.crate",
-		"sha256": "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331",
-		"dest": "cargo/vendor/cssparser-macros-0.6.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331\", \"files\": {}}",
-		"dest": "cargo/vendor/cssparser-macros-0.6.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/ctor/ctor-0.8.0.crate",
-		"sha256": "352d39c2f7bef1d6ad73db6f5160efcaed66d94ef8c6c573a8410c00bf909a98",
-		"dest": "cargo/vendor/ctor-0.8.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"352d39c2f7bef1d6ad73db6f5160efcaed66d94ef8c6c573a8410c00bf909a98\", \"files\": {}}",
-		"dest": "cargo/vendor/ctor-0.8.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/ctor-proc-macro/ctor-proc-macro-0.0.7.crate",
-		"sha256": "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1",
-		"dest": "cargo/vendor/ctor-proc-macro-0.0.7"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1\", \"files\": {}}",
-		"dest": "cargo/vendor/ctor-proc-macro-0.0.7",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/ctr/ctr-0.9.2.crate",
-		"sha256": "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835",
-		"dest": "cargo/vendor/ctr-0.9.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835\", \"files\": {}}",
-		"dest": "cargo/vendor/ctr-0.9.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/ctutils/ctutils-0.4.2.crate",
-		"sha256": "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e",
-		"dest": "cargo/vendor/ctutils-0.4.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e\", \"files\": {}}",
-		"dest": "cargo/vendor/ctutils-0.4.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/curve25519-dalek/curve25519-dalek-5.0.0-rc.0.crate",
-		"sha256": "4f359e08ca85e7bd759e1fd933ff2bccd81864c60a8fba0e259c7f822b0924bf",
-		"dest": "cargo/vendor/curve25519-dalek-5.0.0-rc.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"4f359e08ca85e7bd759e1fd933ff2bccd81864c60a8fba0e259c7f822b0924bf\", \"files\": {}}",
-		"dest": "cargo/vendor/curve25519-dalek-5.0.0-rc.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/curve25519-dalek-derive/curve25519-dalek-derive-0.1.1.crate",
-		"sha256": "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3",
-		"dest": "cargo/vendor/curve25519-dalek-derive-0.1.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3\", \"files\": {}}",
-		"dest": "cargo/vendor/curve25519-dalek-derive-0.1.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/darling/darling-0.20.11.crate",
-		"sha256": "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee",
-		"dest": "cargo/vendor/darling-0.20.11"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee\", \"files\": {}}",
-		"dest": "cargo/vendor/darling-0.20.11",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/darling/darling-0.23.0.crate",
-		"sha256": "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d",
-		"dest": "cargo/vendor/darling-0.23.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d\", \"files\": {}}",
-		"dest": "cargo/vendor/darling-0.23.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/darling_core/darling_core-0.20.11.crate",
-		"sha256": "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e",
-		"dest": "cargo/vendor/darling_core-0.20.11"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e\", \"files\": {}}",
-		"dest": "cargo/vendor/darling_core-0.20.11",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/darling_core/darling_core-0.23.0.crate",
-		"sha256": "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0",
-		"dest": "cargo/vendor/darling_core-0.23.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0\", \"files\": {}}",
-		"dest": "cargo/vendor/darling_core-0.23.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/darling_macro/darling_macro-0.20.11.crate",
-		"sha256": "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead",
-		"dest": "cargo/vendor/darling_macro-0.20.11"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead\", \"files\": {}}",
-		"dest": "cargo/vendor/darling_macro-0.20.11",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/darling_macro/darling_macro-0.23.0.crate",
-		"sha256": "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d",
-		"dest": "cargo/vendor/darling_macro-0.23.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d\", \"files\": {}}",
-		"dest": "cargo/vendor/darling_macro-0.23.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/data-encoding/data-encoding-2.11.0.crate",
-		"sha256": "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8",
-		"dest": "cargo/vendor/data-encoding-2.11.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8\", \"files\": {}}",
-		"dest": "cargo/vendor/data-encoding-2.11.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/data-encoding-macro/data-encoding-macro-0.1.20.crate",
-		"sha256": "3259c913752a86488b501ed8680446a5ed2d5aeac6e596cb23ba3800768ea32c",
-		"dest": "cargo/vendor/data-encoding-macro-0.1.20"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"3259c913752a86488b501ed8680446a5ed2d5aeac6e596cb23ba3800768ea32c\", \"files\": {}}",
-		"dest": "cargo/vendor/data-encoding-macro-0.1.20",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/data-encoding-macro-internal/data-encoding-macro-internal-0.1.18.crate",
-		"sha256": "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090",
-		"dest": "cargo/vendor/data-encoding-macro-internal-0.1.18"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090\", \"files\": {}}",
-		"dest": "cargo/vendor/data-encoding-macro-internal-0.1.18",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/der/der-0.8.0.crate",
-		"sha256": "71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b",
-		"dest": "cargo/vendor/der-0.8.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b\", \"files\": {}}",
-		"dest": "cargo/vendor/der-0.8.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/der-parser/der-parser-10.0.0.crate",
-		"sha256": "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6",
-		"dest": "cargo/vendor/der-parser-10.0.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6\", \"files\": {}}",
-		"dest": "cargo/vendor/der-parser-10.0.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/deranged/deranged-0.5.8.crate",
-		"sha256": "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c",
-		"dest": "cargo/vendor/deranged-0.5.8"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c\", \"files\": {}}",
-		"dest": "cargo/vendor/deranged-0.5.8",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/derive_arbitrary/derive_arbitrary-1.4.2.crate",
-		"sha256": "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a",
-		"dest": "cargo/vendor/derive_arbitrary-1.4.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a\", \"files\": {}}",
-		"dest": "cargo/vendor/derive_arbitrary-1.4.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/derive_builder/derive_builder-0.20.2.crate",
-		"sha256": "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947",
-		"dest": "cargo/vendor/derive_builder-0.20.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947\", \"files\": {}}",
-		"dest": "cargo/vendor/derive_builder-0.20.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/derive_builder_core/derive_builder_core-0.20.2.crate",
-		"sha256": "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8",
-		"dest": "cargo/vendor/derive_builder_core-0.20.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8\", \"files\": {}}",
-		"dest": "cargo/vendor/derive_builder_core-0.20.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/derive_builder_macro/derive_builder_macro-0.20.2.crate",
-		"sha256": "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c",
-		"dest": "cargo/vendor/derive_builder_macro-0.20.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c\", \"files\": {}}",
-		"dest": "cargo/vendor/derive_builder_macro-0.20.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/derive_more/derive_more-0.99.20.crate",
-		"sha256": "6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f",
-		"dest": "cargo/vendor/derive_more-0.99.20"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f\", \"files\": {}}",
-		"dest": "cargo/vendor/derive_more-0.99.20",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/derive_more/derive_more-2.1.1.crate",
-		"sha256": "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134",
-		"dest": "cargo/vendor/derive_more-2.1.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134\", \"files\": {}}",
-		"dest": "cargo/vendor/derive_more-2.1.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/derive_more-impl/derive_more-impl-2.1.1.crate",
-		"sha256": "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb",
-		"dest": "cargo/vendor/derive_more-impl-2.1.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb\", \"files\": {}}",
-		"dest": "cargo/vendor/derive_more-impl-2.1.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/diatomic-waker/diatomic-waker-0.2.3.crate",
-		"sha256": "ab03c107fafeb3ee9f5925686dbb7a73bc76e3932abb0d2b365cb64b169cf04c",
-		"dest": "cargo/vendor/diatomic-waker-0.2.3"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"ab03c107fafeb3ee9f5925686dbb7a73bc76e3932abb0d2b365cb64b169cf04c\", \"files\": {}}",
-		"dest": "cargo/vendor/diatomic-waker-0.2.3",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/digest/digest-0.10.7.crate",
-		"sha256": "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292",
-		"dest": "cargo/vendor/digest-0.10.7"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292\", \"files\": {}}",
-		"dest": "cargo/vendor/digest-0.10.7",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/digest/digest-0.11.3.crate",
-		"sha256": "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2",
-		"dest": "cargo/vendor/digest-0.11.3"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2\", \"files\": {}}",
-		"dest": "cargo/vendor/digest-0.11.3",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/dirs/dirs-6.0.0.crate",
-		"sha256": "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e",
-		"dest": "cargo/vendor/dirs-6.0.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e\", \"files\": {}}",
-		"dest": "cargo/vendor/dirs-6.0.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/dirs-sys/dirs-sys-0.5.0.crate",
-		"sha256": "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab",
-		"dest": "cargo/vendor/dirs-sys-0.5.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab\", \"files\": {}}",
-		"dest": "cargo/vendor/dirs-sys-0.5.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/dispatch2/dispatch2-0.3.1.crate",
-		"sha256": "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38",
-		"dest": "cargo/vendor/dispatch2-0.3.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38\", \"files\": {}}",
-		"dest": "cargo/vendor/dispatch2-0.3.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/displaydoc/displaydoc-0.2.6.crate",
-		"sha256": "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f",
-		"dest": "cargo/vendor/displaydoc-0.2.6"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f\", \"files\": {}}",
-		"dest": "cargo/vendor/displaydoc-0.2.6",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/dlib/dlib-0.5.3.crate",
-		"sha256": "ab8ecd87370524b461f8557c119c405552c396ed91fc0a8eec68679eab26f94a",
-		"dest": "cargo/vendor/dlib-0.5.3"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"ab8ecd87370524b461f8557c119c405552c396ed91fc0a8eec68679eab26f94a\", \"files\": {}}",
-		"dest": "cargo/vendor/dlib-0.5.3",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/dlopen2/dlopen2-0.8.2.crate",
-		"sha256": "5e2c5bd4158e66d1e215c49b837e11d62f3267b30c92f1d171c4d3105e3dc4d4",
-		"dest": "cargo/vendor/dlopen2-0.8.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"5e2c5bd4158e66d1e215c49b837e11d62f3267b30c92f1d171c4d3105e3dc4d4\", \"files\": {}}",
-		"dest": "cargo/vendor/dlopen2-0.8.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/dlopen2_derive/dlopen2_derive-0.4.3.crate",
-		"sha256": "0fbbb781877580993a8707ec48672673ec7b81eeba04cfd2310bd28c08e47c8f",
-		"dest": "cargo/vendor/dlopen2_derive-0.4.3"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"0fbbb781877580993a8707ec48672673ec7b81eeba04cfd2310bd28c08e47c8f\", \"files\": {}}",
-		"dest": "cargo/vendor/dlopen2_derive-0.4.3",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/document-features/document-features-0.2.12.crate",
-		"sha256": "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61",
-		"dest": "cargo/vendor/document-features-0.2.12"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61\", \"files\": {}}",
-		"dest": "cargo/vendor/document-features-0.2.12",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/dom_query/dom_query-0.27.0.crate",
-		"sha256": "521e380c0c8afb8d9a1e83a1822ee03556fc3e3e7dbc1fd30be14e37f9cb3f89",
-		"dest": "cargo/vendor/dom_query-0.27.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"521e380c0c8afb8d9a1e83a1822ee03556fc3e3e7dbc1fd30be14e37f9cb3f89\", \"files\": {}}",
-		"dest": "cargo/vendor/dom_query-0.27.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/downcast-rs/downcast-rs-1.2.1.crate",
-		"sha256": "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2",
-		"dest": "cargo/vendor/downcast-rs-1.2.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2\", \"files\": {}}",
-		"dest": "cargo/vendor/downcast-rs-1.2.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/dpi/dpi-0.1.2.crate",
-		"sha256": "d8b14ccef22fc6f5a8f4d7d768562a182c04ce9a3b3157b91390b52ddfdf1a76",
-		"dest": "cargo/vendor/dpi-0.1.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"d8b14ccef22fc6f5a8f4d7d768562a182c04ce9a3b3157b91390b52ddfdf1a76\", \"files\": {}}",
-		"dest": "cargo/vendor/dpi-0.1.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/dtoa/dtoa-1.0.11.crate",
-		"sha256": "4c3cf4824e2d5f025c7b531afcb2325364084a16806f6d47fbc1f5fbd9960590",
-		"dest": "cargo/vendor/dtoa-1.0.11"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"4c3cf4824e2d5f025c7b531afcb2325364084a16806f6d47fbc1f5fbd9960590\", \"files\": {}}",
-		"dest": "cargo/vendor/dtoa-1.0.11",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/dtoa-short/dtoa-short-0.3.5.crate",
-		"sha256": "cd1511a7b6a56299bd043a9c167a6d2bfb37bf84a6dfceaba651168adfb43c87",
-		"dest": "cargo/vendor/dtoa-short-0.3.5"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"cd1511a7b6a56299bd043a9c167a6d2bfb37bf84a6dfceaba651168adfb43c87\", \"files\": {}}",
-		"dest": "cargo/vendor/dtoa-short-0.3.5",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/dtor/dtor-0.3.0.crate",
-		"sha256": "f1057d6c64987086ff8ed0fd3fbf377a6b7d205cc7715868cd401705f715cbe4",
-		"dest": "cargo/vendor/dtor-0.3.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"f1057d6c64987086ff8ed0fd3fbf377a6b7d205cc7715868cd401705f715cbe4\", \"files\": {}}",
-		"dest": "cargo/vendor/dtor-0.3.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/dtor-proc-macro/dtor-proc-macro-0.0.6.crate",
-		"sha256": "f678cf4a922c215c63e0de95eb1ff08a958a81d47e485cf9da1e27bf6305cfa5",
-		"dest": "cargo/vendor/dtor-proc-macro-0.0.6"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"f678cf4a922c215c63e0de95eb1ff08a958a81d47e485cf9da1e27bf6305cfa5\", \"files\": {}}",
-		"dest": "cargo/vendor/dtor-proc-macro-0.0.6",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/dunce/dunce-1.0.5.crate",
-		"sha256": "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813",
-		"dest": "cargo/vendor/dunce-1.0.5"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813\", \"files\": {}}",
-		"dest": "cargo/vendor/dunce-1.0.5",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/dyn-clone/dyn-clone-1.0.20.crate",
-		"sha256": "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555",
-		"dest": "cargo/vendor/dyn-clone-1.0.20"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555\", \"files\": {}}",
-		"dest": "cargo/vendor/dyn-clone-1.0.20",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/ed25519/ed25519-3.0.0.crate",
-		"sha256": "29fcf32e6c73d1079f83ab4d782de2d81620346a5f38c6237a86a22f8368980a",
-		"dest": "cargo/vendor/ed25519-3.0.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"29fcf32e6c73d1079f83ab4d782de2d81620346a5f38c6237a86a22f8368980a\", \"files\": {}}",
-		"dest": "cargo/vendor/ed25519-3.0.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/ed25519-dalek/ed25519-dalek-3.0.0-rc.0.crate",
-		"sha256": "b011170fe4f04665565b4110afef66774fe9ffff278f3eb5b81cc73d26e27d60",
-		"dest": "cargo/vendor/ed25519-dalek-3.0.0-rc.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"b011170fe4f04665565b4110afef66774fe9ffff278f3eb5b81cc73d26e27d60\", \"files\": {}}",
-		"dest": "cargo/vendor/ed25519-dalek-3.0.0-rc.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/either/either-1.16.0.crate",
-		"sha256": "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e",
-		"dest": "cargo/vendor/either-1.16.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e\", \"files\": {}}",
-		"dest": "cargo/vendor/either-1.16.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/embed-resource/embed-resource-3.0.11.crate",
-		"sha256": "fbfdaacccebec3b28e4866b8973543c7647797db5ada1bdab552e48fe665fbbd",
-		"dest": "cargo/vendor/embed-resource-3.0.11"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"fbfdaacccebec3b28e4866b8973543c7647797db5ada1bdab552e48fe665fbbd\", \"files\": {}}",
-		"dest": "cargo/vendor/embed-resource-3.0.11",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/embed_plist/embed_plist-1.2.2.crate",
-		"sha256": "4ef6b89e5b37196644d8796de5268852ff179b44e96276cf4290264843743bb7",
-		"dest": "cargo/vendor/embed_plist-1.2.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"4ef6b89e5b37196644d8796de5268852ff179b44e96276cf4290264843743bb7\", \"files\": {}}",
-		"dest": "cargo/vendor/embed_plist-1.2.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/embedded-io/embedded-io-0.4.0.crate",
-		"sha256": "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced",
-		"dest": "cargo/vendor/embedded-io-0.4.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced\", \"files\": {}}",
-		"dest": "cargo/vendor/embedded-io-0.4.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/embedded-io/embedded-io-0.6.1.crate",
-		"sha256": "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d",
-		"dest": "cargo/vendor/embedded-io-0.6.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d\", \"files\": {}}",
-		"dest": "cargo/vendor/embedded-io-0.6.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/encode_unicode/encode_unicode-1.0.0.crate",
-		"sha256": "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0",
-		"dest": "cargo/vendor/encode_unicode-1.0.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0\", \"files\": {}}",
-		"dest": "cargo/vendor/encode_unicode-1.0.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/encoding_rs/encoding_rs-0.8.35.crate",
-		"sha256": "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3",
-		"dest": "cargo/vendor/encoding_rs-0.8.35"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3\", \"files\": {}}",
-		"dest": "cargo/vendor/encoding_rs-0.8.35",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/endi/endi-1.1.1.crate",
-		"sha256": "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099",
-		"dest": "cargo/vendor/endi-1.1.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099\", \"files\": {}}",
-		"dest": "cargo/vendor/endi-1.1.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/enum-assoc/enum-assoc-1.3.0.crate",
-		"sha256": "3ed8956bd5c1f0415200516e78ff07ec9e16415ade83c056c230d7b7ea0d55b7",
-		"dest": "cargo/vendor/enum-assoc-1.3.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"3ed8956bd5c1f0415200516e78ff07ec9e16415ade83c056c230d7b7ea0d55b7\", \"files\": {}}",
-		"dest": "cargo/vendor/enum-assoc-1.3.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/enumflags2/enumflags2-0.7.12.crate",
-		"sha256": "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef",
-		"dest": "cargo/vendor/enumflags2-0.7.12"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef\", \"files\": {}}",
-		"dest": "cargo/vendor/enumflags2-0.7.12",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/enumflags2_derive/enumflags2_derive-0.7.12.crate",
-		"sha256": "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827",
-		"dest": "cargo/vendor/enumflags2_derive-0.7.12"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827\", \"files\": {}}",
-		"dest": "cargo/vendor/enumflags2_derive-0.7.12",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/equator/equator-0.4.2.crate",
-		"sha256": "4711b213838dfee0117e3be6ac926007d7f433d7bbe33595975d4190cb07e6fc",
-		"dest": "cargo/vendor/equator-0.4.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"4711b213838dfee0117e3be6ac926007d7f433d7bbe33595975d4190cb07e6fc\", \"files\": {}}",
-		"dest": "cargo/vendor/equator-0.4.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/equator-macro/equator-macro-0.4.2.crate",
-		"sha256": "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3",
-		"dest": "cargo/vendor/equator-macro-0.4.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3\", \"files\": {}}",
-		"dest": "cargo/vendor/equator-macro-0.4.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/equivalent/equivalent-1.0.2.crate",
-		"sha256": "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f",
-		"dest": "cargo/vendor/equivalent-1.0.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f\", \"files\": {}}",
-		"dest": "cargo/vendor/equivalent-1.0.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/erased-serde/erased-serde-0.4.10.crate",
-		"sha256": "d2add8a07dd6a8d93ff627029c51de145e12686fbc36ecb298ac22e74cf02dec",
-		"dest": "cargo/vendor/erased-serde-0.4.10"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"d2add8a07dd6a8d93ff627029c51de145e12686fbc36ecb298ac22e74cf02dec\", \"files\": {}}",
-		"dest": "cargo/vendor/erased-serde-0.4.10",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/errno/errno-0.3.14.crate",
-		"sha256": "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb",
-		"dest": "cargo/vendor/errno-0.3.14"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb\", \"files\": {}}",
-		"dest": "cargo/vendor/errno-0.3.14",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/event-listener/event-listener-5.4.1.crate",
-		"sha256": "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab",
-		"dest": "cargo/vendor/event-listener-5.4.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab\", \"files\": {}}",
-		"dest": "cargo/vendor/event-listener-5.4.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/event-listener-strategy/event-listener-strategy-0.5.4.crate",
-		"sha256": "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93",
-		"dest": "cargo/vendor/event-listener-strategy-0.5.4"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93\", \"files\": {}}",
-		"dest": "cargo/vendor/event-listener-strategy-0.5.4",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/exr/exr-1.74.1.crate",
-		"sha256": "6be87932f10230a4339ab394edd8e4611fcb72553d8295b4d52ea55249b3daa5",
-		"dest": "cargo/vendor/exr-1.74.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"6be87932f10230a4339ab394edd8e4611fcb72553d8295b4d52ea55249b3daa5\", \"files\": {}}",
-		"dest": "cargo/vendor/exr-1.74.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/fastbloom/fastbloom-0.17.0.crate",
-		"sha256": "ef975e30683b2d965054bb0a836f8973857c4ebf6acf274fe46617cd285060d8",
-		"dest": "cargo/vendor/fastbloom-0.17.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"ef975e30683b2d965054bb0a836f8973857c4ebf6acf274fe46617cd285060d8\", \"files\": {}}",
-		"dest": "cargo/vendor/fastbloom-0.17.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/fastrand/fastrand-2.4.1.crate",
-		"sha256": "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6",
-		"dest": "cargo/vendor/fastrand-2.4.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6\", \"files\": {}}",
-		"dest": "cargo/vendor/fastrand-2.4.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/fax/fax-0.2.7.crate",
-		"sha256": "caf1079563223d5d59d83c85886a56e586cfd5c1a26292e971a0fa266531ac5a",
-		"dest": "cargo/vendor/fax-0.2.7"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"caf1079563223d5d59d83c85886a56e586cfd5c1a26292e971a0fa266531ac5a\", \"files\": {}}",
-		"dest": "cargo/vendor/fax-0.2.7",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/fdeflate/fdeflate-0.3.7.crate",
-		"sha256": "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c",
-		"dest": "cargo/vendor/fdeflate-0.3.7"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c\", \"files\": {}}",
-		"dest": "cargo/vendor/fdeflate-0.3.7",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/fiat-crypto/fiat-crypto-0.3.0.crate",
-		"sha256": "64cd1e32ddd350061ae6edb1b082d7c54915b5c672c389143b9a63403a109f24",
-		"dest": "cargo/vendor/fiat-crypto-0.3.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"64cd1e32ddd350061ae6edb1b082d7c54915b5c672c389143b9a63403a109f24\", \"files\": {}}",
-		"dest": "cargo/vendor/fiat-crypto-0.3.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/field-offset/field-offset-0.3.6.crate",
-		"sha256": "38e2275cc4e4fc009b0669731a1e5ab7ebf11f469eaede2bab9309a5b4d6057f",
-		"dest": "cargo/vendor/field-offset-0.3.6"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"38e2275cc4e4fc009b0669731a1e5ab7ebf11f469eaede2bab9309a5b4d6057f\", \"files\": {}}",
-		"dest": "cargo/vendor/field-offset-0.3.6",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/filetime/filetime-0.2.29.crate",
-		"sha256": "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759",
-		"dest": "cargo/vendor/filetime-0.2.29"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759\", \"files\": {}}",
-		"dest": "cargo/vendor/filetime-0.2.29",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/find-msvc-tools/find-msvc-tools-0.1.9.crate",
-		"sha256": "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582",
-		"dest": "cargo/vendor/find-msvc-tools-0.1.9"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582\", \"files\": {}}",
-		"dest": "cargo/vendor/find-msvc-tools-0.1.9",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/flate2/flate2-1.1.9.crate",
-		"sha256": "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c",
-		"dest": "cargo/vendor/flate2-1.1.9"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c\", \"files\": {}}",
-		"dest": "cargo/vendor/flate2-1.1.9",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/fnv/fnv-1.0.7.crate",
-		"sha256": "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1",
-		"dest": "cargo/vendor/fnv-1.0.7"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1\", \"files\": {}}",
-		"dest": "cargo/vendor/fnv-1.0.7",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/foldhash/foldhash-0.2.0.crate",
-		"sha256": "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb",
-		"dest": "cargo/vendor/foldhash-0.2.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb\", \"files\": {}}",
-		"dest": "cargo/vendor/foldhash-0.2.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/foreign-types/foreign-types-0.5.0.crate",
-		"sha256": "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965",
-		"dest": "cargo/vendor/foreign-types-0.5.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965\", \"files\": {}}",
-		"dest": "cargo/vendor/foreign-types-0.5.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/foreign-types-macros/foreign-types-macros-0.2.3.crate",
-		"sha256": "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742",
-		"dest": "cargo/vendor/foreign-types-macros-0.2.3"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742\", \"files\": {}}",
-		"dest": "cargo/vendor/foreign-types-macros-0.2.3",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/foreign-types-shared/foreign-types-shared-0.3.1.crate",
-		"sha256": "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b",
-		"dest": "cargo/vendor/foreign-types-shared-0.3.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b\", \"files\": {}}",
-		"dest": "cargo/vendor/foreign-types-shared-0.3.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/form_urlencoded/form_urlencoded-1.2.2.crate",
-		"sha256": "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf",
-		"dest": "cargo/vendor/form_urlencoded-1.2.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf\", \"files\": {}}",
-		"dest": "cargo/vendor/form_urlencoded-1.2.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/fs_extra/fs_extra-1.3.0.crate",
-		"sha256": "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c",
-		"dest": "cargo/vendor/fs_extra-1.3.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c\", \"files\": {}}",
-		"dest": "cargo/vendor/fs_extra-1.3.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/futf/futf-0.1.5.crate",
-		"sha256": "df420e2e84819663797d1ec6544b13c5be84629e7bb00dc960d6917db2987843",
-		"dest": "cargo/vendor/futf-0.1.5"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"df420e2e84819663797d1ec6544b13c5be84629e7bb00dc960d6917db2987843\", \"files\": {}}",
-		"dest": "cargo/vendor/futf-0.1.5",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/futures/futures-0.3.32.crate",
-		"sha256": "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d",
-		"dest": "cargo/vendor/futures-0.3.32"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d\", \"files\": {}}",
-		"dest": "cargo/vendor/futures-0.3.32",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/futures-buffered/futures-buffered-0.2.13.crate",
-		"sha256": "4421cb78ee172b6b06080093479d3c50f058e7c81b7d577bbb8d118d551d4cd5",
-		"dest": "cargo/vendor/futures-buffered-0.2.13"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"4421cb78ee172b6b06080093479d3c50f058e7c81b7d577bbb8d118d551d4cd5\", \"files\": {}}",
-		"dest": "cargo/vendor/futures-buffered-0.2.13",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/futures-channel/futures-channel-0.3.32.crate",
-		"sha256": "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d",
-		"dest": "cargo/vendor/futures-channel-0.3.32"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d\", \"files\": {}}",
-		"dest": "cargo/vendor/futures-channel-0.3.32",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/futures-core/futures-core-0.3.32.crate",
-		"sha256": "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d",
-		"dest": "cargo/vendor/futures-core-0.3.32"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d\", \"files\": {}}",
-		"dest": "cargo/vendor/futures-core-0.3.32",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/futures-executor/futures-executor-0.3.32.crate",
-		"sha256": "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d",
-		"dest": "cargo/vendor/futures-executor-0.3.32"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d\", \"files\": {}}",
-		"dest": "cargo/vendor/futures-executor-0.3.32",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/futures-io/futures-io-0.3.32.crate",
-		"sha256": "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718",
-		"dest": "cargo/vendor/futures-io-0.3.32"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718\", \"files\": {}}",
-		"dest": "cargo/vendor/futures-io-0.3.32",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/futures-lite/futures-lite-2.6.1.crate",
-		"sha256": "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad",
-		"dest": "cargo/vendor/futures-lite-2.6.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad\", \"files\": {}}",
-		"dest": "cargo/vendor/futures-lite-2.6.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/futures-macro/futures-macro-0.3.32.crate",
-		"sha256": "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b",
-		"dest": "cargo/vendor/futures-macro-0.3.32"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b\", \"files\": {}}",
-		"dest": "cargo/vendor/futures-macro-0.3.32",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/futures-sink/futures-sink-0.3.32.crate",
-		"sha256": "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893",
-		"dest": "cargo/vendor/futures-sink-0.3.32"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893\", \"files\": {}}",
-		"dest": "cargo/vendor/futures-sink-0.3.32",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/futures-task/futures-task-0.3.32.crate",
-		"sha256": "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393",
-		"dest": "cargo/vendor/futures-task-0.3.32"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393\", \"files\": {}}",
-		"dest": "cargo/vendor/futures-task-0.3.32",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/futures-util/futures-util-0.3.32.crate",
-		"sha256": "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6",
-		"dest": "cargo/vendor/futures-util-0.3.32"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6\", \"files\": {}}",
-		"dest": "cargo/vendor/futures-util-0.3.32",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/fxhash/fxhash-0.2.1.crate",
-		"sha256": "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c",
-		"dest": "cargo/vendor/fxhash-0.2.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c\", \"files\": {}}",
-		"dest": "cargo/vendor/fxhash-0.2.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/gdk/gdk-0.18.2.crate",
-		"sha256": "d9f245958c627ac99d8e529166f9823fb3b838d1d41fd2b297af3075093c2691",
-		"dest": "cargo/vendor/gdk-0.18.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"d9f245958c627ac99d8e529166f9823fb3b838d1d41fd2b297af3075093c2691\", \"files\": {}}",
-		"dest": "cargo/vendor/gdk-0.18.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/gdk-pixbuf/gdk-pixbuf-0.18.5.crate",
-		"sha256": "50e1f5f1b0bfb830d6ccc8066d18db35c487b1b2b1e8589b5dfe9f07e8defaec",
-		"dest": "cargo/vendor/gdk-pixbuf-0.18.5"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"50e1f5f1b0bfb830d6ccc8066d18db35c487b1b2b1e8589b5dfe9f07e8defaec\", \"files\": {}}",
-		"dest": "cargo/vendor/gdk-pixbuf-0.18.5",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/gdk-pixbuf-sys/gdk-pixbuf-sys-0.18.0.crate",
-		"sha256": "3f9839ea644ed9c97a34d129ad56d38a25e6756f99f3a88e15cd39c20629caf7",
-		"dest": "cargo/vendor/gdk-pixbuf-sys-0.18.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"3f9839ea644ed9c97a34d129ad56d38a25e6756f99f3a88e15cd39c20629caf7\", \"files\": {}}",
-		"dest": "cargo/vendor/gdk-pixbuf-sys-0.18.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/gdk-sys/gdk-sys-0.18.2.crate",
-		"sha256": "5c2d13f38594ac1e66619e188c6d5a1adb98d11b2fcf7894fc416ad76aa2f3f7",
-		"dest": "cargo/vendor/gdk-sys-0.18.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"5c2d13f38594ac1e66619e188c6d5a1adb98d11b2fcf7894fc416ad76aa2f3f7\", \"files\": {}}",
-		"dest": "cargo/vendor/gdk-sys-0.18.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/gdkwayland-sys/gdkwayland-sys-0.18.2.crate",
-		"sha256": "140071d506d223f7572b9f09b5e155afbd77428cd5cc7af8f2694c41d98dfe69",
-		"dest": "cargo/vendor/gdkwayland-sys-0.18.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"140071d506d223f7572b9f09b5e155afbd77428cd5cc7af8f2694c41d98dfe69\", \"files\": {}}",
-		"dest": "cargo/vendor/gdkwayland-sys-0.18.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/gdkx11/gdkx11-0.18.2.crate",
-		"sha256": "3caa00e14351bebbc8183b3c36690327eb77c49abc2268dd4bd36b856db3fbfe",
-		"dest": "cargo/vendor/gdkx11-0.18.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"3caa00e14351bebbc8183b3c36690327eb77c49abc2268dd4bd36b856db3fbfe\", \"files\": {}}",
-		"dest": "cargo/vendor/gdkx11-0.18.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/gdkx11-sys/gdkx11-sys-0.18.2.crate",
-		"sha256": "6e2e7445fe01ac26f11601db260dd8608fe172514eb63b3b5e261ea6b0f4428d",
-		"dest": "cargo/vendor/gdkx11-sys-0.18.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"6e2e7445fe01ac26f11601db260dd8608fe172514eb63b3b5e261ea6b0f4428d\", \"files\": {}}",
-		"dest": "cargo/vendor/gdkx11-sys-0.18.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/genawaiter/genawaiter-0.99.1.crate",
-		"sha256": "c86bd0361bcbde39b13475e6e36cb24c329964aa2611be285289d1e4b751c1a0",
-		"dest": "cargo/vendor/genawaiter-0.99.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"c86bd0361bcbde39b13475e6e36cb24c329964aa2611be285289d1e4b751c1a0\", \"files\": {}}",
-		"dest": "cargo/vendor/genawaiter-0.99.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/genawaiter-macro/genawaiter-macro-0.99.1.crate",
-		"sha256": "0b32dfe1fdfc0bbde1f22a5da25355514b5e450c33a6af6770884c8750aedfbc",
-		"dest": "cargo/vendor/genawaiter-macro-0.99.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"0b32dfe1fdfc0bbde1f22a5da25355514b5e450c33a6af6770884c8750aedfbc\", \"files\": {}}",
-		"dest": "cargo/vendor/genawaiter-macro-0.99.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/genawaiter-proc-macro/genawaiter-proc-macro-0.99.1.crate",
-		"sha256": "784f84eebc366e15251c4a8c3acee82a6a6f427949776ecb88377362a9621738",
-		"dest": "cargo/vendor/genawaiter-proc-macro-0.99.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"784f84eebc366e15251c4a8c3acee82a6a6f427949776ecb88377362a9621738\", \"files\": {}}",
-		"dest": "cargo/vendor/genawaiter-proc-macro-0.99.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/generator/generator-0.8.9.crate",
-		"sha256": "b3b854b0e584ead1a33f18b2fcad7cf7be18b3875c78816b753639aa501513ae",
-		"dest": "cargo/vendor/generator-0.8.9"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"b3b854b0e584ead1a33f18b2fcad7cf7be18b3875c78816b753639aa501513ae\", \"files\": {}}",
-		"dest": "cargo/vendor/generator-0.8.9",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/generic-array/generic-array-0.14.7.crate",
-		"sha256": "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a",
-		"dest": "cargo/vendor/generic-array-0.14.7"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a\", \"files\": {}}",
-		"dest": "cargo/vendor/generic-array-0.14.7",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/gethostname/gethostname-1.1.0.crate",
-		"sha256": "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8",
-		"dest": "cargo/vendor/gethostname-1.1.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8\", \"files\": {}}",
-		"dest": "cargo/vendor/gethostname-1.1.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/getrandom/getrandom-0.1.16.crate",
-		"sha256": "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce",
-		"dest": "cargo/vendor/getrandom-0.1.16"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce\", \"files\": {}}",
-		"dest": "cargo/vendor/getrandom-0.1.16",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/getrandom/getrandom-0.2.17.crate",
-		"sha256": "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0",
-		"dest": "cargo/vendor/getrandom-0.2.17"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0\", \"files\": {}}",
-		"dest": "cargo/vendor/getrandom-0.2.17",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/getrandom/getrandom-0.3.4.crate",
-		"sha256": "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd",
-		"dest": "cargo/vendor/getrandom-0.3.4"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd\", \"files\": {}}",
-		"dest": "cargo/vendor/getrandom-0.3.4",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/getrandom/getrandom-0.4.3.crate",
-		"sha256": "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099",
-		"dest": "cargo/vendor/getrandom-0.4.3"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099\", \"files\": {}}",
-		"dest": "cargo/vendor/getrandom-0.4.3",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/ghash/ghash-0.5.1.crate",
-		"sha256": "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1",
-		"dest": "cargo/vendor/ghash-0.5.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1\", \"files\": {}}",
-		"dest": "cargo/vendor/ghash-0.5.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/gif/gif-0.14.2.crate",
-		"sha256": "ee8cfcc411d9adbbaba82fb72661cc1bcca13e8bba98b364e62b2dba8f960159",
-		"dest": "cargo/vendor/gif-0.14.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"ee8cfcc411d9adbbaba82fb72661cc1bcca13e8bba98b364e62b2dba8f960159\", \"files\": {}}",
-		"dest": "cargo/vendor/gif-0.14.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/gio/gio-0.18.4.crate",
-		"sha256": "d4fc8f532f87b79cbc51a79748f16a6828fb784be93145a322fa14d06d354c73",
-		"dest": "cargo/vendor/gio-0.18.4"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"d4fc8f532f87b79cbc51a79748f16a6828fb784be93145a322fa14d06d354c73\", \"files\": {}}",
-		"dest": "cargo/vendor/gio-0.18.4",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/gio-sys/gio-sys-0.18.1.crate",
-		"sha256": "37566df850baf5e4cb0dfb78af2e4b9898d817ed9263d1090a2df958c64737d2",
-		"dest": "cargo/vendor/gio-sys-0.18.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"37566df850baf5e4cb0dfb78af2e4b9898d817ed9263d1090a2df958c64737d2\", \"files\": {}}",
-		"dest": "cargo/vendor/gio-sys-0.18.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/gio-sys/gio-sys-0.20.10.crate",
-		"sha256": "521e93a7e56fc89e84aea9a52cfc9436816a4b363b030260b699950ff1336c83",
-		"dest": "cargo/vendor/gio-sys-0.20.10"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"521e93a7e56fc89e84aea9a52cfc9436816a4b363b030260b699950ff1336c83\", \"files\": {}}",
-		"dest": "cargo/vendor/gio-sys-0.20.10",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/glib/glib-0.18.5.crate",
-		"sha256": "233daaf6e83ae6a12a52055f568f9d7cf4671dabb78ff9560ab6da230ce00ee5",
-		"dest": "cargo/vendor/glib-0.18.5"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"233daaf6e83ae6a12a52055f568f9d7cf4671dabb78ff9560ab6da230ce00ee5\", \"files\": {}}",
-		"dest": "cargo/vendor/glib-0.18.5",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/glib/glib-0.20.12.crate",
-		"sha256": "ffc4b6e352d4716d84d7dde562dd9aee2a7d48beb872dd9ece7f2d1515b2d683",
-		"dest": "cargo/vendor/glib-0.20.12"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"ffc4b6e352d4716d84d7dde562dd9aee2a7d48beb872dd9ece7f2d1515b2d683\", \"files\": {}}",
-		"dest": "cargo/vendor/glib-0.20.12",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/glib-macros/glib-macros-0.18.5.crate",
-		"sha256": "0bb0228f477c0900c880fd78c8759b95c7636dbd7842707f49e132378aa2acdc",
-		"dest": "cargo/vendor/glib-macros-0.18.5"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"0bb0228f477c0900c880fd78c8759b95c7636dbd7842707f49e132378aa2acdc\", \"files\": {}}",
-		"dest": "cargo/vendor/glib-macros-0.18.5",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/glib-macros/glib-macros-0.20.12.crate",
-		"sha256": "e8084af62f09475a3f529b1629c10c429d7600ee1398ae12dd3bf175d74e7145",
-		"dest": "cargo/vendor/glib-macros-0.20.12"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"e8084af62f09475a3f529b1629c10c429d7600ee1398ae12dd3bf175d74e7145\", \"files\": {}}",
-		"dest": "cargo/vendor/glib-macros-0.20.12",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/glib-sys/glib-sys-0.18.1.crate",
-		"sha256": "063ce2eb6a8d0ea93d2bf8ba1957e78dbab6be1c2220dd3daca57d5a9d869898",
-		"dest": "cargo/vendor/glib-sys-0.18.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"063ce2eb6a8d0ea93d2bf8ba1957e78dbab6be1c2220dd3daca57d5a9d869898\", \"files\": {}}",
-		"dest": "cargo/vendor/glib-sys-0.18.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/glib-sys/glib-sys-0.20.10.crate",
-		"sha256": "8ab79e1ed126803a8fb827e3de0e2ff95191912b8db65cee467edb56fc4cc215",
-		"dest": "cargo/vendor/glib-sys-0.20.10"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"8ab79e1ed126803a8fb827e3de0e2ff95191912b8db65cee467edb56fc4cc215\", \"files\": {}}",
-		"dest": "cargo/vendor/glib-sys-0.20.10",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/glob/glob-0.3.3.crate",
-		"sha256": "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280",
-		"dest": "cargo/vendor/glob-0.3.3"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280\", \"files\": {}}",
-		"dest": "cargo/vendor/glob-0.3.3",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/gloo-timers/gloo-timers-0.3.0.crate",
-		"sha256": "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994",
-		"dest": "cargo/vendor/gloo-timers-0.3.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994\", \"files\": {}}",
-		"dest": "cargo/vendor/gloo-timers-0.3.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/gobject-sys/gobject-sys-0.18.0.crate",
-		"sha256": "0850127b514d1c4a4654ead6dedadb18198999985908e6ffe4436f53c785ce44",
-		"dest": "cargo/vendor/gobject-sys-0.18.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"0850127b514d1c4a4654ead6dedadb18198999985908e6ffe4436f53c785ce44\", \"files\": {}}",
-		"dest": "cargo/vendor/gobject-sys-0.18.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/gobject-sys/gobject-sys-0.20.10.crate",
-		"sha256": "ec9aca94bb73989e3cfdbf8f2e0f1f6da04db4d291c431f444838925c4c63eda",
-		"dest": "cargo/vendor/gobject-sys-0.20.10"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"ec9aca94bb73989e3cfdbf8f2e0f1f6da04db4d291c431f444838925c4c63eda\", \"files\": {}}",
-		"dest": "cargo/vendor/gobject-sys-0.20.10",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/gstreamer/gstreamer-0.23.7.crate",
-		"sha256": "8757a87f3706560037a01a9f06a59fcc7bdb0864744dcf73546606e60c4316e1",
-		"dest": "cargo/vendor/gstreamer-0.23.7"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"8757a87f3706560037a01a9f06a59fcc7bdb0864744dcf73546606e60c4316e1\", \"files\": {}}",
-		"dest": "cargo/vendor/gstreamer-0.23.7",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/gstreamer-app/gstreamer-app-0.23.5.crate",
-		"sha256": "2e9a883eb21aebcf1289158225c05f7aea5da6ecf71fa7f0ff1ce4d25baf004e",
-		"dest": "cargo/vendor/gstreamer-app-0.23.5"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"2e9a883eb21aebcf1289158225c05f7aea5da6ecf71fa7f0ff1ce4d25baf004e\", \"files\": {}}",
-		"dest": "cargo/vendor/gstreamer-app-0.23.5",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/gstreamer-app-sys/gstreamer-app-sys-0.23.5.crate",
-		"sha256": "94f7ef838306fe51852d503a14dc79ac42de005a59008a05098de3ecdaf05455",
-		"dest": "cargo/vendor/gstreamer-app-sys-0.23.5"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"94f7ef838306fe51852d503a14dc79ac42de005a59008a05098de3ecdaf05455\", \"files\": {}}",
-		"dest": "cargo/vendor/gstreamer-app-sys-0.23.5",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/gstreamer-base/gstreamer-base-0.23.6.crate",
-		"sha256": "f19a74fd04ffdcb847dd322640f2cf520897129d00a7bcb92fd62a63f3e27404",
-		"dest": "cargo/vendor/gstreamer-base-0.23.6"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"f19a74fd04ffdcb847dd322640f2cf520897129d00a7bcb92fd62a63f3e27404\", \"files\": {}}",
-		"dest": "cargo/vendor/gstreamer-base-0.23.6",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/gstreamer-base-sys/gstreamer-base-sys-0.23.6.crate",
-		"sha256": "87f2fb0037b6d3c5b51f60dea11e667910f33be222308ca5a101450018a09840",
-		"dest": "cargo/vendor/gstreamer-base-sys-0.23.6"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"87f2fb0037b6d3c5b51f60dea11e667910f33be222308ca5a101450018a09840\", \"files\": {}}",
-		"dest": "cargo/vendor/gstreamer-base-sys-0.23.6",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/gstreamer-sys/gstreamer-sys-0.23.6.crate",
-		"sha256": "feea73b4d92dbf9c24a203c9cd0bcc740d584f6b5960d5faf359febf288919b2",
-		"dest": "cargo/vendor/gstreamer-sys-0.23.6"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"feea73b4d92dbf9c24a203c9cd0bcc740d584f6b5960d5faf359febf288919b2\", \"files\": {}}",
-		"dest": "cargo/vendor/gstreamer-sys-0.23.6",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/gstreamer-video/gstreamer-video-0.23.6.crate",
-		"sha256": "1318b599d77ca4f7702ecbdeac1672d6304cb16b7e5752fabb3ee8260449a666",
-		"dest": "cargo/vendor/gstreamer-video-0.23.6"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"1318b599d77ca4f7702ecbdeac1672d6304cb16b7e5752fabb3ee8260449a666\", \"files\": {}}",
-		"dest": "cargo/vendor/gstreamer-video-0.23.6",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/gstreamer-video-sys/gstreamer-video-sys-0.23.6.crate",
-		"sha256": "0a70f0947f12d253b9de9bc3fd92f981e4d025336c18389c7f08cdf388a99f5c",
-		"dest": "cargo/vendor/gstreamer-video-sys-0.23.6"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"0a70f0947f12d253b9de9bc3fd92f981e4d025336c18389c7f08cdf388a99f5c\", \"files\": {}}",
-		"dest": "cargo/vendor/gstreamer-video-sys-0.23.6",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/gtk/gtk-0.18.2.crate",
-		"sha256": "fd56fb197bfc42bd5d2751f4f017d44ff59fbb58140c6b49f9b3b2bdab08506a",
-		"dest": "cargo/vendor/gtk-0.18.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"fd56fb197bfc42bd5d2751f4f017d44ff59fbb58140c6b49f9b3b2bdab08506a\", \"files\": {}}",
-		"dest": "cargo/vendor/gtk-0.18.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/gtk-sys/gtk-sys-0.18.2.crate",
-		"sha256": "8f29a1c21c59553eb7dd40e918be54dccd60c52b049b75119d5d96ce6b624414",
-		"dest": "cargo/vendor/gtk-sys-0.18.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"8f29a1c21c59553eb7dd40e918be54dccd60c52b049b75119d5d96ce6b624414\", \"files\": {}}",
-		"dest": "cargo/vendor/gtk-sys-0.18.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/gtk3-macros/gtk3-macros-0.18.2.crate",
-		"sha256": "52ff3c5b21f14f0736fed6dcfc0bfb4225ebf5725f3c0209edeec181e4d73e9d",
-		"dest": "cargo/vendor/gtk3-macros-0.18.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"52ff3c5b21f14f0736fed6dcfc0bfb4225ebf5725f3c0209edeec181e4d73e9d\", \"files\": {}}",
-		"dest": "cargo/vendor/gtk3-macros-0.18.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/h2/h2-0.4.15.crate",
-		"sha256": "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155",
-		"dest": "cargo/vendor/h2-0.4.15"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155\", \"files\": {}}",
-		"dest": "cargo/vendor/h2-0.4.15",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/half/half-2.7.1.crate",
-		"sha256": "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b",
-		"dest": "cargo/vendor/half-2.7.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b\", \"files\": {}}",
-		"dest": "cargo/vendor/half-2.7.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/hash32/hash32-0.2.1.crate",
-		"sha256": "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67",
-		"dest": "cargo/vendor/hash32-0.2.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67\", \"files\": {}}",
-		"dest": "cargo/vendor/hash32-0.2.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/hashbrown/hashbrown-0.12.3.crate",
-		"sha256": "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888",
-		"dest": "cargo/vendor/hashbrown-0.12.3"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888\", \"files\": {}}",
-		"dest": "cargo/vendor/hashbrown-0.12.3",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/hashbrown/hashbrown-0.17.1.crate",
-		"sha256": "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a",
-		"dest": "cargo/vendor/hashbrown-0.17.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a\", \"files\": {}}",
-		"dest": "cargo/vendor/hashbrown-0.17.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/heapless/heapless-0.7.17.crate",
-		"sha256": "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f",
-		"dest": "cargo/vendor/heapless-0.7.17"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f\", \"files\": {}}",
-		"dest": "cargo/vendor/heapless-0.7.17",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/heck/heck-0.4.1.crate",
-		"sha256": "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8",
-		"dest": "cargo/vendor/heck-0.4.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8\", \"files\": {}}",
-		"dest": "cargo/vendor/heck-0.4.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/heck/heck-0.5.0.crate",
-		"sha256": "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea",
-		"dest": "cargo/vendor/heck-0.5.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea\", \"files\": {}}",
-		"dest": "cargo/vendor/heck-0.5.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/hermit-abi/hermit-abi-0.5.2.crate",
-		"sha256": "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c",
-		"dest": "cargo/vendor/hermit-abi-0.5.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c\", \"files\": {}}",
-		"dest": "cargo/vendor/hermit-abi-0.5.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/hex/hex-0.4.3.crate",
-		"sha256": "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70",
-		"dest": "cargo/vendor/hex-0.4.3"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70\", \"files\": {}}",
-		"dest": "cargo/vendor/hex-0.4.3",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/hickory-net/hickory-net-0.26.1.crate",
-		"sha256": "e2295ed2f9c31e471e1428a8f88a3f0e1f4b27c15049592138d1eebe9c35b183",
-		"dest": "cargo/vendor/hickory-net-0.26.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"e2295ed2f9c31e471e1428a8f88a3f0e1f4b27c15049592138d1eebe9c35b183\", \"files\": {}}",
-		"dest": "cargo/vendor/hickory-net-0.26.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/hickory-proto/hickory-proto-0.26.1.crate",
-		"sha256": "0bab31817bfb44672a252e97fe81cd0c18d1b2cf892108922f6818820df8c643",
-		"dest": "cargo/vendor/hickory-proto-0.26.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"0bab31817bfb44672a252e97fe81cd0c18d1b2cf892108922f6818820df8c643\", \"files\": {}}",
-		"dest": "cargo/vendor/hickory-proto-0.26.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/hickory-resolver/hickory-resolver-0.26.1.crate",
-		"sha256": "f0d58d28879ceecde6607729660c2667a081ccdc082e082675042793960f178c",
-		"dest": "cargo/vendor/hickory-resolver-0.26.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"f0d58d28879ceecde6607729660c2667a081ccdc082e082675042793960f178c\", \"files\": {}}",
-		"dest": "cargo/vendor/hickory-resolver-0.26.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/html5ever/html5ever-0.29.1.crate",
-		"sha256": "3b7410cae13cbc75623c98ac4cbfd1f0bedddf3227afc24f370cf0f50a44a11c",
-		"dest": "cargo/vendor/html5ever-0.29.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"3b7410cae13cbc75623c98ac4cbfd1f0bedddf3227afc24f370cf0f50a44a11c\", \"files\": {}}",
-		"dest": "cargo/vendor/html5ever-0.29.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/html5ever/html5ever-0.38.0.crate",
-		"sha256": "1054432bae2f14e0061e33d23402fbaa67a921d319d56adc6bcf887ddad1cbc2",
-		"dest": "cargo/vendor/html5ever-0.38.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"1054432bae2f14e0061e33d23402fbaa67a921d319d56adc6bcf887ddad1cbc2\", \"files\": {}}",
-		"dest": "cargo/vendor/html5ever-0.38.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/http/http-1.4.2.crate",
-		"sha256": "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425",
-		"dest": "cargo/vendor/http-1.4.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425\", \"files\": {}}",
-		"dest": "cargo/vendor/http-1.4.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/http-body/http-body-1.0.1.crate",
-		"sha256": "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184",
-		"dest": "cargo/vendor/http-body-1.0.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184\", \"files\": {}}",
-		"dest": "cargo/vendor/http-body-1.0.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/http-body-util/http-body-util-0.1.3.crate",
-		"sha256": "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a",
-		"dest": "cargo/vendor/http-body-util-0.1.3"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a\", \"files\": {}}",
-		"dest": "cargo/vendor/http-body-util-0.1.3",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/httparse/httparse-1.10.1.crate",
-		"sha256": "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87",
-		"dest": "cargo/vendor/httparse-1.10.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87\", \"files\": {}}",
-		"dest": "cargo/vendor/httparse-1.10.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/httpdate/httpdate-1.0.3.crate",
-		"sha256": "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9",
-		"dest": "cargo/vendor/httpdate-1.0.3"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9\", \"files\": {}}",
-		"dest": "cargo/vendor/httpdate-1.0.3",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/hybrid-array/hybrid-array-0.4.13.crate",
-		"sha256": "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c",
-		"dest": "cargo/vendor/hybrid-array-0.4.13"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c\", \"files\": {}}",
-		"dest": "cargo/vendor/hybrid-array-0.4.13",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/hyper/hyper-1.10.1.crate",
-		"sha256": "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498",
-		"dest": "cargo/vendor/hyper-1.10.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498\", \"files\": {}}",
-		"dest": "cargo/vendor/hyper-1.10.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/hyper-rustls/hyper-rustls-0.27.9.crate",
-		"sha256": "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f",
-		"dest": "cargo/vendor/hyper-rustls-0.27.9"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f\", \"files\": {}}",
-		"dest": "cargo/vendor/hyper-rustls-0.27.9",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/hyper-util/hyper-util-0.1.20.crate",
-		"sha256": "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0",
-		"dest": "cargo/vendor/hyper-util-0.1.20"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0\", \"files\": {}}",
-		"dest": "cargo/vendor/hyper-util-0.1.20",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/iana-time-zone/iana-time-zone-0.1.65.crate",
-		"sha256": "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470",
-		"dest": "cargo/vendor/iana-time-zone-0.1.65"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470\", \"files\": {}}",
-		"dest": "cargo/vendor/iana-time-zone-0.1.65",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/iana-time-zone-haiku/iana-time-zone-haiku-0.1.2.crate",
-		"sha256": "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f",
-		"dest": "cargo/vendor/iana-time-zone-haiku-0.1.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f\", \"files\": {}}",
-		"dest": "cargo/vendor/iana-time-zone-haiku-0.1.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/ico/ico-0.5.0.crate",
-		"sha256": "3e795dff5605e0f04bff85ca41b51a96b83e80b281e96231bcaaf1ac35103371",
-		"dest": "cargo/vendor/ico-0.5.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"3e795dff5605e0f04bff85ca41b51a96b83e80b281e96231bcaaf1ac35103371\", \"files\": {}}",
-		"dest": "cargo/vendor/ico-0.5.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/icu_collections/icu_collections-2.2.0.crate",
-		"sha256": "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c",
-		"dest": "cargo/vendor/icu_collections-2.2.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c\", \"files\": {}}",
-		"dest": "cargo/vendor/icu_collections-2.2.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/icu_locale_core/icu_locale_core-2.2.0.crate",
-		"sha256": "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29",
-		"dest": "cargo/vendor/icu_locale_core-2.2.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29\", \"files\": {}}",
-		"dest": "cargo/vendor/icu_locale_core-2.2.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/icu_normalizer/icu_normalizer-2.2.0.crate",
-		"sha256": "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4",
-		"dest": "cargo/vendor/icu_normalizer-2.2.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4\", \"files\": {}}",
-		"dest": "cargo/vendor/icu_normalizer-2.2.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/icu_normalizer_data/icu_normalizer_data-2.2.0.crate",
-		"sha256": "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38",
-		"dest": "cargo/vendor/icu_normalizer_data-2.2.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38\", \"files\": {}}",
-		"dest": "cargo/vendor/icu_normalizer_data-2.2.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/icu_properties/icu_properties-2.2.0.crate",
-		"sha256": "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de",
-		"dest": "cargo/vendor/icu_properties-2.2.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de\", \"files\": {}}",
-		"dest": "cargo/vendor/icu_properties-2.2.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/icu_properties_data/icu_properties_data-2.2.0.crate",
-		"sha256": "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14",
-		"dest": "cargo/vendor/icu_properties_data-2.2.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14\", \"files\": {}}",
-		"dest": "cargo/vendor/icu_properties_data-2.2.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/icu_provider/icu_provider-2.2.0.crate",
-		"sha256": "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421",
-		"dest": "cargo/vendor/icu_provider-2.2.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421\", \"files\": {}}",
-		"dest": "cargo/vendor/icu_provider-2.2.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/ident_case/ident_case-1.0.1.crate",
-		"sha256": "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39",
-		"dest": "cargo/vendor/ident_case-1.0.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39\", \"files\": {}}",
-		"dest": "cargo/vendor/ident_case-1.0.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/identity-hash/identity-hash-0.1.0.crate",
-		"sha256": "dfdd7caa900436d8f13b2346fe10257e0c05c1f1f9e351f4f5d57c03bd5f45da",
-		"dest": "cargo/vendor/identity-hash-0.1.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"dfdd7caa900436d8f13b2346fe10257e0c05c1f1f9e351f4f5d57c03bd5f45da\", \"files\": {}}",
-		"dest": "cargo/vendor/identity-hash-0.1.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/idna/idna-1.1.0.crate",
-		"sha256": "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de",
-		"dest": "cargo/vendor/idna-1.1.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de\", \"files\": {}}",
-		"dest": "cargo/vendor/idna-1.1.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/idna_adapter/idna_adapter-1.2.2.crate",
-		"sha256": "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714",
-		"dest": "cargo/vendor/idna_adapter-1.2.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714\", \"files\": {}}",
-		"dest": "cargo/vendor/idna_adapter-1.2.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/igd-next/igd-next-0.17.1.crate",
-		"sha256": "de7238d487a9aff61f81b5ab41c0a841532a115a398b5fa92a2fadd0885e2581",
-		"dest": "cargo/vendor/igd-next-0.17.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"de7238d487a9aff61f81b5ab41c0a841532a115a398b5fa92a2fadd0885e2581\", \"files\": {}}",
-		"dest": "cargo/vendor/igd-next-0.17.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/image/image-0.25.10.crate",
-		"sha256": "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104",
-		"dest": "cargo/vendor/image-0.25.10"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104\", \"files\": {}}",
-		"dest": "cargo/vendor/image-0.25.10",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/image-webp/image-webp-0.2.4.crate",
-		"sha256": "525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3",
-		"dest": "cargo/vendor/image-webp-0.2.4"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3\", \"files\": {}}",
-		"dest": "cargo/vendor/image-webp-0.2.4",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/imgref/imgref-1.12.2.crate",
-		"sha256": "89194689a993ab15268672e99e7b0e19da2da3268ac682e8f02d29d4d1434cd7",
-		"dest": "cargo/vendor/imgref-1.12.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"89194689a993ab15268672e99e7b0e19da2da3268ac682e8f02d29d4d1434cd7\", \"files\": {}}",
-		"dest": "cargo/vendor/imgref-1.12.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/indexmap/indexmap-1.9.3.crate",
-		"sha256": "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99",
-		"dest": "cargo/vendor/indexmap-1.9.3"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99\", \"files\": {}}",
-		"dest": "cargo/vendor/indexmap-1.9.3",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/indexmap/indexmap-2.14.0.crate",
-		"sha256": "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9",
-		"dest": "cargo/vendor/indexmap-2.14.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9\", \"files\": {}}",
-		"dest": "cargo/vendor/indexmap-2.14.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/indicatif/indicatif-0.17.11.crate",
-		"sha256": "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235",
-		"dest": "cargo/vendor/indicatif-0.17.11"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235\", \"files\": {}}",
-		"dest": "cargo/vendor/indicatif-0.17.11",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/infer/infer-0.19.0.crate",
-		"sha256": "a588916bfdfd92e71cacef98a63d9b1f0d74d6599980d11894290e7ddefffcf7",
-		"dest": "cargo/vendor/infer-0.19.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"a588916bfdfd92e71cacef98a63d9b1f0d74d6599980d11894290e7ddefffcf7\", \"files\": {}}",
-		"dest": "cargo/vendor/infer-0.19.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/inout/inout-0.1.4.crate",
-		"sha256": "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01",
-		"dest": "cargo/vendor/inout-0.1.4"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01\", \"files\": {}}",
-		"dest": "cargo/vendor/inout-0.1.4",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/inplace-vec-builder/inplace-vec-builder-0.1.1.crate",
-		"sha256": "cf64c2edc8226891a71f127587a2861b132d2b942310843814d5001d99a1d307",
-		"dest": "cargo/vendor/inplace-vec-builder-0.1.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"cf64c2edc8226891a71f127587a2861b132d2b942310843814d5001d99a1d307\", \"files\": {}}",
-		"dest": "cargo/vendor/inplace-vec-builder-0.1.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/interpolate_name/interpolate_name-0.2.4.crate",
-		"sha256": "c34819042dc3d3971c46c2190835914dfbe0c3c13f61449b2997f4e9722dfa60",
-		"dest": "cargo/vendor/interpolate_name-0.2.4"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"c34819042dc3d3971c46c2190835914dfbe0c3c13f61449b2997f4e9722dfa60\", \"files\": {}}",
-		"dest": "cargo/vendor/interpolate_name-0.2.4",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/ipconfig/ipconfig-0.3.4.crate",
-		"sha256": "4d40460c0ce33d6ce4b0630ad68ff63d6661961c48b6dba35e5a4d81cfb48222",
-		"dest": "cargo/vendor/ipconfig-0.3.4"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"4d40460c0ce33d6ce4b0630ad68ff63d6661961c48b6dba35e5a4d81cfb48222\", \"files\": {}}",
-		"dest": "cargo/vendor/ipconfig-0.3.4",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/ipnet/ipnet-2.12.0.crate",
-		"sha256": "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2",
-		"dest": "cargo/vendor/ipnet-2.12.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2\", \"files\": {}}",
-		"dest": "cargo/vendor/ipnet-2.12.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/iroh/iroh-1.0.2.crate",
-		"sha256": "5fca9b4b462c343ff88fc0af4096c186f939b602a0bc08723536ef2c31c93971",
-		"dest": "cargo/vendor/iroh-1.0.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"5fca9b4b462c343ff88fc0af4096c186f939b602a0bc08723536ef2c31c93971\", \"files\": {}}",
-		"dest": "cargo/vendor/iroh-1.0.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/iroh-base/iroh-base-1.0.2.crate",
-		"sha256": "830a582cd54410dc1aa71d4786a82c3297d7b0165accd8b6dbbb3b240b48140d",
-		"dest": "cargo/vendor/iroh-base-1.0.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"830a582cd54410dc1aa71d4786a82c3297d7b0165accd8b6dbbb3b240b48140d\", \"files\": {}}",
-		"dest": "cargo/vendor/iroh-base-1.0.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/iroh-blobs/iroh-blobs-0.103.0.crate",
-		"sha256": "5be50b0e2d0a9ba65cee4e0dfb708b3704e02ad12bd4c14c6307e94245943126",
-		"dest": "cargo/vendor/iroh-blobs-0.103.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"5be50b0e2d0a9ba65cee4e0dfb708b3704e02ad12bd4c14c6307e94245943126\", \"files\": {}}",
-		"dest": "cargo/vendor/iroh-blobs-0.103.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/iroh-dns/iroh-dns-1.0.2.crate",
-		"sha256": "516e4eedc38e33ab69a6bd325520332dc3d67b25454e2d590ebb84a25240dd9a",
-		"dest": "cargo/vendor/iroh-dns-1.0.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"516e4eedc38e33ab69a6bd325520332dc3d67b25454e2d590ebb84a25240dd9a\", \"files\": {}}",
-		"dest": "cargo/vendor/iroh-dns-1.0.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/iroh-io/iroh-io-0.6.2.crate",
-		"sha256": "e0a5feb781017b983ff1b155cd1faf8174da2acafd807aa482876da2d7e6577a",
-		"dest": "cargo/vendor/iroh-io-0.6.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"e0a5feb781017b983ff1b155cd1faf8174da2acafd807aa482876da2d7e6577a\", \"files\": {}}",
-		"dest": "cargo/vendor/iroh-io-0.6.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/iroh-metrics/iroh-metrics-1.0.1.crate",
-		"sha256": "291065721ad7c477b972e581bbc528df031dc8eb5e39fe1ff3300ae5dfb157ef",
-		"dest": "cargo/vendor/iroh-metrics-1.0.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"291065721ad7c477b972e581bbc528df031dc8eb5e39fe1ff3300ae5dfb157ef\", \"files\": {}}",
-		"dest": "cargo/vendor/iroh-metrics-1.0.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/iroh-metrics-derive/iroh-metrics-derive-1.0.1.crate",
-		"sha256": "1ae5f0c4405d1fbc9fb16ff422ca40620e93dc36c30ecaba0c2aee3992b7bd48",
-		"dest": "cargo/vendor/iroh-metrics-derive-1.0.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"1ae5f0c4405d1fbc9fb16ff422ca40620e93dc36c30ecaba0c2aee3992b7bd48\", \"files\": {}}",
-		"dest": "cargo/vendor/iroh-metrics-derive-1.0.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/iroh-relay/iroh-relay-1.0.2.crate",
-		"sha256": "8149bb6a57126225a07d6928846d82dcedfd24ea0f863ef7b2eb475e1d726354",
-		"dest": "cargo/vendor/iroh-relay-1.0.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"8149bb6a57126225a07d6928846d82dcedfd24ea0f863ef7b2eb475e1d726354\", \"files\": {}}",
-		"dest": "cargo/vendor/iroh-relay-1.0.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/iroh-tickets/iroh-tickets-1.0.0.crate",
-		"sha256": "da53233419ca36bf521ed45683b7748366f9b233032891eefc2d70567a84ac54",
-		"dest": "cargo/vendor/iroh-tickets-1.0.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"da53233419ca36bf521ed45683b7748366f9b233032891eefc2d70567a84ac54\", \"files\": {}}",
-		"dest": "cargo/vendor/iroh-tickets-1.0.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/iroh-util/iroh-util-0.6.0.crate",
-		"sha256": "20e41eb982f15230c55f0a70a74a514360e1f565b07861924fd0e8db172b3d00",
-		"dest": "cargo/vendor/iroh-util-0.6.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"20e41eb982f15230c55f0a70a74a514360e1f565b07861924fd0e8db172b3d00\", \"files\": {}}",
-		"dest": "cargo/vendor/iroh-util-0.6.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/irpc/irpc-0.17.0.crate",
-		"sha256": "3623d6ff582b415904b29bbe6ebcb4a4f9a262ccdee05a45fdd003ef0950c386",
-		"dest": "cargo/vendor/irpc-0.17.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"3623d6ff582b415904b29bbe6ebcb4a4f9a262ccdee05a45fdd003ef0950c386\", \"files\": {}}",
-		"dest": "cargo/vendor/irpc-0.17.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/irpc-derive/irpc-derive-0.17.0.crate",
-		"sha256": "35c254013736de16472140d26904e6ac98e8f3887284dcf4af40f88c77411b56",
-		"dest": "cargo/vendor/irpc-derive-0.17.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"35c254013736de16472140d26904e6ac98e8f3887284dcf4af40f88c77411b56\", \"files\": {}}",
-		"dest": "cargo/vendor/irpc-derive-0.17.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/is-docker/is-docker-0.2.0.crate",
-		"sha256": "928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3",
-		"dest": "cargo/vendor/is-docker-0.2.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3\", \"files\": {}}",
-		"dest": "cargo/vendor/is-docker-0.2.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/is-wsl/is-wsl-0.4.0.crate",
-		"sha256": "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5",
-		"dest": "cargo/vendor/is-wsl-0.4.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5\", \"files\": {}}",
-		"dest": "cargo/vendor/is-wsl-0.4.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/is_terminal_polyfill/is_terminal_polyfill-1.70.2.crate",
-		"sha256": "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695",
-		"dest": "cargo/vendor/is_terminal_polyfill-1.70.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695\", \"files\": {}}",
-		"dest": "cargo/vendor/is_terminal_polyfill-1.70.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/itertools/itertools-0.14.0.crate",
-		"sha256": "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285",
-		"dest": "cargo/vendor/itertools-0.14.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285\", \"files\": {}}",
-		"dest": "cargo/vendor/itertools-0.14.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/itoa/itoa-1.0.18.crate",
-		"sha256": "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682",
-		"dest": "cargo/vendor/itoa-1.0.18"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682\", \"files\": {}}",
-		"dest": "cargo/vendor/itoa-1.0.18",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/javascriptcore-rs/javascriptcore-rs-1.1.2.crate",
-		"sha256": "ca5671e9ffce8ffba57afc24070e906da7fc4b1ba66f2cabebf61bf2ea257fcc",
-		"dest": "cargo/vendor/javascriptcore-rs-1.1.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"ca5671e9ffce8ffba57afc24070e906da7fc4b1ba66f2cabebf61bf2ea257fcc\", \"files\": {}}",
-		"dest": "cargo/vendor/javascriptcore-rs-1.1.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/javascriptcore-rs-sys/javascriptcore-rs-sys-1.1.1.crate",
-		"sha256": "af1be78d14ffa4b75b66df31840478fef72b51f8c2465d4ca7c194da9f7a5124",
-		"dest": "cargo/vendor/javascriptcore-rs-sys-1.1.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"af1be78d14ffa4b75b66df31840478fef72b51f8c2465d4ca7c194da9f7a5124\", \"files\": {}}",
-		"dest": "cargo/vendor/javascriptcore-rs-sys-1.1.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/jni/jni-0.21.1.crate",
-		"sha256": "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97",
-		"dest": "cargo/vendor/jni-0.21.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97\", \"files\": {}}",
-		"dest": "cargo/vendor/jni-0.21.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/jni/jni-0.22.4.crate",
-		"sha256": "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498",
-		"dest": "cargo/vendor/jni-0.22.4"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498\", \"files\": {}}",
-		"dest": "cargo/vendor/jni-0.22.4",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/jni-macros/jni-macros-0.22.4.crate",
-		"sha256": "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3",
-		"dest": "cargo/vendor/jni-macros-0.22.4"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3\", \"files\": {}}",
-		"dest": "cargo/vendor/jni-macros-0.22.4",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/jni-sys/jni-sys-0.3.1.crate",
-		"sha256": "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258",
-		"dest": "cargo/vendor/jni-sys-0.3.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258\", \"files\": {}}",
-		"dest": "cargo/vendor/jni-sys-0.3.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/jni-sys/jni-sys-0.4.1.crate",
-		"sha256": "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2",
-		"dest": "cargo/vendor/jni-sys-0.4.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2\", \"files\": {}}",
-		"dest": "cargo/vendor/jni-sys-0.4.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/jni-sys-macros/jni-sys-macros-0.4.1.crate",
-		"sha256": "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264",
-		"dest": "cargo/vendor/jni-sys-macros-0.4.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264\", \"files\": {}}",
-		"dest": "cargo/vendor/jni-sys-macros-0.4.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/jobserver/jobserver-0.1.35.crate",
-		"sha256": "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3",
-		"dest": "cargo/vendor/jobserver-0.1.35"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3\", \"files\": {}}",
-		"dest": "cargo/vendor/jobserver-0.1.35",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/js-sys/js-sys-0.3.103.crate",
-		"sha256": "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102",
-		"dest": "cargo/vendor/js-sys-0.3.103"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102\", \"files\": {}}",
-		"dest": "cargo/vendor/js-sys-0.3.103",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/json-patch/json-patch-3.0.1.crate",
-		"sha256": "863726d7afb6bc2590eeff7135d923545e5e964f004c2ccf8716c25e70a86f08",
-		"dest": "cargo/vendor/json-patch-3.0.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"863726d7afb6bc2590eeff7135d923545e5e964f004c2ccf8716c25e70a86f08\", \"files\": {}}",
-		"dest": "cargo/vendor/json-patch-3.0.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/jsonptr/jsonptr-0.6.3.crate",
-		"sha256": "5dea2b27dd239b2556ed7a25ba842fe47fd602e7fc7433c2a8d6106d4d9edd70",
-		"dest": "cargo/vendor/jsonptr-0.6.3"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"5dea2b27dd239b2556ed7a25ba842fe47fd602e7fc7433c2a8d6106d4d9edd70\", \"files\": {}}",
-		"dest": "cargo/vendor/jsonptr-0.6.3",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/keyboard-types/keyboard-types-0.7.0.crate",
-		"sha256": "b750dcadc39a09dbadd74e118f6dd6598df77fa01df0cfcdc52c28dece74528a",
-		"dest": "cargo/vendor/keyboard-types-0.7.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"b750dcadc39a09dbadd74e118f6dd6598df77fa01df0cfcdc52c28dece74528a\", \"files\": {}}",
-		"dest": "cargo/vendor/keyboard-types-0.7.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/keyring/keyring-3.6.3.crate",
-		"sha256": "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c",
-		"dest": "cargo/vendor/keyring-3.6.3"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c\", \"files\": {}}",
-		"dest": "cargo/vendor/keyring-3.6.3",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/kuchikiki/kuchikiki-0.8.8-speedreader.crate",
-		"sha256": "02cb977175687f33fa4afa0c95c112b987ea1443e5a51c8f8ff27dc618270cc2",
-		"dest": "cargo/vendor/kuchikiki-0.8.8-speedreader"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"02cb977175687f33fa4afa0c95c112b987ea1443e5a51c8f8ff27dc618270cc2\", \"files\": {}}",
-		"dest": "cargo/vendor/kuchikiki-0.8.8-speedreader",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/lazy_static/lazy_static-1.5.0.crate",
-		"sha256": "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe",
-		"dest": "cargo/vendor/lazy_static-1.5.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe\", \"files\": {}}",
-		"dest": "cargo/vendor/lazy_static-1.5.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/lebe/lebe-0.5.3.crate",
-		"sha256": "7a79a3332a6609480d7d0c9eab957bca6b455b91bb84e66d19f5ff66294b85b8",
-		"dest": "cargo/vendor/lebe-0.5.3"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"7a79a3332a6609480d7d0c9eab957bca6b455b91bb84e66d19f5ff66294b85b8\", \"files\": {}}",
-		"dest": "cargo/vendor/lebe-0.5.3",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/libappindicator/libappindicator-0.9.0.crate",
-		"sha256": "03589b9607c868cc7ae54c0b2a22c8dc03dd41692d48f2d7df73615c6a95dc0a",
-		"dest": "cargo/vendor/libappindicator-0.9.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"03589b9607c868cc7ae54c0b2a22c8dc03dd41692d48f2d7df73615c6a95dc0a\", \"files\": {}}",
-		"dest": "cargo/vendor/libappindicator-0.9.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/libappindicator-sys/libappindicator-sys-0.9.0.crate",
-		"sha256": "6e9ec52138abedcc58dc17a7c6c0c00a2bdb4f3427c7f63fa97fd0d859155caf",
-		"dest": "cargo/vendor/libappindicator-sys-0.9.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"6e9ec52138abedcc58dc17a7c6c0c00a2bdb4f3427c7f63fa97fd0d859155caf\", \"files\": {}}",
-		"dest": "cargo/vendor/libappindicator-sys-0.9.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/libc/libc-0.2.186.crate",
-		"sha256": "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66",
-		"dest": "cargo/vendor/libc-0.2.186"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66\", \"files\": {}}",
-		"dest": "cargo/vendor/libc-0.2.186",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/libfuzzer-sys/libfuzzer-sys-0.4.13.crate",
-		"sha256": "a9fd2f41a1cba099f79a0b6b6c35656cf7c03351a7bae8ff0f28f25270f929d2",
-		"dest": "cargo/vendor/libfuzzer-sys-0.4.13"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"a9fd2f41a1cba099f79a0b6b6c35656cf7c03351a7bae8ff0f28f25270f929d2\", \"files\": {}}",
-		"dest": "cargo/vendor/libfuzzer-sys-0.4.13",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/libloading/libloading-0.7.4.crate",
-		"sha256": "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f",
-		"dest": "cargo/vendor/libloading-0.7.4"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f\", \"files\": {}}",
-		"dest": "cargo/vendor/libloading-0.7.4",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/libm/libm-0.2.16.crate",
-		"sha256": "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981",
-		"dest": "cargo/vendor/libm-0.2.16"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981\", \"files\": {}}",
-		"dest": "cargo/vendor/libm-0.2.16",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/libredox/libredox-0.1.18.crate",
-		"sha256": "c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652",
-		"dest": "cargo/vendor/libredox-0.1.18"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652\", \"files\": {}}",
-		"dest": "cargo/vendor/libredox-0.1.18",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/linux-raw-sys/linux-raw-sys-0.12.1.crate",
-		"sha256": "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53",
-		"dest": "cargo/vendor/linux-raw-sys-0.12.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53\", \"files\": {}}",
-		"dest": "cargo/vendor/linux-raw-sys-0.12.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/litemap/litemap-0.8.2.crate",
-		"sha256": "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0",
-		"dest": "cargo/vendor/litemap-0.8.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0\", \"files\": {}}",
-		"dest": "cargo/vendor/litemap-0.8.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/litrs/litrs-1.0.0.crate",
-		"sha256": "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092",
-		"dest": "cargo/vendor/litrs-1.0.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092\", \"files\": {}}",
-		"dest": "cargo/vendor/litrs-1.0.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/lock_api/lock_api-0.4.14.crate",
-		"sha256": "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965",
-		"dest": "cargo/vendor/lock_api-0.4.14"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965\", \"files\": {}}",
-		"dest": "cargo/vendor/lock_api-0.4.14",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/log/log-0.4.33.crate",
-		"sha256": "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad",
-		"dest": "cargo/vendor/log-0.4.33"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad\", \"files\": {}}",
-		"dest": "cargo/vendor/log-0.4.33",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/loom/loom-0.7.2.crate",
-		"sha256": "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca",
-		"dest": "cargo/vendor/loom-0.7.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca\", \"files\": {}}",
-		"dest": "cargo/vendor/loom-0.7.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/loop9/loop9-0.1.5.crate",
-		"sha256": "0fae87c125b03c1d2c0150c90365d7d6bcc53fb73a9acaef207d2d065860f062",
-		"dest": "cargo/vendor/loop9-0.1.5"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"0fae87c125b03c1d2c0150c90365d7d6bcc53fb73a9acaef207d2d065860f062\", \"files\": {}}",
-		"dest": "cargo/vendor/loop9-0.1.5",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/lru/lru-0.18.0.crate",
-		"sha256": "8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9",
-		"dest": "cargo/vendor/lru-0.18.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9\", \"files\": {}}",
-		"dest": "cargo/vendor/lru-0.18.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/lru-slab/lru-slab-0.1.2.crate",
-		"sha256": "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154",
-		"dest": "cargo/vendor/lru-slab-0.1.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154\", \"files\": {}}",
-		"dest": "cargo/vendor/lru-slab-0.1.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/mac/mac-0.1.1.crate",
-		"sha256": "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4",
-		"dest": "cargo/vendor/mac-0.1.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4\", \"files\": {}}",
-		"dest": "cargo/vendor/mac-0.1.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/mac-addr/mac-addr-0.3.0.crate",
-		"sha256": "d3d25b0e0b648a86960ac23b7ad4abb9717601dec6f66c165f5b037f3f03065f",
-		"dest": "cargo/vendor/mac-addr-0.3.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"d3d25b0e0b648a86960ac23b7ad4abb9717601dec6f66c165f5b037f3f03065f\", \"files\": {}}",
-		"dest": "cargo/vendor/mac-addr-0.3.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/mac-notification-sys/mac-notification-sys-0.6.15.crate",
-		"sha256": "fd604973958ddcc11b561193c0fb96ba146506ef2f231ef2e7c35fd2cbc9beca",
-		"dest": "cargo/vendor/mac-notification-sys-0.6.15"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"fd604973958ddcc11b561193c0fb96ba146506ef2f231ef2e7c35fd2cbc9beca\", \"files\": {}}",
-		"dest": "cargo/vendor/mac-notification-sys-0.6.15",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/malloc_buf/malloc_buf-0.0.6.crate",
-		"sha256": "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb",
-		"dest": "cargo/vendor/malloc_buf-0.0.6"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb\", \"files\": {}}",
-		"dest": "cargo/vendor/malloc_buf-0.0.6",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/markup5ever/markup5ever-0.14.1.crate",
-		"sha256": "c7a7213d12e1864c0f002f52c2923d4556935a43dec5e71355c2760e0f6e7a18",
-		"dest": "cargo/vendor/markup5ever-0.14.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"c7a7213d12e1864c0f002f52c2923d4556935a43dec5e71355c2760e0f6e7a18\", \"files\": {}}",
-		"dest": "cargo/vendor/markup5ever-0.14.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/markup5ever/markup5ever-0.38.0.crate",
-		"sha256": "8983d30f2915feeaaab2d6babdd6bc7e9ed1a00b66b5e6d74df19aa9c0e91862",
-		"dest": "cargo/vendor/markup5ever-0.38.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"8983d30f2915feeaaab2d6babdd6bc7e9ed1a00b66b5e6d74df19aa9c0e91862\", \"files\": {}}",
-		"dest": "cargo/vendor/markup5ever-0.38.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/match_token/match_token-0.1.0.crate",
-		"sha256": "88a9689d8d44bf9964484516275f5cd4c9b59457a6940c1d5d0ecbb94510a36b",
-		"dest": "cargo/vendor/match_token-0.1.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"88a9689d8d44bf9964484516275f5cd4c9b59457a6940c1d5d0ecbb94510a36b\", \"files\": {}}",
-		"dest": "cargo/vendor/match_token-0.1.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/matchers/matchers-0.2.0.crate",
-		"sha256": "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9",
-		"dest": "cargo/vendor/matchers-0.2.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9\", \"files\": {}}",
-		"dest": "cargo/vendor/matchers-0.2.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/matches/matches-0.1.10.crate",
-		"sha256": "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5",
-		"dest": "cargo/vendor/matches-0.1.10"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5\", \"files\": {}}",
-		"dest": "cargo/vendor/matches-0.1.10",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/maybe-rayon/maybe-rayon-0.1.1.crate",
-		"sha256": "8ea1f30cedd69f0a2954655f7188c6a834246d2bcf1e315e2ac40c4b24dc9519",
-		"dest": "cargo/vendor/maybe-rayon-0.1.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"8ea1f30cedd69f0a2954655f7188c6a834246d2bcf1e315e2ac40c4b24dc9519\", \"files\": {}}",
-		"dest": "cargo/vendor/maybe-rayon-0.1.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/memchr/memchr-2.8.3.crate",
-		"sha256": "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98",
-		"dest": "cargo/vendor/memchr-2.8.3"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98\", \"files\": {}}",
-		"dest": "cargo/vendor/memchr-2.8.3",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/memoffset/memoffset-0.9.1.crate",
-		"sha256": "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a",
-		"dest": "cargo/vendor/memoffset-0.9.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a\", \"files\": {}}",
-		"dest": "cargo/vendor/memoffset-0.9.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/mime/mime-0.3.17.crate",
-		"sha256": "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a",
-		"dest": "cargo/vendor/mime-0.3.17"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a\", \"files\": {}}",
-		"dest": "cargo/vendor/mime-0.3.17",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/mime_guess/mime_guess-2.0.5.crate",
-		"sha256": "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e",
-		"dest": "cargo/vendor/mime_guess-2.0.5"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e\", \"files\": {}}",
-		"dest": "cargo/vendor/mime_guess-2.0.5",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/minimal-lexical/minimal-lexical-0.2.1.crate",
-		"sha256": "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a",
-		"dest": "cargo/vendor/minimal-lexical-0.2.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a\", \"files\": {}}",
-		"dest": "cargo/vendor/minimal-lexical-0.2.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/minisign-verify/minisign-verify-0.2.5.crate",
-		"sha256": "22f9645cb765ea72b8111f36c522475d2daa0d22c957a9826437e97534bc4e9e",
-		"dest": "cargo/vendor/minisign-verify-0.2.5"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"22f9645cb765ea72b8111f36c522475d2daa0d22c957a9826437e97534bc4e9e\", \"files\": {}}",
-		"dest": "cargo/vendor/minisign-verify-0.2.5",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/miniz_oxide/miniz_oxide-0.8.9.crate",
-		"sha256": "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316",
-		"dest": "cargo/vendor/miniz_oxide-0.8.9"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316\", \"files\": {}}",
-		"dest": "cargo/vendor/miniz_oxide-0.8.9",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/mio/mio-1.2.1.crate",
-		"sha256": "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda",
-		"dest": "cargo/vendor/mio-1.2.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda\", \"files\": {}}",
-		"dest": "cargo/vendor/mio-1.2.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/moka/moka-0.12.15.crate",
-		"sha256": "957228ad12042ee839f93c8f257b62b4c0ab5eaae1d4fa60de53b27c9d7c5046",
-		"dest": "cargo/vendor/moka-0.12.15"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"957228ad12042ee839f93c8f257b62b4c0ab5eaae1d4fa60de53b27c9d7c5046\", \"files\": {}}",
-		"dest": "cargo/vendor/moka-0.12.15",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/moxcms/moxcms-0.8.1.crate",
-		"sha256": "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b",
-		"dest": "cargo/vendor/moxcms-0.8.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b\", \"files\": {}}",
-		"dest": "cargo/vendor/moxcms-0.8.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/muda/muda-0.17.2.crate",
-		"sha256": "7c9fec5a4e89860383d778d10563a605838f8f0b2f9303868937e5ff32e86177",
-		"dest": "cargo/vendor/muda-0.17.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"7c9fec5a4e89860383d778d10563a605838f8f0b2f9303868937e5ff32e86177\", \"files\": {}}",
-		"dest": "cargo/vendor/muda-0.17.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/muldiv/muldiv-1.0.1.crate",
-		"sha256": "956787520e75e9bd233246045d19f42fb73242759cc57fba9611d940ae96d4b0",
-		"dest": "cargo/vendor/muldiv-1.0.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"956787520e75e9bd233246045d19f42fb73242759cc57fba9611d940ae96d4b0\", \"files\": {}}",
-		"dest": "cargo/vendor/muldiv-1.0.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/n0-error/n0-error-1.0.0.crate",
-		"sha256": "c37e81176a83a77d2514528b91bdafc70ef88aab428f0e1b91aebb8d99888895",
-		"dest": "cargo/vendor/n0-error-1.0.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"c37e81176a83a77d2514528b91bdafc70ef88aab428f0e1b91aebb8d99888895\", \"files\": {}}",
-		"dest": "cargo/vendor/n0-error-1.0.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/n0-error-macros/n0-error-macros-1.0.0.crate",
-		"sha256": "e2acd8b070213b0299282f884b4beba4e7b52d624fdcd504a3ad3665390c11e1",
-		"dest": "cargo/vendor/n0-error-macros-1.0.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"e2acd8b070213b0299282f884b4beba4e7b52d624fdcd504a3ad3665390c11e1\", \"files\": {}}",
-		"dest": "cargo/vendor/n0-error-macros-1.0.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/n0-future/n0-future-0.3.2.crate",
-		"sha256": "e2ab99dfb861450e68853d34ae665243a88b8c493d01ba957321a1e9b2312bbe",
-		"dest": "cargo/vendor/n0-future-0.3.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"e2ab99dfb861450e68853d34ae665243a88b8c493d01ba957321a1e9b2312bbe\", \"files\": {}}",
-		"dest": "cargo/vendor/n0-future-0.3.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/n0-watcher/n0-watcher-1.0.0.crate",
-		"sha256": "bbc618745ad0b7414b149d0517ad8b5573b2fb4d4e2717add3d2446ce1fdd826",
-		"dest": "cargo/vendor/n0-watcher-1.0.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"bbc618745ad0b7414b149d0517ad8b5573b2fb4d4e2717add3d2446ce1fdd826\", \"files\": {}}",
-		"dest": "cargo/vendor/n0-watcher-1.0.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/ndk/ndk-0.9.0.crate",
-		"sha256": "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4",
-		"dest": "cargo/vendor/ndk-0.9.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4\", \"files\": {}}",
-		"dest": "cargo/vendor/ndk-0.9.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/ndk-context/ndk-context-0.1.1.crate",
-		"sha256": "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b",
-		"dest": "cargo/vendor/ndk-context-0.1.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b\", \"files\": {}}",
-		"dest": "cargo/vendor/ndk-context-0.1.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/ndk-sys/ndk-sys-0.6.0+11769913.crate",
-		"sha256": "ee6cda3051665f1fb8d9e08fc35c96d5a244fb1be711a03b71118828afc9a873",
-		"dest": "cargo/vendor/ndk-sys-0.6.0+11769913"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"ee6cda3051665f1fb8d9e08fc35c96d5a244fb1be711a03b71118828afc9a873\", \"files\": {}}",
-		"dest": "cargo/vendor/ndk-sys-0.6.0+11769913",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/nested_enum_utils/nested_enum_utils-0.2.3.crate",
-		"sha256": "b1d5475271bdd36a4a2769eac1ef88df0f99428ea43e52dfd8b0ee5cb674695f",
-		"dest": "cargo/vendor/nested_enum_utils-0.2.3"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"b1d5475271bdd36a4a2769eac1ef88df0f99428ea43e52dfd8b0ee5cb674695f\", \"files\": {}}",
-		"dest": "cargo/vendor/nested_enum_utils-0.2.3",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/netdev/netdev-0.45.0.crate",
-		"sha256": "569dfbdd2efd771b24ec9bb57f956e04d4fbfc72f62b2f11961723f9b3f4b020",
-		"dest": "cargo/vendor/netdev-0.45.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"569dfbdd2efd771b24ec9bb57f956e04d4fbfc72f62b2f11961723f9b3f4b020\", \"files\": {}}",
-		"dest": "cargo/vendor/netdev-0.45.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/netlink-packet-core/netlink-packet-core-0.8.1.crate",
-		"sha256": "3463cbb78394cb0141e2c926b93fc2197e473394b761986eca3b9da2c63ae0f4",
-		"dest": "cargo/vendor/netlink-packet-core-0.8.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"3463cbb78394cb0141e2c926b93fc2197e473394b761986eca3b9da2c63ae0f4\", \"files\": {}}",
-		"dest": "cargo/vendor/netlink-packet-core-0.8.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/netlink-packet-route/netlink-packet-route-0.31.0.crate",
-		"sha256": "e2288fcb784eb3defd5fb16f4c4160d5f477de192eac730f43e1d11c24d9a007",
-		"dest": "cargo/vendor/netlink-packet-route-0.31.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"e2288fcb784eb3defd5fb16f4c4160d5f477de192eac730f43e1d11c24d9a007\", \"files\": {}}",
-		"dest": "cargo/vendor/netlink-packet-route-0.31.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/netlink-proto/netlink-proto-0.12.0.crate",
-		"sha256": "b65d130ee111430e47eed7896ea43ca693c387f097dd97376bffafbf25812128",
-		"dest": "cargo/vendor/netlink-proto-0.12.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"b65d130ee111430e47eed7896ea43ca693c387f097dd97376bffafbf25812128\", \"files\": {}}",
-		"dest": "cargo/vendor/netlink-proto-0.12.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/netlink-sys/netlink-sys-0.8.8.crate",
-		"sha256": "cd6c30ed10fa69cc491d491b85cc971f6bdeb8e7367b7cde2ee6cc878d583fae",
-		"dest": "cargo/vendor/netlink-sys-0.8.8"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"cd6c30ed10fa69cc491d491b85cc971f6bdeb8e7367b7cde2ee6cc878d583fae\", \"files\": {}}",
-		"dest": "cargo/vendor/netlink-sys-0.8.8",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/netwatch/netwatch-0.19.1.crate",
-		"sha256": "4d9cbe01741347ef750d743d6690603f5eed8341e679fb51c8e629337aa11976",
-		"dest": "cargo/vendor/netwatch-0.19.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"4d9cbe01741347ef750d743d6690603f5eed8341e679fb51c8e629337aa11976\", \"files\": {}}",
-		"dest": "cargo/vendor/netwatch-0.19.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/new_debug_unreachable/new_debug_unreachable-1.0.6.crate",
-		"sha256": "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086",
-		"dest": "cargo/vendor/new_debug_unreachable-1.0.6"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086\", \"files\": {}}",
-		"dest": "cargo/vendor/new_debug_unreachable-1.0.6",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/nix/nix-0.31.3.crate",
-		"sha256": "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d",
-		"dest": "cargo/vendor/nix-0.31.3"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d\", \"files\": {}}",
-		"dest": "cargo/vendor/nix-0.31.3",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/no_std_io2/no_std_io2-0.9.4.crate",
-		"sha256": "418abd1b6d34fbf6cae440dc874771b0525a604428704c76e48b29a5e67b8003",
-		"dest": "cargo/vendor/no_std_io2-0.9.4"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"418abd1b6d34fbf6cae440dc874771b0525a604428704c76e48b29a5e67b8003\", \"files\": {}}",
-		"dest": "cargo/vendor/no_std_io2-0.9.4",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/nodrop/nodrop-0.1.14.crate",
-		"sha256": "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb",
-		"dest": "cargo/vendor/nodrop-0.1.14"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb\", \"files\": {}}",
-		"dest": "cargo/vendor/nodrop-0.1.14",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/nom/nom-7.1.3.crate",
-		"sha256": "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a",
-		"dest": "cargo/vendor/nom-7.1.3"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a\", \"files\": {}}",
-		"dest": "cargo/vendor/nom-7.1.3",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/nom/nom-8.0.0.crate",
-		"sha256": "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405",
-		"dest": "cargo/vendor/nom-8.0.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405\", \"files\": {}}",
-		"dest": "cargo/vendor/nom-8.0.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/noop_proc_macro/noop_proc_macro-0.3.0.crate",
-		"sha256": "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8",
-		"dest": "cargo/vendor/noop_proc_macro-0.3.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8\", \"files\": {}}",
-		"dest": "cargo/vendor/noop_proc_macro-0.3.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/noq/noq-1.0.1.crate",
-		"sha256": "4bf95190af1bd4a00a10e8255ca0c8ddd9e9a9f5e79151d7a7eb6d56aff5dc89",
-		"dest": "cargo/vendor/noq-1.0.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"4bf95190af1bd4a00a10e8255ca0c8ddd9e9a9f5e79151d7a7eb6d56aff5dc89\", \"files\": {}}",
-		"dest": "cargo/vendor/noq-1.0.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/noq-proto/noq-proto-1.0.1.crate",
-		"sha256": "aa6c890013591e709a3e45dd53501351b7e27e7ff3c7e9fc3dce43e300e7e9d3",
-		"dest": "cargo/vendor/noq-proto-1.0.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"aa6c890013591e709a3e45dd53501351b7e27e7ff3c7e9fc3dce43e300e7e9d3\", \"files\": {}}",
-		"dest": "cargo/vendor/noq-proto-1.0.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/noq-udp/noq-udp-1.0.1.crate",
-		"sha256": "3137a52df66c20090a889828d1c655f21f52294cba64e5c4fbb04fc83eee7c8e",
-		"dest": "cargo/vendor/noq-udp-1.0.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"3137a52df66c20090a889828d1c655f21f52294cba64e5c4fbb04fc83eee7c8e\", \"files\": {}}",
-		"dest": "cargo/vendor/noq-udp-1.0.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/notify-rust/notify-rust-4.18.0.crate",
-		"sha256": "c5b4c1b4f2aa9f25f63a7a49d3dd0ed567b3670da15330a66b29434be899b891",
-		"dest": "cargo/vendor/notify-rust-4.18.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"c5b4c1b4f2aa9f25f63a7a49d3dd0ed567b3670da15330a66b29434be899b891\", \"files\": {}}",
-		"dest": "cargo/vendor/notify-rust-4.18.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/nu-ansi-term/nu-ansi-term-0.50.3.crate",
-		"sha256": "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5",
-		"dest": "cargo/vendor/nu-ansi-term-0.50.3"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5\", \"files\": {}}",
-		"dest": "cargo/vendor/nu-ansi-term-0.50.3",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/num-bigint/num-bigint-0.4.8.crate",
-		"sha256": "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367",
-		"dest": "cargo/vendor/num-bigint-0.4.8"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367\", \"files\": {}}",
-		"dest": "cargo/vendor/num-bigint-0.4.8",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/num-complex/num-complex-0.4.6.crate",
-		"sha256": "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495",
-		"dest": "cargo/vendor/num-complex-0.4.6"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495\", \"files\": {}}",
-		"dest": "cargo/vendor/num-complex-0.4.6",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/num-conv/num-conv-0.2.2.crate",
-		"sha256": "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441",
-		"dest": "cargo/vendor/num-conv-0.2.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441\", \"files\": {}}",
-		"dest": "cargo/vendor/num-conv-0.2.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/num-derive/num-derive-0.4.2.crate",
-		"sha256": "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202",
-		"dest": "cargo/vendor/num-derive-0.4.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202\", \"files\": {}}",
-		"dest": "cargo/vendor/num-derive-0.4.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/num-integer/num-integer-0.1.46.crate",
-		"sha256": "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f",
-		"dest": "cargo/vendor/num-integer-0.1.46"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f\", \"files\": {}}",
-		"dest": "cargo/vendor/num-integer-0.1.46",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/num-rational/num-rational-0.4.2.crate",
-		"sha256": "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824",
-		"dest": "cargo/vendor/num-rational-0.4.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824\", \"files\": {}}",
-		"dest": "cargo/vendor/num-rational-0.4.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/num-traits/num-traits-0.2.19.crate",
-		"sha256": "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841",
-		"dest": "cargo/vendor/num-traits-0.2.19"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841\", \"files\": {}}",
-		"dest": "cargo/vendor/num-traits-0.2.19",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/num_cpus/num_cpus-1.17.0.crate",
-		"sha256": "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b",
-		"dest": "cargo/vendor/num_cpus-1.17.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b\", \"files\": {}}",
-		"dest": "cargo/vendor/num_cpus-1.17.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/num_enum/num_enum-0.7.6.crate",
-		"sha256": "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26",
-		"dest": "cargo/vendor/num_enum-0.7.6"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26\", \"files\": {}}",
-		"dest": "cargo/vendor/num_enum-0.7.6",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/num_enum_derive/num_enum_derive-0.7.6.crate",
-		"sha256": "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8",
-		"dest": "cargo/vendor/num_enum_derive-0.7.6"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8\", \"files\": {}}",
-		"dest": "cargo/vendor/num_enum_derive-0.7.6",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/num_threads/num_threads-0.1.7.crate",
-		"sha256": "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9",
-		"dest": "cargo/vendor/num_threads-0.1.7"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9\", \"files\": {}}",
-		"dest": "cargo/vendor/num_threads-0.1.7",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/number_prefix/number_prefix-0.4.0.crate",
-		"sha256": "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3",
-		"dest": "cargo/vendor/number_prefix-0.4.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3\", \"files\": {}}",
-		"dest": "cargo/vendor/number_prefix-0.4.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/objc/objc-0.2.7.crate",
-		"sha256": "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1",
-		"dest": "cargo/vendor/objc-0.2.7"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1\", \"files\": {}}",
-		"dest": "cargo/vendor/objc-0.2.7",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/objc2/objc2-0.6.4.crate",
-		"sha256": "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f",
-		"dest": "cargo/vendor/objc2-0.6.4"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f\", \"files\": {}}",
-		"dest": "cargo/vendor/objc2-0.6.4",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/objc2-app-kit/objc2-app-kit-0.3.2.crate",
-		"sha256": "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c",
-		"dest": "cargo/vendor/objc2-app-kit-0.3.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c\", \"files\": {}}",
-		"dest": "cargo/vendor/objc2-app-kit-0.3.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/objc2-cloud-kit/objc2-cloud-kit-0.3.2.crate",
-		"sha256": "73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c",
-		"dest": "cargo/vendor/objc2-cloud-kit-0.3.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c\", \"files\": {}}",
-		"dest": "cargo/vendor/objc2-cloud-kit-0.3.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/objc2-core-data/objc2-core-data-0.3.2.crate",
-		"sha256": "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa",
-		"dest": "cargo/vendor/objc2-core-data-0.3.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa\", \"files\": {}}",
-		"dest": "cargo/vendor/objc2-core-data-0.3.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/objc2-core-foundation/objc2-core-foundation-0.3.2.crate",
-		"sha256": "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536",
-		"dest": "cargo/vendor/objc2-core-foundation-0.3.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536\", \"files\": {}}",
-		"dest": "cargo/vendor/objc2-core-foundation-0.3.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/objc2-core-graphics/objc2-core-graphics-0.3.2.crate",
-		"sha256": "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807",
-		"dest": "cargo/vendor/objc2-core-graphics-0.3.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807\", \"files\": {}}",
-		"dest": "cargo/vendor/objc2-core-graphics-0.3.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/objc2-core-image/objc2-core-image-0.3.2.crate",
-		"sha256": "e5d563b38d2b97209f8e861173de434bd0214cf020e3423a52624cd1d989f006",
-		"dest": "cargo/vendor/objc2-core-image-0.3.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"e5d563b38d2b97209f8e861173de434bd0214cf020e3423a52624cd1d989f006\", \"files\": {}}",
-		"dest": "cargo/vendor/objc2-core-image-0.3.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/objc2-core-location/objc2-core-location-0.3.2.crate",
-		"sha256": "ca347214e24bc973fc025fd0d36ebb179ff30536ed1f80252706db19ee452009",
-		"dest": "cargo/vendor/objc2-core-location-0.3.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"ca347214e24bc973fc025fd0d36ebb179ff30536ed1f80252706db19ee452009\", \"files\": {}}",
-		"dest": "cargo/vendor/objc2-core-location-0.3.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/objc2-core-text/objc2-core-text-0.3.2.crate",
-		"sha256": "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d",
-		"dest": "cargo/vendor/objc2-core-text-0.3.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d\", \"files\": {}}",
-		"dest": "cargo/vendor/objc2-core-text-0.3.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/objc2-core-wlan/objc2-core-wlan-0.3.2.crate",
-		"sha256": "c71e34919aba0d701380d911702455038a8a3587467fe0141d6a71501e7ffe48",
-		"dest": "cargo/vendor/objc2-core-wlan-0.3.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"c71e34919aba0d701380d911702455038a8a3587467fe0141d6a71501e7ffe48\", \"files\": {}}",
-		"dest": "cargo/vendor/objc2-core-wlan-0.3.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/objc2-encode/objc2-encode-4.1.0.crate",
-		"sha256": "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33",
-		"dest": "cargo/vendor/objc2-encode-4.1.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33\", \"files\": {}}",
-		"dest": "cargo/vendor/objc2-encode-4.1.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/objc2-exception-helper/objc2-exception-helper-0.1.1.crate",
-		"sha256": "c7a1c5fbb72d7735b076bb47b578523aedc40f3c439bea6dfd595c089d79d98a",
-		"dest": "cargo/vendor/objc2-exception-helper-0.1.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"c7a1c5fbb72d7735b076bb47b578523aedc40f3c439bea6dfd595c089d79d98a\", \"files\": {}}",
-		"dest": "cargo/vendor/objc2-exception-helper-0.1.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/objc2-foundation/objc2-foundation-0.3.2.crate",
-		"sha256": "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272",
-		"dest": "cargo/vendor/objc2-foundation-0.3.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272\", \"files\": {}}",
-		"dest": "cargo/vendor/objc2-foundation-0.3.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/objc2-io-surface/objc2-io-surface-0.3.2.crate",
-		"sha256": "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d",
-		"dest": "cargo/vendor/objc2-io-surface-0.3.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d\", \"files\": {}}",
-		"dest": "cargo/vendor/objc2-io-surface-0.3.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/objc2-javascript-core/objc2-javascript-core-0.3.2.crate",
-		"sha256": "2a1e6550c4caed348956ce3370c9ffeca70bb1dbed4fa96112e7c6170e074586",
-		"dest": "cargo/vendor/objc2-javascript-core-0.3.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"2a1e6550c4caed348956ce3370c9ffeca70bb1dbed4fa96112e7c6170e074586\", \"files\": {}}",
-		"dest": "cargo/vendor/objc2-javascript-core-0.3.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/objc2-osa-kit/objc2-osa-kit-0.3.2.crate",
-		"sha256": "f112d1746737b0da274ef79a23aac283376f335f4095a083a267a082f21db0c0",
-		"dest": "cargo/vendor/objc2-osa-kit-0.3.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"f112d1746737b0da274ef79a23aac283376f335f4095a083a267a082f21db0c0\", \"files\": {}}",
-		"dest": "cargo/vendor/objc2-osa-kit-0.3.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/objc2-quartz-core/objc2-quartz-core-0.3.2.crate",
-		"sha256": "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f",
-		"dest": "cargo/vendor/objc2-quartz-core-0.3.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f\", \"files\": {}}",
-		"dest": "cargo/vendor/objc2-quartz-core-0.3.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/objc2-security/objc2-security-0.3.2.crate",
-		"sha256": "709fe137109bd1e8b5a99390f77a7d8b2961dafc1a1c5db8f2e60329ad6d895a",
-		"dest": "cargo/vendor/objc2-security-0.3.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"709fe137109bd1e8b5a99390f77a7d8b2961dafc1a1c5db8f2e60329ad6d895a\", \"files\": {}}",
-		"dest": "cargo/vendor/objc2-security-0.3.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/objc2-security-foundation/objc2-security-foundation-0.3.2.crate",
-		"sha256": "ef76382e9cedd18123099f17638715cc3d81dba3637d4c0d39ab69df2ef345a5",
-		"dest": "cargo/vendor/objc2-security-foundation-0.3.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"ef76382e9cedd18123099f17638715cc3d81dba3637d4c0d39ab69df2ef345a5\", \"files\": {}}",
-		"dest": "cargo/vendor/objc2-security-foundation-0.3.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/objc2-system-configuration/objc2-system-configuration-0.3.2.crate",
-		"sha256": "7216bd11cbda54ccabcab84d523dc93b858ec75ecfb3a7d89513fa22464da396",
-		"dest": "cargo/vendor/objc2-system-configuration-0.3.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"7216bd11cbda54ccabcab84d523dc93b858ec75ecfb3a7d89513fa22464da396\", \"files\": {}}",
-		"dest": "cargo/vendor/objc2-system-configuration-0.3.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/objc2-ui-kit/objc2-ui-kit-0.3.2.crate",
-		"sha256": "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22",
-		"dest": "cargo/vendor/objc2-ui-kit-0.3.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22\", \"files\": {}}",
-		"dest": "cargo/vendor/objc2-ui-kit-0.3.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/objc2-user-notifications/objc2-user-notifications-0.3.2.crate",
-		"sha256": "9df9128cbbfef73cda168416ccf7f837b62737d748333bfe9ab71c245d76613e",
-		"dest": "cargo/vendor/objc2-user-notifications-0.3.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"9df9128cbbfef73cda168416ccf7f837b62737d748333bfe9ab71c245d76613e\", \"files\": {}}",
-		"dest": "cargo/vendor/objc2-user-notifications-0.3.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/objc2-web-kit/objc2-web-kit-0.3.2.crate",
-		"sha256": "b2e5aaab980c433cf470df9d7af96a7b46a9d892d521a2cbbb2f8a4c16751e7f",
-		"dest": "cargo/vendor/objc2-web-kit-0.3.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"b2e5aaab980c433cf470df9d7af96a7b46a9d892d521a2cbbb2f8a4c16751e7f\", \"files\": {}}",
-		"dest": "cargo/vendor/objc2-web-kit-0.3.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/oid-registry/oid-registry-0.8.1.crate",
-		"sha256": "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7",
-		"dest": "cargo/vendor/oid-registry-0.8.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7\", \"files\": {}}",
-		"dest": "cargo/vendor/oid-registry-0.8.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/once_cell/once_cell-1.21.4.crate",
-		"sha256": "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50",
-		"dest": "cargo/vendor/once_cell-1.21.4"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50\", \"files\": {}}",
-		"dest": "cargo/vendor/once_cell-1.21.4",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/once_cell_polyfill/once_cell_polyfill-1.70.2.crate",
-		"sha256": "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe",
-		"dest": "cargo/vendor/once_cell_polyfill-1.70.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe\", \"files\": {}}",
-		"dest": "cargo/vendor/once_cell_polyfill-1.70.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/opaque-debug/opaque-debug-0.3.1.crate",
-		"sha256": "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381",
-		"dest": "cargo/vendor/opaque-debug-0.3.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381\", \"files\": {}}",
-		"dest": "cargo/vendor/opaque-debug-0.3.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/open/open-5.3.6.crate",
-		"sha256": "cd8d3b65c44123a56e0133d2cd06ce4361bd3ca99d41198b2f25e3c3db9b8b4a",
-		"dest": "cargo/vendor/open-5.3.6"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"cd8d3b65c44123a56e0133d2cd06ce4361bd3ca99d41198b2f25e3c3db9b8b4a\", \"files\": {}}",
-		"dest": "cargo/vendor/open-5.3.6",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/openssl-probe/openssl-probe-0.2.1.crate",
-		"sha256": "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe",
-		"dest": "cargo/vendor/openssl-probe-0.2.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe\", \"files\": {}}",
-		"dest": "cargo/vendor/openssl-probe-0.2.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/option-ext/option-ext-0.2.0.crate",
-		"sha256": "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d",
-		"dest": "cargo/vendor/option-ext-0.2.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d\", \"files\": {}}",
-		"dest": "cargo/vendor/option-ext-0.2.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/option-operations/option-operations-0.5.0.crate",
-		"sha256": "7c26d27bb1aeab65138e4bf7666045169d1717febcc9ff870166be8348b223d0",
-		"dest": "cargo/vendor/option-operations-0.5.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"7c26d27bb1aeab65138e4bf7666045169d1717febcc9ff870166be8348b223d0\", \"files\": {}}",
-		"dest": "cargo/vendor/option-operations-0.5.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/ordered-stream/ordered-stream-0.2.0.crate",
-		"sha256": "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50",
-		"dest": "cargo/vendor/ordered-stream-0.2.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50\", \"files\": {}}",
-		"dest": "cargo/vendor/ordered-stream-0.2.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/os_info/os_info-3.15.0.crate",
-		"sha256": "9cf20a545b305cf1da722b236b5155c9bb35f1d5ceb28c048bd96ca842f41b5b",
-		"dest": "cargo/vendor/os_info-3.15.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"9cf20a545b305cf1da722b236b5155c9bb35f1d5ceb28c048bd96ca842f41b5b\", \"files\": {}}",
-		"dest": "cargo/vendor/os_info-3.15.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/osakit/osakit-0.3.1.crate",
-		"sha256": "732c71caeaa72c065bb69d7ea08717bd3f4863a4f451402fc9513e29dbd5261b",
-		"dest": "cargo/vendor/osakit-0.3.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"732c71caeaa72c065bb69d7ea08717bd3f4863a4f451402fc9513e29dbd5261b\", \"files\": {}}",
-		"dest": "cargo/vendor/osakit-0.3.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/pango/pango-0.18.3.crate",
-		"sha256": "7ca27ec1eb0457ab26f3036ea52229edbdb74dee1edd29063f5b9b010e7ebee4",
-		"dest": "cargo/vendor/pango-0.18.3"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"7ca27ec1eb0457ab26f3036ea52229edbdb74dee1edd29063f5b9b010e7ebee4\", \"files\": {}}",
-		"dest": "cargo/vendor/pango-0.18.3",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/pango-sys/pango-sys-0.18.0.crate",
-		"sha256": "436737e391a843e5933d6d9aa102cb126d501e815b83601365a948a518555dc5",
-		"dest": "cargo/vendor/pango-sys-0.18.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"436737e391a843e5933d6d9aa102cb126d501e815b83601365a948a518555dc5\", \"files\": {}}",
-		"dest": "cargo/vendor/pango-sys-0.18.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/papaya/papaya-0.2.4.crate",
-		"sha256": "997ee03cd38c01469a7046643714f0ad28880bcb9e6679ff0666e24817ca19b7",
-		"dest": "cargo/vendor/papaya-0.2.4"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"997ee03cd38c01469a7046643714f0ad28880bcb9e6679ff0666e24817ca19b7\", \"files\": {}}",
-		"dest": "cargo/vendor/papaya-0.2.4",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/parking/parking-2.2.1.crate",
-		"sha256": "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba",
-		"dest": "cargo/vendor/parking-2.2.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba\", \"files\": {}}",
-		"dest": "cargo/vendor/parking-2.2.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/parking_lot/parking_lot-0.12.5.crate",
-		"sha256": "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a",
-		"dest": "cargo/vendor/parking_lot-0.12.5"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a\", \"files\": {}}",
-		"dest": "cargo/vendor/parking_lot-0.12.5",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/parking_lot_core/parking_lot_core-0.9.12.crate",
-		"sha256": "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1",
-		"dest": "cargo/vendor/parking_lot_core-0.9.12"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1\", \"files\": {}}",
-		"dest": "cargo/vendor/parking_lot_core-0.9.12",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/paste/paste-1.0.15.crate",
-		"sha256": "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a",
-		"dest": "cargo/vendor/paste-1.0.15"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a\", \"files\": {}}",
-		"dest": "cargo/vendor/paste-1.0.15",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/pastey/pastey-0.1.1.crate",
-		"sha256": "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec",
-		"dest": "cargo/vendor/pastey-0.1.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec\", \"files\": {}}",
-		"dest": "cargo/vendor/pastey-0.1.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/pem/pem-3.0.6.crate",
-		"sha256": "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be",
-		"dest": "cargo/vendor/pem-3.0.6"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be\", \"files\": {}}",
-		"dest": "cargo/vendor/pem-3.0.6",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/pem-rfc7468/pem-rfc7468-1.0.0.crate",
-		"sha256": "a6305423e0e7738146434843d1694d621cce767262b2a86910beab705e4493d9",
-		"dest": "cargo/vendor/pem-rfc7468-1.0.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"a6305423e0e7738146434843d1694d621cce767262b2a86910beab705e4493d9\", \"files\": {}}",
-		"dest": "cargo/vendor/pem-rfc7468-1.0.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/percent-encoding/percent-encoding-2.3.2.crate",
-		"sha256": "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220",
-		"dest": "cargo/vendor/percent-encoding-2.3.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220\", \"files\": {}}",
-		"dest": "cargo/vendor/percent-encoding-2.3.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/pharos/pharos-0.5.3.crate",
-		"sha256": "e9567389417feee6ce15dd6527a8a1ecac205ef62c2932bcf3d9f6fc5b78b414",
-		"dest": "cargo/vendor/pharos-0.5.3"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"e9567389417feee6ce15dd6527a8a1ecac205ef62c2932bcf3d9f6fc5b78b414\", \"files\": {}}",
-		"dest": "cargo/vendor/pharos-0.5.3",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/phf/phf-0.8.0.crate",
-		"sha256": "3dfb61232e34fcb633f43d12c58f83c1df82962dcdfa565a4e866ffc17dafe12",
-		"dest": "cargo/vendor/phf-0.8.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"3dfb61232e34fcb633f43d12c58f83c1df82962dcdfa565a4e866ffc17dafe12\", \"files\": {}}",
-		"dest": "cargo/vendor/phf-0.8.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/phf/phf-0.10.1.crate",
-		"sha256": "fabbf1ead8a5bcbc20f5f8b939ee3f5b0f6f281b6ad3468b84656b658b455259",
-		"dest": "cargo/vendor/phf-0.10.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"fabbf1ead8a5bcbc20f5f8b939ee3f5b0f6f281b6ad3468b84656b658b455259\", \"files\": {}}",
-		"dest": "cargo/vendor/phf-0.10.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/phf/phf-0.11.3.crate",
-		"sha256": "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078",
-		"dest": "cargo/vendor/phf-0.11.3"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078\", \"files\": {}}",
-		"dest": "cargo/vendor/phf-0.11.3",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/phf/phf-0.13.1.crate",
-		"sha256": "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf",
-		"dest": "cargo/vendor/phf-0.13.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf\", \"files\": {}}",
-		"dest": "cargo/vendor/phf-0.13.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/phf_codegen/phf_codegen-0.8.0.crate",
-		"sha256": "cbffee61585b0411840d3ece935cce9cb6321f01c45477d30066498cd5e1a815",
-		"dest": "cargo/vendor/phf_codegen-0.8.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"cbffee61585b0411840d3ece935cce9cb6321f01c45477d30066498cd5e1a815\", \"files\": {}}",
-		"dest": "cargo/vendor/phf_codegen-0.8.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/phf_codegen/phf_codegen-0.11.3.crate",
-		"sha256": "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a",
-		"dest": "cargo/vendor/phf_codegen-0.11.3"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a\", \"files\": {}}",
-		"dest": "cargo/vendor/phf_codegen-0.11.3",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/phf_codegen/phf_codegen-0.13.1.crate",
-		"sha256": "49aa7f9d80421bca176ca8dbfebe668cc7a2684708594ec9f3c0db0805d5d6e1",
-		"dest": "cargo/vendor/phf_codegen-0.13.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"49aa7f9d80421bca176ca8dbfebe668cc7a2684708594ec9f3c0db0805d5d6e1\", \"files\": {}}",
-		"dest": "cargo/vendor/phf_codegen-0.13.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/phf_generator/phf_generator-0.8.0.crate",
-		"sha256": "17367f0cc86f2d25802b2c26ee58a7b23faeccf78a396094c13dced0d0182526",
-		"dest": "cargo/vendor/phf_generator-0.8.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"17367f0cc86f2d25802b2c26ee58a7b23faeccf78a396094c13dced0d0182526\", \"files\": {}}",
-		"dest": "cargo/vendor/phf_generator-0.8.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/phf_generator/phf_generator-0.10.0.crate",
-		"sha256": "5d5285893bb5eb82e6aaf5d59ee909a06a16737a8970984dd7746ba9283498d6",
-		"dest": "cargo/vendor/phf_generator-0.10.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"5d5285893bb5eb82e6aaf5d59ee909a06a16737a8970984dd7746ba9283498d6\", \"files\": {}}",
-		"dest": "cargo/vendor/phf_generator-0.10.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/phf_generator/phf_generator-0.11.3.crate",
-		"sha256": "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d",
-		"dest": "cargo/vendor/phf_generator-0.11.3"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d\", \"files\": {}}",
-		"dest": "cargo/vendor/phf_generator-0.11.3",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/phf_generator/phf_generator-0.13.1.crate",
-		"sha256": "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737",
-		"dest": "cargo/vendor/phf_generator-0.13.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737\", \"files\": {}}",
-		"dest": "cargo/vendor/phf_generator-0.13.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/phf_macros/phf_macros-0.10.0.crate",
-		"sha256": "58fdf3184dd560f160dd73922bea2d5cd6e8f064bf4b13110abd81b03697b4e0",
-		"dest": "cargo/vendor/phf_macros-0.10.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"58fdf3184dd560f160dd73922bea2d5cd6e8f064bf4b13110abd81b03697b4e0\", \"files\": {}}",
-		"dest": "cargo/vendor/phf_macros-0.10.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/phf_macros/phf_macros-0.13.1.crate",
-		"sha256": "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef",
-		"dest": "cargo/vendor/phf_macros-0.13.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef\", \"files\": {}}",
-		"dest": "cargo/vendor/phf_macros-0.13.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/phf_shared/phf_shared-0.8.0.crate",
-		"sha256": "c00cf8b9eafe68dde5e9eaa2cef8ee84a9336a47d566ec55ca16589633b65af7",
-		"dest": "cargo/vendor/phf_shared-0.8.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"c00cf8b9eafe68dde5e9eaa2cef8ee84a9336a47d566ec55ca16589633b65af7\", \"files\": {}}",
-		"dest": "cargo/vendor/phf_shared-0.8.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/phf_shared/phf_shared-0.10.0.crate",
-		"sha256": "b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096",
-		"dest": "cargo/vendor/phf_shared-0.10.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096\", \"files\": {}}",
-		"dest": "cargo/vendor/phf_shared-0.10.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/phf_shared/phf_shared-0.11.3.crate",
-		"sha256": "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5",
-		"dest": "cargo/vendor/phf_shared-0.11.3"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5\", \"files\": {}}",
-		"dest": "cargo/vendor/phf_shared-0.11.3",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/phf_shared/phf_shared-0.13.1.crate",
-		"sha256": "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266",
-		"dest": "cargo/vendor/phf_shared-0.13.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266\", \"files\": {}}",
-		"dest": "cargo/vendor/phf_shared-0.13.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/pin-project/pin-project-1.1.13.crate",
-		"sha256": "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924",
-		"dest": "cargo/vendor/pin-project-1.1.13"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924\", \"files\": {}}",
-		"dest": "cargo/vendor/pin-project-1.1.13",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/pin-project-internal/pin-project-internal-1.1.13.crate",
-		"sha256": "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b",
-		"dest": "cargo/vendor/pin-project-internal-1.1.13"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b\", \"files\": {}}",
-		"dest": "cargo/vendor/pin-project-internal-1.1.13",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/pin-project-lite/pin-project-lite-0.2.17.crate",
-		"sha256": "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd",
-		"dest": "cargo/vendor/pin-project-lite-0.2.17"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd\", \"files\": {}}",
-		"dest": "cargo/vendor/pin-project-lite-0.2.17",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/piper/piper-0.2.5.crate",
-		"sha256": "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1",
-		"dest": "cargo/vendor/piper-0.2.5"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1\", \"files\": {}}",
-		"dest": "cargo/vendor/piper-0.2.5",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/pkcs8/pkcs8-0.11.0.crate",
-		"sha256": "451913da69c775a56034ea8d9003d27ee8948e12443eae7c038ba100a4f21cb7",
-		"dest": "cargo/vendor/pkcs8-0.11.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"451913da69c775a56034ea8d9003d27ee8948e12443eae7c038ba100a4f21cb7\", \"files\": {}}",
-		"dest": "cargo/vendor/pkcs8-0.11.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/pkg-config/pkg-config-0.3.33.crate",
-		"sha256": "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e",
-		"dest": "cargo/vendor/pkg-config-0.3.33"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e\", \"files\": {}}",
-		"dest": "cargo/vendor/pkg-config-0.3.33",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/plist/plist-1.10.0.crate",
-		"sha256": "7da1d65da6dd5d1e44199ac0f58712d241c0f439f80adea8924d832384087f85",
-		"dest": "cargo/vendor/plist-1.10.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"7da1d65da6dd5d1e44199ac0f58712d241c0f439f80adea8924d832384087f85\", \"files\": {}}",
-		"dest": "cargo/vendor/plist-1.10.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/png/png-0.17.16.crate",
-		"sha256": "82151a2fc869e011c153adc57cf2789ccb8d9906ce52c0b39a6b5697749d7526",
-		"dest": "cargo/vendor/png-0.17.16"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"82151a2fc869e011c153adc57cf2789ccb8d9906ce52c0b39a6b5697749d7526\", \"files\": {}}",
-		"dest": "cargo/vendor/png-0.17.16",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/png/png-0.18.1.crate",
-		"sha256": "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61",
-		"dest": "cargo/vendor/png-0.18.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61\", \"files\": {}}",
-		"dest": "cargo/vendor/png-0.18.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/polling/polling-3.11.0.crate",
-		"sha256": "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218",
-		"dest": "cargo/vendor/polling-3.11.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218\", \"files\": {}}",
-		"dest": "cargo/vendor/polling-3.11.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/pollster/pollster-0.4.0.crate",
-		"sha256": "2f3a9f18d041e6d0e102a0a46750538147e5e8992d3b4873aaafee2520b00ce3",
-		"dest": "cargo/vendor/pollster-0.4.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"2f3a9f18d041e6d0e102a0a46750538147e5e8992d3b4873aaafee2520b00ce3\", \"files\": {}}",
-		"dest": "cargo/vendor/pollster-0.4.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/polyval/polyval-0.6.2.crate",
-		"sha256": "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25",
-		"dest": "cargo/vendor/polyval-0.6.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25\", \"files\": {}}",
-		"dest": "cargo/vendor/polyval-0.6.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/portable-atomic/portable-atomic-1.13.1.crate",
-		"sha256": "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49",
-		"dest": "cargo/vendor/portable-atomic-1.13.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49\", \"files\": {}}",
-		"dest": "cargo/vendor/portable-atomic-1.13.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/portmapper/portmapper-0.19.1.crate",
-		"sha256": "eb3713e4977408279158444a18c1a01ac9bf2e7eaf1fbfd1a19ac9cd18d90721",
-		"dest": "cargo/vendor/portmapper-0.19.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"eb3713e4977408279158444a18c1a01ac9bf2e7eaf1fbfd1a19ac9cd18d90721\", \"files\": {}}",
-		"dest": "cargo/vendor/portmapper-0.19.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/positioned-io/positioned-io-0.3.5.crate",
-		"sha256": "d4ec4b80060f033312b99b6874025d9503d2af87aef2dd4c516e253fbfcdada7",
-		"dest": "cargo/vendor/positioned-io-0.3.5"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"d4ec4b80060f033312b99b6874025d9503d2af87aef2dd4c516e253fbfcdada7\", \"files\": {}}",
-		"dest": "cargo/vendor/positioned-io-0.3.5",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/postcard/postcard-1.1.3.crate",
-		"sha256": "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24",
-		"dest": "cargo/vendor/postcard-1.1.3"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24\", \"files\": {}}",
-		"dest": "cargo/vendor/postcard-1.1.3",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/postcard-derive/postcard-derive-0.2.2.crate",
-		"sha256": "e0232bd009a197ceec9cc881ba46f727fcd8060a2d8d6a9dde7a69030a6fe2bb",
-		"dest": "cargo/vendor/postcard-derive-0.2.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"e0232bd009a197ceec9cc881ba46f727fcd8060a2d8d6a9dde7a69030a6fe2bb\", \"files\": {}}",
-		"dest": "cargo/vendor/postcard-derive-0.2.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/potential_utf/potential_utf-0.1.5.crate",
-		"sha256": "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564",
-		"dest": "cargo/vendor/potential_utf-0.1.5"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564\", \"files\": {}}",
-		"dest": "cargo/vendor/potential_utf-0.1.5",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/powerfmt/powerfmt-0.2.0.crate",
-		"sha256": "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391",
-		"dest": "cargo/vendor/powerfmt-0.2.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391\", \"files\": {}}",
-		"dest": "cargo/vendor/powerfmt-0.2.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/ppv-lite86/ppv-lite86-0.2.21.crate",
-		"sha256": "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9",
-		"dest": "cargo/vendor/ppv-lite86-0.2.21"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9\", \"files\": {}}",
-		"dest": "cargo/vendor/ppv-lite86-0.2.21",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/precomputed-hash/precomputed-hash-0.1.1.crate",
-		"sha256": "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c",
-		"dest": "cargo/vendor/precomputed-hash-0.1.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c\", \"files\": {}}",
-		"dest": "cargo/vendor/precomputed-hash-0.1.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/prefix-trie/prefix-trie-0.8.4.crate",
-		"sha256": "4cf6e3177f0684016a5c209b00882e15f8bdd3f3bb48f0491df10cd102d0c6e7",
-		"dest": "cargo/vendor/prefix-trie-0.8.4"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"4cf6e3177f0684016a5c209b00882e15f8bdd3f3bb48f0491df10cd102d0c6e7\", \"files\": {}}",
-		"dest": "cargo/vendor/prefix-trie-0.8.4",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/proc-macro-crate/proc-macro-crate-1.3.1.crate",
-		"sha256": "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919",
-		"dest": "cargo/vendor/proc-macro-crate-1.3.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919\", \"files\": {}}",
-		"dest": "cargo/vendor/proc-macro-crate-1.3.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/proc-macro-crate/proc-macro-crate-2.0.2.crate",
-		"sha256": "b00f26d3400549137f92511a46ac1cd8ce37cb5598a96d382381458b992a5d24",
-		"dest": "cargo/vendor/proc-macro-crate-2.0.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"b00f26d3400549137f92511a46ac1cd8ce37cb5598a96d382381458b992a5d24\", \"files\": {}}",
-		"dest": "cargo/vendor/proc-macro-crate-2.0.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/proc-macro-crate/proc-macro-crate-3.5.0.crate",
-		"sha256": "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f",
-		"dest": "cargo/vendor/proc-macro-crate-3.5.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f\", \"files\": {}}",
-		"dest": "cargo/vendor/proc-macro-crate-3.5.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/proc-macro-error/proc-macro-error-0.4.12.crate",
-		"sha256": "18f33027081eba0a6d8aba6d1b1c3a3be58cbb12106341c2d5759fcd9b5277e7",
-		"dest": "cargo/vendor/proc-macro-error-0.4.12"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"18f33027081eba0a6d8aba6d1b1c3a3be58cbb12106341c2d5759fcd9b5277e7\", \"files\": {}}",
-		"dest": "cargo/vendor/proc-macro-error-0.4.12",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/proc-macro-error/proc-macro-error-1.0.4.crate",
-		"sha256": "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c",
-		"dest": "cargo/vendor/proc-macro-error-1.0.4"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c\", \"files\": {}}",
-		"dest": "cargo/vendor/proc-macro-error-1.0.4",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/proc-macro-error-attr/proc-macro-error-attr-0.4.12.crate",
-		"sha256": "8a5b4b77fdb63c1eca72173d68d24501c54ab1269409f6b672c85deb18af69de",
-		"dest": "cargo/vendor/proc-macro-error-attr-0.4.12"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"8a5b4b77fdb63c1eca72173d68d24501c54ab1269409f6b672c85deb18af69de\", \"files\": {}}",
-		"dest": "cargo/vendor/proc-macro-error-attr-0.4.12",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/proc-macro-error-attr/proc-macro-error-attr-1.0.4.crate",
-		"sha256": "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869",
-		"dest": "cargo/vendor/proc-macro-error-attr-1.0.4"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869\", \"files\": {}}",
-		"dest": "cargo/vendor/proc-macro-error-attr-1.0.4",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/proc-macro-hack/proc-macro-hack-0.5.20+deprecated.crate",
-		"sha256": "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068",
-		"dest": "cargo/vendor/proc-macro-hack-0.5.20+deprecated"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068\", \"files\": {}}",
-		"dest": "cargo/vendor/proc-macro-hack-0.5.20+deprecated",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/proc-macro2/proc-macro2-1.0.106.crate",
-		"sha256": "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934",
-		"dest": "cargo/vendor/proc-macro2-1.0.106"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934\", \"files\": {}}",
-		"dest": "cargo/vendor/proc-macro2-1.0.106",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/profiling/profiling-1.0.18.crate",
-		"sha256": "3d595e54a326bc53c1c197b32d295e14b169e3cfeaa8dc82b529f947fba6bcf5",
-		"dest": "cargo/vendor/profiling-1.0.18"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"3d595e54a326bc53c1c197b32d295e14b169e3cfeaa8dc82b529f947fba6bcf5\", \"files\": {}}",
-		"dest": "cargo/vendor/profiling-1.0.18",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/profiling-procmacros/profiling-procmacros-1.0.18.crate",
-		"sha256": "4488a4a36b9a4ba6b9334a32a39971f77c1436ec82c38707bce707699cc3bbcb",
-		"dest": "cargo/vendor/profiling-procmacros-1.0.18"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"4488a4a36b9a4ba6b9334a32a39971f77c1436ec82c38707bce707699cc3bbcb\", \"files\": {}}",
-		"dest": "cargo/vendor/profiling-procmacros-1.0.18",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/pulp/pulp-0.22.3.crate",
-		"sha256": "046aa45b989642ec2e4717c8e72d677b13edd831a4d3b6cf37d9a3e54912496a",
-		"dest": "cargo/vendor/pulp-0.22.3"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"046aa45b989642ec2e4717c8e72d677b13edd831a4d3b6cf37d9a3e54912496a\", \"files\": {}}",
-		"dest": "cargo/vendor/pulp-0.22.3",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/pulp-wasm-simd-flag/pulp-wasm-simd-flag-0.1.1.crate",
-		"sha256": "1d8f70e07b9c3962945a74e59ca1c511bba65b6419468acc217c457d93f3c740",
-		"dest": "cargo/vendor/pulp-wasm-simd-flag-0.1.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"1d8f70e07b9c3962945a74e59ca1c511bba65b6419468acc217c457d93f3c740\", \"files\": {}}",
-		"dest": "cargo/vendor/pulp-wasm-simd-flag-0.1.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/pxfm/pxfm-0.1.30.crate",
-		"sha256": "d55d956fa96f5ec02be2e13af0e20391a5aa83d6a074e3ad368959d0fab299ea",
-		"dest": "cargo/vendor/pxfm-0.1.30"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"d55d956fa96f5ec02be2e13af0e20391a5aa83d6a074e3ad368959d0fab299ea\", \"files\": {}}",
-		"dest": "cargo/vendor/pxfm-0.1.30",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/qoi/qoi-0.4.1.crate",
-		"sha256": "7f6d64c71eb498fe9eae14ce4ec935c555749aef511cca85b5568910d6e48001",
-		"dest": "cargo/vendor/qoi-0.4.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"7f6d64c71eb498fe9eae14ce4ec935c555749aef511cca85b5568910d6e48001\", \"files\": {}}",
-		"dest": "cargo/vendor/qoi-0.4.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/quick-error/quick-error-2.0.1.crate",
-		"sha256": "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3",
-		"dest": "cargo/vendor/quick-error-2.0.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3\", \"files\": {}}",
-		"dest": "cargo/vendor/quick-error-2.0.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/quick-xml/quick-xml-0.41.0.crate",
-		"sha256": "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1",
-		"dest": "cargo/vendor/quick-xml-0.41.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1\", \"files\": {}}",
-		"dest": "cargo/vendor/quick-xml-0.41.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/quinn/quinn-0.11.11.crate",
-		"sha256": "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8",
-		"dest": "cargo/vendor/quinn-0.11.11"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8\", \"files\": {}}",
-		"dest": "cargo/vendor/quinn-0.11.11",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/quinn-proto/quinn-proto-0.11.16.crate",
-		"sha256": "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560",
-		"dest": "cargo/vendor/quinn-proto-0.11.16"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560\", \"files\": {}}",
-		"dest": "cargo/vendor/quinn-proto-0.11.16",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/quinn-udp/quinn-udp-0.5.15.crate",
-		"sha256": "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694",
-		"dest": "cargo/vendor/quinn-udp-0.5.15"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694\", \"files\": {}}",
-		"dest": "cargo/vendor/quinn-udp-0.5.15",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/quote/quote-1.0.46.crate",
-		"sha256": "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368",
-		"dest": "cargo/vendor/quote-1.0.46"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368\", \"files\": {}}",
-		"dest": "cargo/vendor/quote-1.0.46",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/r-efi/r-efi-5.3.0.crate",
-		"sha256": "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f",
-		"dest": "cargo/vendor/r-efi-5.3.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f\", \"files\": {}}",
-		"dest": "cargo/vendor/r-efi-5.3.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/r-efi/r-efi-6.0.0.crate",
-		"sha256": "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf",
-		"dest": "cargo/vendor/r-efi-6.0.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf\", \"files\": {}}",
-		"dest": "cargo/vendor/r-efi-6.0.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/rand/rand-0.7.3.crate",
-		"sha256": "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03",
-		"dest": "cargo/vendor/rand-0.7.3"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03\", \"files\": {}}",
-		"dest": "cargo/vendor/rand-0.7.3",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/rand/rand-0.8.6.crate",
-		"sha256": "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a",
-		"dest": "cargo/vendor/rand-0.8.6"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a\", \"files\": {}}",
-		"dest": "cargo/vendor/rand-0.8.6",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/rand/rand-0.9.4.crate",
-		"sha256": "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea",
-		"dest": "cargo/vendor/rand-0.9.4"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea\", \"files\": {}}",
-		"dest": "cargo/vendor/rand-0.9.4",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/rand/rand-0.10.2.crate",
-		"sha256": "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80",
-		"dest": "cargo/vendor/rand-0.10.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80\", \"files\": {}}",
-		"dest": "cargo/vendor/rand-0.10.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/rand_chacha/rand_chacha-0.2.2.crate",
-		"sha256": "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402",
-		"dest": "cargo/vendor/rand_chacha-0.2.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402\", \"files\": {}}",
-		"dest": "cargo/vendor/rand_chacha-0.2.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/rand_chacha/rand_chacha-0.3.1.crate",
-		"sha256": "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88",
-		"dest": "cargo/vendor/rand_chacha-0.3.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88\", \"files\": {}}",
-		"dest": "cargo/vendor/rand_chacha-0.3.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/rand_chacha/rand_chacha-0.9.0.crate",
-		"sha256": "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb",
-		"dest": "cargo/vendor/rand_chacha-0.9.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb\", \"files\": {}}",
-		"dest": "cargo/vendor/rand_chacha-0.9.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/rand_core/rand_core-0.5.1.crate",
-		"sha256": "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19",
-		"dest": "cargo/vendor/rand_core-0.5.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19\", \"files\": {}}",
-		"dest": "cargo/vendor/rand_core-0.5.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/rand_core/rand_core-0.6.4.crate",
-		"sha256": "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c",
-		"dest": "cargo/vendor/rand_core-0.6.4"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c\", \"files\": {}}",
-		"dest": "cargo/vendor/rand_core-0.6.4",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/rand_core/rand_core-0.9.5.crate",
-		"sha256": "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c",
-		"dest": "cargo/vendor/rand_core-0.9.5"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c\", \"files\": {}}",
-		"dest": "cargo/vendor/rand_core-0.9.5",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/rand_core/rand_core-0.10.1.crate",
-		"sha256": "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69",
-		"dest": "cargo/vendor/rand_core-0.10.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69\", \"files\": {}}",
-		"dest": "cargo/vendor/rand_core-0.10.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/rand_hc/rand_hc-0.2.0.crate",
-		"sha256": "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c",
-		"dest": "cargo/vendor/rand_hc-0.2.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c\", \"files\": {}}",
-		"dest": "cargo/vendor/rand_hc-0.2.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/rand_pcg/rand_pcg-0.2.1.crate",
-		"sha256": "16abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429",
-		"dest": "cargo/vendor/rand_pcg-0.2.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"16abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429\", \"files\": {}}",
-		"dest": "cargo/vendor/rand_pcg-0.2.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/rand_pcg/rand_pcg-0.10.2.crate",
-		"sha256": "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a",
-		"dest": "cargo/vendor/rand_pcg-0.10.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a\", \"files\": {}}",
-		"dest": "cargo/vendor/rand_pcg-0.10.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/range-collections/range-collections-0.4.6.crate",
-		"sha256": "861706ea9c4aded7584c5cd1d241cec2ea7f5f50999f236c22b65409a1f1a0d0",
-		"dest": "cargo/vendor/range-collections-0.4.6"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"861706ea9c4aded7584c5cd1d241cec2ea7f5f50999f236c22b65409a1f1a0d0\", \"files\": {}}",
-		"dest": "cargo/vendor/range-collections-0.4.6",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/rav1e/rav1e-0.8.1.crate",
-		"sha256": "43b6dd56e85d9483277cde964fd1bdb0428de4fec5ebba7540995639a21cb32b",
-		"dest": "cargo/vendor/rav1e-0.8.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"43b6dd56e85d9483277cde964fd1bdb0428de4fec5ebba7540995639a21cb32b\", \"files\": {}}",
-		"dest": "cargo/vendor/rav1e-0.8.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/ravif/ravif-0.13.0.crate",
-		"sha256": "e52310197d971b0f5be7fe6b57530dcd27beb35c1b013f29d66c1ad73fbbcc45",
-		"dest": "cargo/vendor/ravif-0.13.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"e52310197d971b0f5be7fe6b57530dcd27beb35c1b013f29d66c1ad73fbbcc45\", \"files\": {}}",
-		"dest": "cargo/vendor/ravif-0.13.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/raw-cpuid/raw-cpuid-11.6.0.crate",
-		"sha256": "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186",
-		"dest": "cargo/vendor/raw-cpuid-11.6.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186\", \"files\": {}}",
-		"dest": "cargo/vendor/raw-cpuid-11.6.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/raw-window-handle/raw-window-handle-0.6.2.crate",
-		"sha256": "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539",
-		"dest": "cargo/vendor/raw-window-handle-0.6.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539\", \"files\": {}}",
-		"dest": "cargo/vendor/raw-window-handle-0.6.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/rayon/rayon-1.12.0.crate",
-		"sha256": "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d",
-		"dest": "cargo/vendor/rayon-1.12.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d\", \"files\": {}}",
-		"dest": "cargo/vendor/rayon-1.12.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/rayon-core/rayon-core-1.13.0.crate",
-		"sha256": "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91",
-		"dest": "cargo/vendor/rayon-core-1.13.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91\", \"files\": {}}",
-		"dest": "cargo/vendor/rayon-core-1.13.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/rcgen/rcgen-0.14.8.crate",
-		"sha256": "57f6d249aad744e274e682777a50283a225a32705394ee6d5fcc01efa25e4055",
-		"dest": "cargo/vendor/rcgen-0.14.8"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"57f6d249aad744e274e682777a50283a225a32705394ee6d5fcc01efa25e4055\", \"files\": {}}",
-		"dest": "cargo/vendor/rcgen-0.14.8",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/reborrow/reborrow-0.5.5.crate",
-		"sha256": "03251193000f4bd3b042892be858ee50e8b3719f2b08e5833ac4353724632430",
-		"dest": "cargo/vendor/reborrow-0.5.5"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"03251193000f4bd3b042892be858ee50e8b3719f2b08e5833ac4353724632430\", \"files\": {}}",
-		"dest": "cargo/vendor/reborrow-0.5.5",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/redb/redb-4.1.0.crate",
-		"sha256": "8e925444704b5f17d32bf42f5b6e2df050bceebc3dcd6e71cc73dafe8092e839",
-		"dest": "cargo/vendor/redb-4.1.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"8e925444704b5f17d32bf42f5b6e2df050bceebc3dcd6e71cc73dafe8092e839\", \"files\": {}}",
-		"dest": "cargo/vendor/redb-4.1.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/redox_syscall/redox_syscall-0.5.18.crate",
-		"sha256": "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d",
-		"dest": "cargo/vendor/redox_syscall-0.5.18"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d\", \"files\": {}}",
-		"dest": "cargo/vendor/redox_syscall-0.5.18",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/redox_users/redox_users-0.5.2.crate",
-		"sha256": "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac",
-		"dest": "cargo/vendor/redox_users-0.5.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac\", \"files\": {}}",
-		"dest": "cargo/vendor/redox_users-0.5.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/ref-cast/ref-cast-1.0.25.crate",
-		"sha256": "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d",
-		"dest": "cargo/vendor/ref-cast-1.0.25"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d\", \"files\": {}}",
-		"dest": "cargo/vendor/ref-cast-1.0.25",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/ref-cast-impl/ref-cast-impl-1.0.25.crate",
-		"sha256": "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da",
-		"dest": "cargo/vendor/ref-cast-impl-1.0.25"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da\", \"files\": {}}",
-		"dest": "cargo/vendor/ref-cast-impl-1.0.25",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/reflink-copy/reflink-copy-0.1.30.crate",
-		"sha256": "d9dd7ab4af0363d5ccfd2838d782a28196cf32a5cc2e4fe3c5dc83f2be588b8b",
-		"dest": "cargo/vendor/reflink-copy-0.1.30"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"d9dd7ab4af0363d5ccfd2838d782a28196cf32a5cc2e4fe3c5dc83f2be588b8b\", \"files\": {}}",
-		"dest": "cargo/vendor/reflink-copy-0.1.30",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/regex/regex-1.12.4.crate",
-		"sha256": "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba",
-		"dest": "cargo/vendor/regex-1.12.4"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba\", \"files\": {}}",
-		"dest": "cargo/vendor/regex-1.12.4",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/regex-automata/regex-automata-0.4.14.crate",
-		"sha256": "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f",
-		"dest": "cargo/vendor/regex-automata-0.4.14"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f\", \"files\": {}}",
-		"dest": "cargo/vendor/regex-automata-0.4.14",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/regex-syntax/regex-syntax-0.8.11.crate",
-		"sha256": "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4",
-		"dest": "cargo/vendor/regex-syntax-0.8.11"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4\", \"files\": {}}",
-		"dest": "cargo/vendor/regex-syntax-0.8.11",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/reqwest/reqwest-0.13.4.crate",
-		"sha256": "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3",
-		"dest": "cargo/vendor/reqwest-0.13.4"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3\", \"files\": {}}",
-		"dest": "cargo/vendor/reqwest-0.13.4",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/resolv-conf/resolv-conf-0.7.6.crate",
-		"sha256": "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7",
-		"dest": "cargo/vendor/resolv-conf-0.7.6"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7\", \"files\": {}}",
-		"dest": "cargo/vendor/resolv-conf-0.7.6",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/rfd/rfd-0.16.0.crate",
-		"sha256": "a15ad77d9e70a92437d8f74c35d99b4e4691128df018833e99f90bcd36152672",
-		"dest": "cargo/vendor/rfd-0.16.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"a15ad77d9e70a92437d8f74c35d99b4e4691128df018833e99f90bcd36152672\", \"files\": {}}",
-		"dest": "cargo/vendor/rfd-0.16.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/rgb/rgb-0.8.53.crate",
-		"sha256": "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4",
-		"dest": "cargo/vendor/rgb-0.8.53"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4\", \"files\": {}}",
-		"dest": "cargo/vendor/rgb-0.8.53",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/ring/ring-0.17.14.crate",
-		"sha256": "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7",
-		"dest": "cargo/vendor/ring-0.17.14"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7\", \"files\": {}}",
-		"dest": "cargo/vendor/ring-0.17.14",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/rustc-hash/rustc-hash-2.1.3.crate",
-		"sha256": "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d",
-		"dest": "cargo/vendor/rustc-hash-2.1.3"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d\", \"files\": {}}",
-		"dest": "cargo/vendor/rustc-hash-2.1.3",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/rustc_version/rustc_version-0.4.1.crate",
-		"sha256": "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92",
-		"dest": "cargo/vendor/rustc_version-0.4.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92\", \"files\": {}}",
-		"dest": "cargo/vendor/rustc_version-0.4.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/rusticata-macros/rusticata-macros-4.1.0.crate",
-		"sha256": "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632",
-		"dest": "cargo/vendor/rusticata-macros-4.1.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632\", \"files\": {}}",
-		"dest": "cargo/vendor/rusticata-macros-4.1.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/rustix/rustix-1.1.4.crate",
-		"sha256": "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190",
-		"dest": "cargo/vendor/rustix-1.1.4"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190\", \"files\": {}}",
-		"dest": "cargo/vendor/rustix-1.1.4",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/rustls/rustls-0.23.41.crate",
-		"sha256": "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f",
-		"dest": "cargo/vendor/rustls-0.23.41"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f\", \"files\": {}}",
-		"dest": "cargo/vendor/rustls-0.23.41",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/rustls-native-certs/rustls-native-certs-0.8.4.crate",
-		"sha256": "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d",
-		"dest": "cargo/vendor/rustls-native-certs-0.8.4"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d\", \"files\": {}}",
-		"dest": "cargo/vendor/rustls-native-certs-0.8.4",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/rustls-pki-types/rustls-pki-types-1.15.0.crate",
-		"sha256": "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046",
-		"dest": "cargo/vendor/rustls-pki-types-1.15.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046\", \"files\": {}}",
-		"dest": "cargo/vendor/rustls-pki-types-1.15.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/rustls-platform-verifier/rustls-platform-verifier-0.7.0.crate",
-		"sha256": "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0",
-		"dest": "cargo/vendor/rustls-platform-verifier-0.7.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0\", \"files\": {}}",
-		"dest": "cargo/vendor/rustls-platform-verifier-0.7.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/rustls-platform-verifier-android/rustls-platform-verifier-android-0.1.1.crate",
-		"sha256": "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f",
-		"dest": "cargo/vendor/rustls-platform-verifier-android-0.1.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f\", \"files\": {}}",
-		"dest": "cargo/vendor/rustls-platform-verifier-android-0.1.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/rustls-webpki/rustls-webpki-0.103.13.crate",
-		"sha256": "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e",
-		"dest": "cargo/vendor/rustls-webpki-0.103.13"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e\", \"files\": {}}",
-		"dest": "cargo/vendor/rustls-webpki-0.103.13",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/rustversion/rustversion-1.0.23.crate",
-		"sha256": "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f",
-		"dest": "cargo/vendor/rustversion-1.0.23"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f\", \"files\": {}}",
-		"dest": "cargo/vendor/rustversion-1.0.23",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/ryu/ryu-1.0.23.crate",
-		"sha256": "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f",
-		"dest": "cargo/vendor/ryu-1.0.23"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f\", \"files\": {}}",
-		"dest": "cargo/vendor/ryu-1.0.23",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/same-file/same-file-1.0.6.crate",
-		"sha256": "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502",
-		"dest": "cargo/vendor/same-file-1.0.6"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502\", \"files\": {}}",
-		"dest": "cargo/vendor/same-file-1.0.6",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/schannel/schannel-0.1.29.crate",
-		"sha256": "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939",
-		"dest": "cargo/vendor/schannel-0.1.29"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939\", \"files\": {}}",
-		"dest": "cargo/vendor/schannel-0.1.29",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/schemars/schemars-0.8.22.crate",
-		"sha256": "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615",
-		"dest": "cargo/vendor/schemars-0.8.22"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615\", \"files\": {}}",
-		"dest": "cargo/vendor/schemars-0.8.22",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/schemars/schemars-0.9.0.crate",
-		"sha256": "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f",
-		"dest": "cargo/vendor/schemars-0.9.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f\", \"files\": {}}",
-		"dest": "cargo/vendor/schemars-0.9.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/schemars/schemars-1.2.1.crate",
-		"sha256": "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc",
-		"dest": "cargo/vendor/schemars-1.2.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc\", \"files\": {}}",
-		"dest": "cargo/vendor/schemars-1.2.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/schemars_derive/schemars_derive-0.8.22.crate",
-		"sha256": "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d",
-		"dest": "cargo/vendor/schemars_derive-0.8.22"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d\", \"files\": {}}",
-		"dest": "cargo/vendor/schemars_derive-0.8.22",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/scoped-tls/scoped-tls-1.0.1.crate",
-		"sha256": "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294",
-		"dest": "cargo/vendor/scoped-tls-1.0.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294\", \"files\": {}}",
-		"dest": "cargo/vendor/scoped-tls-1.0.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/scopeguard/scopeguard-1.2.0.crate",
-		"sha256": "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49",
-		"dest": "cargo/vendor/scopeguard-1.2.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49\", \"files\": {}}",
-		"dest": "cargo/vendor/scopeguard-1.2.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/security-framework/security-framework-3.7.0.crate",
-		"sha256": "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d",
-		"dest": "cargo/vendor/security-framework-3.7.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d\", \"files\": {}}",
-		"dest": "cargo/vendor/security-framework-3.7.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/security-framework-sys/security-framework-sys-2.17.0.crate",
-		"sha256": "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3",
-		"dest": "cargo/vendor/security-framework-sys-2.17.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3\", \"files\": {}}",
-		"dest": "cargo/vendor/security-framework-sys-2.17.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/seize/seize-0.5.1.crate",
-		"sha256": "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521",
-		"dest": "cargo/vendor/seize-0.5.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521\", \"files\": {}}",
-		"dest": "cargo/vendor/seize-0.5.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/selectors/selectors-0.24.0.crate",
-		"sha256": "0c37578180969d00692904465fb7f6b3d50b9a2b952b87c23d0e2e5cb5013416",
-		"dest": "cargo/vendor/selectors-0.24.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"0c37578180969d00692904465fb7f6b3d50b9a2b952b87c23d0e2e5cb5013416\", \"files\": {}}",
-		"dest": "cargo/vendor/selectors-0.24.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/selectors/selectors-0.36.1.crate",
-		"sha256": "c5d9c0c92a92d33f08817311cf3f2c29a3538a8240e94a6a3c622ce652d7e00c",
-		"dest": "cargo/vendor/selectors-0.36.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"c5d9c0c92a92d33f08817311cf3f2c29a3538a8240e94a6a3c622ce652d7e00c\", \"files\": {}}",
-		"dest": "cargo/vendor/selectors-0.36.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/self_cell/self_cell-1.2.2.crate",
-		"sha256": "b12e76d157a900eb52e81bc6e9f3069344290341720e9178cde2407113ac8d89",
-		"dest": "cargo/vendor/self_cell-1.2.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"b12e76d157a900eb52e81bc6e9f3069344290341720e9178cde2407113ac8d89\", \"files\": {}}",
-		"dest": "cargo/vendor/self_cell-1.2.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/semver/semver-1.0.28.crate",
-		"sha256": "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd",
-		"dest": "cargo/vendor/semver-1.0.28"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd\", \"files\": {}}",
-		"dest": "cargo/vendor/semver-1.0.28",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/send_wrapper/send_wrapper-0.6.0.crate",
-		"sha256": "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73",
-		"dest": "cargo/vendor/send_wrapper-0.6.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73\", \"files\": {}}",
-		"dest": "cargo/vendor/send_wrapper-0.6.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/serde/serde-1.0.228.crate",
-		"sha256": "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e",
-		"dest": "cargo/vendor/serde-1.0.228"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e\", \"files\": {}}",
-		"dest": "cargo/vendor/serde-1.0.228",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/serde-untagged/serde-untagged-0.1.9.crate",
-		"sha256": "f9faf48a4a2d2693be24c6289dbe26552776eb7737074e6722891fadbe6c5058",
-		"dest": "cargo/vendor/serde-untagged-0.1.9"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"f9faf48a4a2d2693be24c6289dbe26552776eb7737074e6722891fadbe6c5058\", \"files\": {}}",
-		"dest": "cargo/vendor/serde-untagged-0.1.9",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/serde_bytes/serde_bytes-0.11.19.crate",
-		"sha256": "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8",
-		"dest": "cargo/vendor/serde_bytes-0.11.19"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8\", \"files\": {}}",
-		"dest": "cargo/vendor/serde_bytes-0.11.19",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/serde_core/serde_core-1.0.228.crate",
-		"sha256": "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad",
-		"dest": "cargo/vendor/serde_core-1.0.228"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad\", \"files\": {}}",
-		"dest": "cargo/vendor/serde_core-1.0.228",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/serde_derive/serde_derive-1.0.228.crate",
-		"sha256": "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79",
-		"dest": "cargo/vendor/serde_derive-1.0.228"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79\", \"files\": {}}",
-		"dest": "cargo/vendor/serde_derive-1.0.228",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/serde_derive_internals/serde_derive_internals-0.29.1.crate",
-		"sha256": "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711",
-		"dest": "cargo/vendor/serde_derive_internals-0.29.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711\", \"files\": {}}",
-		"dest": "cargo/vendor/serde_derive_internals-0.29.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/serde_json/serde_json-1.0.150.crate",
-		"sha256": "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9",
-		"dest": "cargo/vendor/serde_json-1.0.150"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9\", \"files\": {}}",
-		"dest": "cargo/vendor/serde_json-1.0.150",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/serde_repr/serde_repr-0.1.20.crate",
-		"sha256": "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c",
-		"dest": "cargo/vendor/serde_repr-0.1.20"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c\", \"files\": {}}",
-		"dest": "cargo/vendor/serde_repr-0.1.20",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/serde_spanned/serde_spanned-0.6.9.crate",
-		"sha256": "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3",
-		"dest": "cargo/vendor/serde_spanned-0.6.9"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3\", \"files\": {}}",
-		"dest": "cargo/vendor/serde_spanned-0.6.9",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/serde_spanned/serde_spanned-1.1.1.crate",
-		"sha256": "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26",
-		"dest": "cargo/vendor/serde_spanned-1.1.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26\", \"files\": {}}",
-		"dest": "cargo/vendor/serde_spanned-1.1.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/serde_with/serde_with-3.21.0.crate",
-		"sha256": "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c",
-		"dest": "cargo/vendor/serde_with-3.21.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c\", \"files\": {}}",
-		"dest": "cargo/vendor/serde_with-3.21.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/serde_with_macros/serde_with_macros-3.21.0.crate",
-		"sha256": "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660",
-		"dest": "cargo/vendor/serde_with_macros-3.21.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660\", \"files\": {}}",
-		"dest": "cargo/vendor/serde_with_macros-3.21.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/serdect/serdect-0.4.3.crate",
-		"sha256": "66cf8fedced2fcf12406bcb34223dffb92eaf34908ede12fed414c82b7f00b3e",
-		"dest": "cargo/vendor/serdect-0.4.3"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"66cf8fedced2fcf12406bcb34223dffb92eaf34908ede12fed414c82b7f00b3e\", \"files\": {}}",
-		"dest": "cargo/vendor/serdect-0.4.3",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/serialize-to-javascript/serialize-to-javascript-0.1.2.crate",
-		"sha256": "04f3666a07a197cdb77cdf306c32be9b7f598d7060d50cfd4d5aa04bfd92f6c5",
-		"dest": "cargo/vendor/serialize-to-javascript-0.1.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"04f3666a07a197cdb77cdf306c32be9b7f598d7060d50cfd4d5aa04bfd92f6c5\", \"files\": {}}",
-		"dest": "cargo/vendor/serialize-to-javascript-0.1.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/serialize-to-javascript-impl/serialize-to-javascript-impl-0.1.2.crate",
-		"sha256": "772ee033c0916d670af7860b6e1ef7d658a4629a6d0b4c8c3e67f09b3765b75d",
-		"dest": "cargo/vendor/serialize-to-javascript-impl-0.1.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"772ee033c0916d670af7860b6e1ef7d658a4629a6d0b4c8c3e67f09b3765b75d\", \"files\": {}}",
-		"dest": "cargo/vendor/serialize-to-javascript-impl-0.1.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/servo_arc/servo_arc-0.2.0.crate",
-		"sha256": "d52aa42f8fdf0fed91e5ce7f23d8138441002fa31dca008acf47e6fd4721f741",
-		"dest": "cargo/vendor/servo_arc-0.2.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"d52aa42f8fdf0fed91e5ce7f23d8138441002fa31dca008acf47e6fd4721f741\", \"files\": {}}",
-		"dest": "cargo/vendor/servo_arc-0.2.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/servo_arc/servo_arc-0.4.3.crate",
-		"sha256": "170fb83ab34de17dc69aa7c67482b22218ddb85da56546f9bd6b929e32a05930",
-		"dest": "cargo/vendor/servo_arc-0.4.3"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"170fb83ab34de17dc69aa7c67482b22218ddb85da56546f9bd6b929e32a05930\", \"files\": {}}",
-		"dest": "cargo/vendor/servo_arc-0.4.3",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/sha1_smol/sha1_smol-1.0.1.crate",
-		"sha256": "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d",
-		"dest": "cargo/vendor/sha1_smol-1.0.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d\", \"files\": {}}",
-		"dest": "cargo/vendor/sha1_smol-1.0.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/sha2/sha2-0.10.9.crate",
-		"sha256": "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283",
-		"dest": "cargo/vendor/sha2-0.10.9"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283\", \"files\": {}}",
-		"dest": "cargo/vendor/sha2-0.10.9",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/sha2/sha2-0.11.0.crate",
-		"sha256": "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4",
-		"dest": "cargo/vendor/sha2-0.11.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4\", \"files\": {}}",
-		"dest": "cargo/vendor/sha2-0.11.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/sharded-slab/sharded-slab-0.1.7.crate",
-		"sha256": "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6",
-		"dest": "cargo/vendor/sharded-slab-0.1.7"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6\", \"files\": {}}",
-		"dest": "cargo/vendor/sharded-slab-0.1.7",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/shlex/shlex-2.0.1.crate",
-		"sha256": "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba",
-		"dest": "cargo/vendor/shlex-2.0.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba\", \"files\": {}}",
-		"dest": "cargo/vendor/shlex-2.0.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/signal-hook/signal-hook-0.3.18.crate",
-		"sha256": "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2",
-		"dest": "cargo/vendor/signal-hook-0.3.18"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2\", \"files\": {}}",
-		"dest": "cargo/vendor/signal-hook-0.3.18",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/signal-hook-mio/signal-hook-mio-0.2.5.crate",
-		"sha256": "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc",
-		"dest": "cargo/vendor/signal-hook-mio-0.2.5"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc\", \"files\": {}}",
-		"dest": "cargo/vendor/signal-hook-mio-0.2.5",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/signal-hook-registry/signal-hook-registry-1.4.8.crate",
-		"sha256": "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b",
-		"dest": "cargo/vendor/signal-hook-registry-1.4.8"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b\", \"files\": {}}",
-		"dest": "cargo/vendor/signal-hook-registry-1.4.8",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/signature/signature-3.0.0.crate",
-		"sha256": "28d567dcbaf0049cb8ac2608a76cd95ff9e4412e1899d389ee400918ca7537f5",
-		"dest": "cargo/vendor/signature-3.0.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"28d567dcbaf0049cb8ac2608a76cd95ff9e4412e1899d389ee400918ca7537f5\", \"files\": {}}",
-		"dest": "cargo/vendor/signature-3.0.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/simd-adler32/simd-adler32-0.3.9.crate",
-		"sha256": "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214",
-		"dest": "cargo/vendor/simd-adler32-0.3.9"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214\", \"files\": {}}",
-		"dest": "cargo/vendor/simd-adler32-0.3.9",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/simd_cesu8/simd_cesu8-1.1.1.crate",
-		"sha256": "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33",
-		"dest": "cargo/vendor/simd_cesu8-1.1.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33\", \"files\": {}}",
-		"dest": "cargo/vendor/simd_cesu8-1.1.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/simd_helpers/simd_helpers-0.1.0.crate",
-		"sha256": "95890f873bec569a0362c235787f3aca6e1e887302ba4840839bcc6459c42da6",
-		"dest": "cargo/vendor/simd_helpers-0.1.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"95890f873bec569a0362c235787f3aca6e1e887302ba4840839bcc6459c42da6\", \"files\": {}}",
-		"dest": "cargo/vendor/simd_helpers-0.1.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/simdutf8/simdutf8-0.1.5.crate",
-		"sha256": "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e",
-		"dest": "cargo/vendor/simdutf8-0.1.5"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e\", \"files\": {}}",
-		"dest": "cargo/vendor/simdutf8-0.1.5",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/simple-dns/simple-dns-0.11.3.crate",
-		"sha256": "7a75cbde1bf934313596a004973e462f9a82caa814dcf1a5f507bdf51597eeb4",
-		"dest": "cargo/vendor/simple-dns-0.11.3"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"7a75cbde1bf934313596a004973e462f9a82caa814dcf1a5f507bdf51597eeb4\", \"files\": {}}",
-		"dest": "cargo/vendor/simple-dns-0.11.3",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/siphasher/siphasher-0.3.11.crate",
-		"sha256": "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d",
-		"dest": "cargo/vendor/siphasher-0.3.11"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d\", \"files\": {}}",
-		"dest": "cargo/vendor/siphasher-0.3.11",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/siphasher/siphasher-1.0.3.crate",
-		"sha256": "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649",
-		"dest": "cargo/vendor/siphasher-1.0.3"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649\", \"files\": {}}",
-		"dest": "cargo/vendor/siphasher-1.0.3",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/slab/slab-0.4.12.crate",
-		"sha256": "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5",
-		"dest": "cargo/vendor/slab-0.4.12"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5\", \"files\": {}}",
-		"dest": "cargo/vendor/slab-0.4.12",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/smallvec/smallvec-1.15.2.crate",
-		"sha256": "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90",
-		"dest": "cargo/vendor/smallvec-1.15.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90\", \"files\": {}}",
-		"dest": "cargo/vendor/smallvec-1.15.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/socket2/socket2-0.6.4.crate",
-		"sha256": "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51",
-		"dest": "cargo/vendor/socket2-0.6.4"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51\", \"files\": {}}",
-		"dest": "cargo/vendor/socket2-0.6.4",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/softbuffer/softbuffer-0.4.8.crate",
-		"sha256": "aac18da81ebbf05109ab275b157c22a653bb3c12cf884450179942f81bcbf6c3",
-		"dest": "cargo/vendor/softbuffer-0.4.8"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"aac18da81ebbf05109ab275b157c22a653bb3c12cf884450179942f81bcbf6c3\", \"files\": {}}",
-		"dest": "cargo/vendor/softbuffer-0.4.8",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/sorted-index-buffer/sorted-index-buffer-0.2.1.crate",
-		"sha256": "ea06cc588e43c632923a55450401b8f25e628131571d4e1baea1bdfdb2b5ed06",
-		"dest": "cargo/vendor/sorted-index-buffer-0.2.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"ea06cc588e43c632923a55450401b8f25e628131571d4e1baea1bdfdb2b5ed06\", \"files\": {}}",
-		"dest": "cargo/vendor/sorted-index-buffer-0.2.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/soup3/soup3-0.5.0.crate",
-		"sha256": "471f924a40f31251afc77450e781cb26d55c0b650842efafc9c6cbd2f7cc4f9f",
-		"dest": "cargo/vendor/soup3-0.5.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"471f924a40f31251afc77450e781cb26d55c0b650842efafc9c6cbd2f7cc4f9f\", \"files\": {}}",
-		"dest": "cargo/vendor/soup3-0.5.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/soup3-sys/soup3-sys-0.5.0.crate",
-		"sha256": "7ebe8950a680a12f24f15ebe1bf70db7af98ad242d9db43596ad3108aab86c27",
-		"dest": "cargo/vendor/soup3-sys-0.5.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"7ebe8950a680a12f24f15ebe1bf70db7af98ad242d9db43596ad3108aab86c27\", \"files\": {}}",
-		"dest": "cargo/vendor/soup3-sys-0.5.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/spez/spez-0.1.2.crate",
-		"sha256": "c87e960f4dca2788eeb86bbdde8dd246be8948790b7618d656e68f9b720a86e8",
-		"dest": "cargo/vendor/spez-0.1.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"c87e960f4dca2788eeb86bbdde8dd246be8948790b7618d656e68f9b720a86e8\", \"files\": {}}",
-		"dest": "cargo/vendor/spez-0.1.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/spin/spin-0.9.8.crate",
-		"sha256": "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67",
-		"dest": "cargo/vendor/spin-0.9.8"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67\", \"files\": {}}",
-		"dest": "cargo/vendor/spin-0.9.8",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/spin/spin-0.10.0.crate",
-		"sha256": "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591",
-		"dest": "cargo/vendor/spin-0.10.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591\", \"files\": {}}",
-		"dest": "cargo/vendor/spin-0.10.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/spki/spki-0.8.0.crate",
-		"sha256": "1d9efca8738c78ee9484207732f728b1ef517bbb1833d6fc0879ca898a522f6f",
-		"dest": "cargo/vendor/spki-0.8.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"1d9efca8738c78ee9484207732f728b1ef517bbb1833d6fc0879ca898a522f6f\", \"files\": {}}",
-		"dest": "cargo/vendor/spki-0.8.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/stable_deref_trait/stable_deref_trait-1.2.1.crate",
-		"sha256": "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596",
-		"dest": "cargo/vendor/stable_deref_trait-1.2.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596\", \"files\": {}}",
-		"dest": "cargo/vendor/stable_deref_trait-1.2.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/string_cache/string_cache-0.8.9.crate",
-		"sha256": "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f",
-		"dest": "cargo/vendor/string_cache-0.8.9"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f\", \"files\": {}}",
-		"dest": "cargo/vendor/string_cache-0.8.9",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/string_cache/string_cache-0.9.0.crate",
-		"sha256": "a18596f8c785a729f2819c0f6a7eae6ebeebdfffbfe4214ae6b087f690e31901",
-		"dest": "cargo/vendor/string_cache-0.9.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"a18596f8c785a729f2819c0f6a7eae6ebeebdfffbfe4214ae6b087f690e31901\", \"files\": {}}",
-		"dest": "cargo/vendor/string_cache-0.9.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/string_cache_codegen/string_cache_codegen-0.5.4.crate",
-		"sha256": "c711928715f1fe0fe509c53b43e993a9a557babc2d0a3567d0a3006f1ac931a0",
-		"dest": "cargo/vendor/string_cache_codegen-0.5.4"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"c711928715f1fe0fe509c53b43e993a9a557babc2d0a3567d0a3006f1ac931a0\", \"files\": {}}",
-		"dest": "cargo/vendor/string_cache_codegen-0.5.4",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/string_cache_codegen/string_cache_codegen-0.6.1.crate",
-		"sha256": "585635e46db231059f76c5849798146164652513eb9e8ab2685939dd90f29b69",
-		"dest": "cargo/vendor/string_cache_codegen-0.6.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"585635e46db231059f76c5849798146164652513eb9e8ab2685939dd90f29b69\", \"files\": {}}",
-		"dest": "cargo/vendor/string_cache_codegen-0.6.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/strsim/strsim-0.11.1.crate",
-		"sha256": "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f",
-		"dest": "cargo/vendor/strsim-0.11.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f\", \"files\": {}}",
-		"dest": "cargo/vendor/strsim-0.11.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/strum/strum-0.28.0.crate",
-		"sha256": "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd",
-		"dest": "cargo/vendor/strum-0.28.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd\", \"files\": {}}",
-		"dest": "cargo/vendor/strum-0.28.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/strum_macros/strum_macros-0.28.0.crate",
-		"sha256": "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664",
-		"dest": "cargo/vendor/strum_macros-0.28.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664\", \"files\": {}}",
-		"dest": "cargo/vendor/strum_macros-0.28.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/subtle/subtle-2.6.1.crate",
-		"sha256": "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292",
-		"dest": "cargo/vendor/subtle-2.6.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292\", \"files\": {}}",
-		"dest": "cargo/vendor/subtle-2.6.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/swift-rs/swift-rs-1.0.7.crate",
-		"sha256": "4057c98e2e852d51fdcfca832aac7b571f6b351ad159f9eda5db1655f8d0c4d7",
-		"dest": "cargo/vendor/swift-rs-1.0.7"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"4057c98e2e852d51fdcfca832aac7b571f6b351ad159f9eda5db1655f8d0c4d7\", \"files\": {}}",
-		"dest": "cargo/vendor/swift-rs-1.0.7",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/syn/syn-1.0.109.crate",
-		"sha256": "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237",
-		"dest": "cargo/vendor/syn-1.0.109"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237\", \"files\": {}}",
-		"dest": "cargo/vendor/syn-1.0.109",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/syn/syn-2.0.118.crate",
-		"sha256": "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422",
-		"dest": "cargo/vendor/syn-2.0.118"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422\", \"files\": {}}",
-		"dest": "cargo/vendor/syn-2.0.118",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/syn-mid/syn-mid-0.5.4.crate",
-		"sha256": "fea305d57546cc8cd04feb14b62ec84bf17f50e3f7b12560d7bfa9265f39d9ed",
-		"dest": "cargo/vendor/syn-mid-0.5.4"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"fea305d57546cc8cd04feb14b62ec84bf17f50e3f7b12560d7bfa9265f39d9ed\", \"files\": {}}",
-		"dest": "cargo/vendor/syn-mid-0.5.4",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/sync_wrapper/sync_wrapper-1.0.2.crate",
-		"sha256": "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263",
-		"dest": "cargo/vendor/sync_wrapper-1.0.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263\", \"files\": {}}",
-		"dest": "cargo/vendor/sync_wrapper-1.0.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/synstructure/synstructure-0.13.2.crate",
-		"sha256": "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2",
-		"dest": "cargo/vendor/synstructure-0.13.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2\", \"files\": {}}",
-		"dest": "cargo/vendor/synstructure-0.13.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/sys-locale/sys-locale-0.3.2.crate",
-		"sha256": "8eab9a99a024a169fe8a903cf9d4a3b3601109bcc13bd9e3c6fff259138626c4",
-		"dest": "cargo/vendor/sys-locale-0.3.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"8eab9a99a024a169fe8a903cf9d4a3b3601109bcc13bd9e3c6fff259138626c4\", \"files\": {}}",
-		"dest": "cargo/vendor/sys-locale-0.3.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/system-configuration/system-configuration-0.7.0.crate",
-		"sha256": "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b",
-		"dest": "cargo/vendor/system-configuration-0.7.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b\", \"files\": {}}",
-		"dest": "cargo/vendor/system-configuration-0.7.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/system-configuration-sys/system-configuration-sys-0.6.0.crate",
-		"sha256": "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4",
-		"dest": "cargo/vendor/system-configuration-sys-0.6.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4\", \"files\": {}}",
-		"dest": "cargo/vendor/system-configuration-sys-0.6.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/system-deps/system-deps-6.2.2.crate",
-		"sha256": "a3e535eb8dded36d55ec13eddacd30dec501792ff23a0b1682c38601b8cf2349",
-		"dest": "cargo/vendor/system-deps-6.2.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"a3e535eb8dded36d55ec13eddacd30dec501792ff23a0b1682c38601b8cf2349\", \"files\": {}}",
-		"dest": "cargo/vendor/system-deps-6.2.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/system-deps/system-deps-7.0.8.crate",
-		"sha256": "396a35feb67335377e0251fcbc1092fc85c484bd4e3a7a54319399da127796e7",
-		"dest": "cargo/vendor/system-deps-7.0.8"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"396a35feb67335377e0251fcbc1092fc85c484bd4e3a7a54319399da127796e7\", \"files\": {}}",
-		"dest": "cargo/vendor/system-deps-7.0.8",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/tagptr/tagptr-0.2.0.crate",
-		"sha256": "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417",
-		"dest": "cargo/vendor/tagptr-0.2.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417\", \"files\": {}}",
-		"dest": "cargo/vendor/tagptr-0.2.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/tao/tao-0.34.8.crate",
-		"sha256": "9103edf55f2da3c82aea4c7fab7c4241032bfeea0e71fa557d98e00e7ce7cc20",
-		"dest": "cargo/vendor/tao-0.34.8"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"9103edf55f2da3c82aea4c7fab7c4241032bfeea0e71fa557d98e00e7ce7cc20\", \"files\": {}}",
-		"dest": "cargo/vendor/tao-0.34.8",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/tao-macros/tao-macros-0.1.3.crate",
-		"sha256": "f4e16beb8b2ac17db28eab8bca40e62dbfbb34c0fcdc6d9826b11b7b5d047dfd",
-		"dest": "cargo/vendor/tao-macros-0.1.3"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"f4e16beb8b2ac17db28eab8bca40e62dbfbb34c0fcdc6d9826b11b7b5d047dfd\", \"files\": {}}",
-		"dest": "cargo/vendor/tao-macros-0.1.3",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/tar/tar-0.4.46.crate",
-		"sha256": "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840",
-		"dest": "cargo/vendor/tar-0.4.46"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840\", \"files\": {}}",
-		"dest": "cargo/vendor/tar-0.4.46",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/target-lexicon/target-lexicon-0.12.16.crate",
-		"sha256": "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1",
-		"dest": "cargo/vendor/target-lexicon-0.12.16"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1\", \"files\": {}}",
-		"dest": "cargo/vendor/target-lexicon-0.12.16",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/target-lexicon/target-lexicon-0.13.5.crate",
-		"sha256": "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca",
-		"dest": "cargo/vendor/target-lexicon-0.13.5"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca\", \"files\": {}}",
-		"dest": "cargo/vendor/target-lexicon-0.13.5",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/tauri/tauri-2.10.1.crate",
-		"sha256": "1025aa560c1eaa14ef96de5540cbe13ed6be1933ebe4398338c96bc370b807c6",
-		"dest": "cargo/vendor/tauri-2.10.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"1025aa560c1eaa14ef96de5540cbe13ed6be1933ebe4398338c96bc370b807c6\", \"files\": {}}",
-		"dest": "cargo/vendor/tauri-2.10.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/tauri-build/tauri-build-2.6.3.crate",
-		"sha256": "bc9ce40b16101cb6ea63d3e221567affd1c3a9205f95d7bc574941a10636b632",
-		"dest": "cargo/vendor/tauri-build-2.6.3"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"bc9ce40b16101cb6ea63d3e221567affd1c3a9205f95d7bc574941a10636b632\", \"files\": {}}",
-		"dest": "cargo/vendor/tauri-build-2.6.3",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/tauri-codegen/tauri-codegen-2.6.3.crate",
-		"sha256": "08279169ff42f8fc45a1dbc9dcae888893ba95288142e5880c59b93a26d2cfc5",
-		"dest": "cargo/vendor/tauri-codegen-2.6.3"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"08279169ff42f8fc45a1dbc9dcae888893ba95288142e5880c59b93a26d2cfc5\", \"files\": {}}",
-		"dest": "cargo/vendor/tauri-codegen-2.6.3",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/tauri-macros/tauri-macros-2.6.3.crate",
-		"sha256": "e8b394794f399a421811d06966343e7933fcae92d59f5180b9388d1174497a45",
-		"dest": "cargo/vendor/tauri-macros-2.6.3"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"e8b394794f399a421811d06966343e7933fcae92d59f5180b9388d1174497a45\", \"files\": {}}",
-		"dest": "cargo/vendor/tauri-macros-2.6.3",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/tauri-plugin/tauri-plugin-2.6.3.crate",
-		"sha256": "74be5dd4bed9afbd145e5716b5fa2ec28cbc29c34ffa61c258c9273d896c8020",
-		"dest": "cargo/vendor/tauri-plugin-2.6.3"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"74be5dd4bed9afbd145e5716b5fa2ec28cbc29c34ffa61c258c9273d896c8020\", \"files\": {}}",
-		"dest": "cargo/vendor/tauri-plugin-2.6.3",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/tauri-plugin-dialog/tauri-plugin-dialog-2.7.1.crate",
-		"sha256": "65981abb771e74e571a38196c3baa11c459379164791eba0e67abc1a5fac9884",
-		"dest": "cargo/vendor/tauri-plugin-dialog-2.7.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"65981abb771e74e571a38196c3baa11c459379164791eba0e67abc1a5fac9884\", \"files\": {}}",
-		"dest": "cargo/vendor/tauri-plugin-dialog-2.7.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/tauri-plugin-fs/tauri-plugin-fs-2.5.1.crate",
-		"sha256": "b7ecc274121aca0c036a2b42d1cbe83d368d348f54e0bb8a735c2b1548e8f371",
-		"dest": "cargo/vendor/tauri-plugin-fs-2.5.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"b7ecc274121aca0c036a2b42d1cbe83d368d348f54e0bb8a735c2b1548e8f371\", \"files\": {}}",
-		"dest": "cargo/vendor/tauri-plugin-fs-2.5.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/tauri-plugin-notification/tauri-plugin-notification-2.3.3.crate",
-		"sha256": "01fc2c5ff41105bd1f7242d8201fdf3efd70749b82fa013a17f2126357d194cc",
-		"dest": "cargo/vendor/tauri-plugin-notification-2.3.3"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"01fc2c5ff41105bd1f7242d8201fdf3efd70749b82fa013a17f2126357d194cc\", \"files\": {}}",
-		"dest": "cargo/vendor/tauri-plugin-notification-2.3.3",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/tauri-plugin-opener/tauri-plugin-opener-2.5.4.crate",
-		"sha256": "17e1bea14edce6b793a04e2417e3fd924b9bc4faae83cdee7d714156cceeed29",
-		"dest": "cargo/vendor/tauri-plugin-opener-2.5.4"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"17e1bea14edce6b793a04e2417e3fd924b9bc4faae83cdee7d714156cceeed29\", \"files\": {}}",
-		"dest": "cargo/vendor/tauri-plugin-opener-2.5.4",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/tauri-plugin-os/tauri-plugin-os-2.3.2.crate",
-		"sha256": "d8f08346c8deb39e96f86973da0e2d76cbb933d7ac9b750f6dc4daf955a6f997",
-		"dest": "cargo/vendor/tauri-plugin-os-2.3.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"d8f08346c8deb39e96f86973da0e2d76cbb933d7ac9b750f6dc4daf955a6f997\", \"files\": {}}",
-		"dest": "cargo/vendor/tauri-plugin-os-2.3.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/tauri-plugin-single-instance/tauri-plugin-single-instance-2.4.2.crate",
-		"sha256": "5c8f29386f5e9fdc699182388a33ee80a56de436d91b67459e86afef426282af",
-		"dest": "cargo/vendor/tauri-plugin-single-instance-2.4.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"5c8f29386f5e9fdc699182388a33ee80a56de436d91b67459e86afef426282af\", \"files\": {}}",
-		"dest": "cargo/vendor/tauri-plugin-single-instance-2.4.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/tauri-plugin-store/tauri-plugin-store-2.4.3.crate",
-		"sha256": "6c72dda16786eb4a3f903e43a17b64d8d78dc0f00fe2aa4b757c28f617a8630b",
-		"dest": "cargo/vendor/tauri-plugin-store-2.4.3"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"6c72dda16786eb4a3f903e43a17b64d8d78dc0f00fe2aa4b757c28f617a8630b\", \"files\": {}}",
-		"dest": "cargo/vendor/tauri-plugin-store-2.4.3",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/tauri-plugin-updater/tauri-plugin-updater-2.10.1.crate",
-		"sha256": "806d9dac662c2e4594ff03c647a552f2c9bd544e7d0f683ec58f872f952ce4af",
-		"dest": "cargo/vendor/tauri-plugin-updater-2.10.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"806d9dac662c2e4594ff03c647a552f2c9bd544e7d0f683ec58f872f952ce4af\", \"files\": {}}",
-		"dest": "cargo/vendor/tauri-plugin-updater-2.10.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/tauri-runtime/tauri-runtime-2.10.1.crate",
-		"sha256": "2826d79a3297ed08cd6ea7f412644ef58e32969504bc4fbd8d7dbeabc4445ea2",
-		"dest": "cargo/vendor/tauri-runtime-2.10.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"2826d79a3297ed08cd6ea7f412644ef58e32969504bc4fbd8d7dbeabc4445ea2\", \"files\": {}}",
-		"dest": "cargo/vendor/tauri-runtime-2.10.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/tauri-runtime-wry/tauri-runtime-wry-2.10.1.crate",
-		"sha256": "e11ea2e6f801d275fdd890d6c9603736012742a1c33b96d0db788c9cdebf7f9e",
-		"dest": "cargo/vendor/tauri-runtime-wry-2.10.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"e11ea2e6f801d275fdd890d6c9603736012742a1c33b96d0db788c9cdebf7f9e\", \"files\": {}}",
-		"dest": "cargo/vendor/tauri-runtime-wry-2.10.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/tauri-utils/tauri-utils-2.9.3.crate",
-		"sha256": "3e176a18e67764923c4f1ce66f25ae4abe5f688384d5eb1a0fa6c77f3d90f887",
-		"dest": "cargo/vendor/tauri-utils-2.9.3"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"3e176a18e67764923c4f1ce66f25ae4abe5f688384d5eb1a0fa6c77f3d90f887\", \"files\": {}}",
-		"dest": "cargo/vendor/tauri-utils-2.9.3",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/tauri-winres/tauri-winres-0.3.6.crate",
-		"sha256": "cc65d45c68858bfe420dd29e834b5d15dbecf8a07a8a16cf4d532c7b1f69d4b6",
-		"dest": "cargo/vendor/tauri-winres-0.3.6"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"cc65d45c68858bfe420dd29e834b5d15dbecf8a07a8a16cf4d532c7b1f69d4b6\", \"files\": {}}",
-		"dest": "cargo/vendor/tauri-winres-0.3.6",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/tauri-winrt-notification/tauri-winrt-notification-0.7.3.crate",
-		"sha256": "9ed071c670382e85fc2f48ae706492d8c338f4f89bf72520d32f8abfe880aade",
-		"dest": "cargo/vendor/tauri-winrt-notification-0.7.3"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"9ed071c670382e85fc2f48ae706492d8c338f4f89bf72520d32f8abfe880aade\", \"files\": {}}",
-		"dest": "cargo/vendor/tauri-winrt-notification-0.7.3",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/tempfile/tempfile-3.27.0.crate",
-		"sha256": "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd",
-		"dest": "cargo/vendor/tempfile-3.27.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd\", \"files\": {}}",
-		"dest": "cargo/vendor/tempfile-3.27.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/tendril/tendril-0.4.3.crate",
-		"sha256": "d24a120c5fc464a3458240ee02c299ebcb9d67b5249c8848b09d639dca8d7bb0",
-		"dest": "cargo/vendor/tendril-0.4.3"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"d24a120c5fc464a3458240ee02c299ebcb9d67b5249c8848b09d639dca8d7bb0\", \"files\": {}}",
-		"dest": "cargo/vendor/tendril-0.4.3",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/tendril/tendril-0.5.1.crate",
-		"sha256": "5fed54709c5b3a53d09bb1c113ea4f5ceafd1e772ddcb0030a82e1d56c087b08",
-		"dest": "cargo/vendor/tendril-0.5.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"5fed54709c5b3a53d09bb1c113ea4f5ceafd1e772ddcb0030a82e1d56c087b08\", \"files\": {}}",
-		"dest": "cargo/vendor/tendril-0.5.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/thiserror/thiserror-1.0.69.crate",
-		"sha256": "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52",
-		"dest": "cargo/vendor/thiserror-1.0.69"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52\", \"files\": {}}",
-		"dest": "cargo/vendor/thiserror-1.0.69",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/thiserror/thiserror-2.0.18.crate",
-		"sha256": "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4",
-		"dest": "cargo/vendor/thiserror-2.0.18"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4\", \"files\": {}}",
-		"dest": "cargo/vendor/thiserror-2.0.18",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/thiserror-impl/thiserror-impl-1.0.69.crate",
-		"sha256": "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1",
-		"dest": "cargo/vendor/thiserror-impl-1.0.69"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1\", \"files\": {}}",
-		"dest": "cargo/vendor/thiserror-impl-1.0.69",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/thiserror-impl/thiserror-impl-2.0.18.crate",
-		"sha256": "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5",
-		"dest": "cargo/vendor/thiserror-impl-2.0.18"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5\", \"files\": {}}",
-		"dest": "cargo/vendor/thiserror-impl-2.0.18",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/thread_local/thread_local-1.1.9.crate",
-		"sha256": "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185",
-		"dest": "cargo/vendor/thread_local-1.1.9"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185\", \"files\": {}}",
-		"dest": "cargo/vendor/thread_local-1.1.9",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/tiff/tiff-0.11.3.crate",
-		"sha256": "b63feaf3343d35b6ca4d50483f94843803b0f51634937cc2ec519fc32232bc52",
-		"dest": "cargo/vendor/tiff-0.11.3"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"b63feaf3343d35b6ca4d50483f94843803b0f51634937cc2ec519fc32232bc52\", \"files\": {}}",
-		"dest": "cargo/vendor/tiff-0.11.3",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/time/time-0.3.53.crate",
-		"sha256": "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50",
-		"dest": "cargo/vendor/time-0.3.53"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50\", \"files\": {}}",
-		"dest": "cargo/vendor/time-0.3.53",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/time-core/time-core-0.1.9.crate",
-		"sha256": "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109",
-		"dest": "cargo/vendor/time-core-0.1.9"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109\", \"files\": {}}",
-		"dest": "cargo/vendor/time-core-0.1.9",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/time-macros/time-macros-0.2.31.crate",
-		"sha256": "c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f",
-		"dest": "cargo/vendor/time-macros-0.2.31"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f\", \"files\": {}}",
-		"dest": "cargo/vendor/time-macros-0.2.31",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/tinystr/tinystr-0.8.3.crate",
-		"sha256": "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d",
-		"dest": "cargo/vendor/tinystr-0.8.3"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d\", \"files\": {}}",
-		"dest": "cargo/vendor/tinystr-0.8.3",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/tinyvec/tinyvec-1.11.0.crate",
-		"sha256": "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3",
-		"dest": "cargo/vendor/tinyvec-1.11.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3\", \"files\": {}}",
-		"dest": "cargo/vendor/tinyvec-1.11.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/tinyvec_macros/tinyvec_macros-0.1.1.crate",
-		"sha256": "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20",
-		"dest": "cargo/vendor/tinyvec_macros-0.1.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20\", \"files\": {}}",
-		"dest": "cargo/vendor/tinyvec_macros-0.1.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/tokio/tokio-1.52.3.crate",
-		"sha256": "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe",
-		"dest": "cargo/vendor/tokio-1.52.3"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe\", \"files\": {}}",
-		"dest": "cargo/vendor/tokio-1.52.3",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/tokio-macros/tokio-macros-2.7.0.crate",
-		"sha256": "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496",
-		"dest": "cargo/vendor/tokio-macros-2.7.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496\", \"files\": {}}",
-		"dest": "cargo/vendor/tokio-macros-2.7.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/tokio-rustls/tokio-rustls-0.26.4.crate",
-		"sha256": "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61",
-		"dest": "cargo/vendor/tokio-rustls-0.26.4"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61\", \"files\": {}}",
-		"dest": "cargo/vendor/tokio-rustls-0.26.4",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/tokio-stream/tokio-stream-0.1.18.crate",
-		"sha256": "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70",
-		"dest": "cargo/vendor/tokio-stream-0.1.18"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70\", \"files\": {}}",
-		"dest": "cargo/vendor/tokio-stream-0.1.18",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/tokio-util/tokio-util-0.7.18.crate",
-		"sha256": "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098",
-		"dest": "cargo/vendor/tokio-util-0.7.18"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098\", \"files\": {}}",
-		"dest": "cargo/vendor/tokio-util-0.7.18",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/tokio-websockets/tokio-websockets-0.13.3.crate",
-		"sha256": "d52efb639344a7c6adb8e62c6f3d2c19c001ff1b79a5041ba1c6ed42e19c6aa5",
-		"dest": "cargo/vendor/tokio-websockets-0.13.3"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"d52efb639344a7c6adb8e62c6f3d2c19c001ff1b79a5041ba1c6ed42e19c6aa5\", \"files\": {}}",
-		"dest": "cargo/vendor/tokio-websockets-0.13.3",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/toml/toml-0.8.2.crate",
-		"sha256": "185d8ab0dfbb35cf1399a6344d8484209c088f75f8f68230da55d48d95d43e3d",
-		"dest": "cargo/vendor/toml-0.8.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"185d8ab0dfbb35cf1399a6344d8484209c088f75f8f68230da55d48d95d43e3d\", \"files\": {}}",
-		"dest": "cargo/vendor/toml-0.8.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/toml/toml-0.9.12+spec-1.1.0.crate",
-		"sha256": "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863",
-		"dest": "cargo/vendor/toml-0.9.12+spec-1.1.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863\", \"files\": {}}",
-		"dest": "cargo/vendor/toml-0.9.12+spec-1.1.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/toml/toml-1.1.2+spec-1.1.0.crate",
-		"sha256": "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee",
-		"dest": "cargo/vendor/toml-1.1.2+spec-1.1.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee\", \"files\": {}}",
-		"dest": "cargo/vendor/toml-1.1.2+spec-1.1.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/toml_datetime/toml_datetime-0.6.3.crate",
-		"sha256": "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b",
-		"dest": "cargo/vendor/toml_datetime-0.6.3"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b\", \"files\": {}}",
-		"dest": "cargo/vendor/toml_datetime-0.6.3",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/toml_datetime/toml_datetime-0.7.5+spec-1.1.0.crate",
-		"sha256": "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347",
-		"dest": "cargo/vendor/toml_datetime-0.7.5+spec-1.1.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347\", \"files\": {}}",
-		"dest": "cargo/vendor/toml_datetime-0.7.5+spec-1.1.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/toml_datetime/toml_datetime-1.1.1+spec-1.1.0.crate",
-		"sha256": "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7",
-		"dest": "cargo/vendor/toml_datetime-1.1.1+spec-1.1.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7\", \"files\": {}}",
-		"dest": "cargo/vendor/toml_datetime-1.1.1+spec-1.1.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/toml_edit/toml_edit-0.19.15.crate",
-		"sha256": "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421",
-		"dest": "cargo/vendor/toml_edit-0.19.15"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421\", \"files\": {}}",
-		"dest": "cargo/vendor/toml_edit-0.19.15",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/toml_edit/toml_edit-0.20.2.crate",
-		"sha256": "396e4d48bbb2b7554c944bde63101b5ae446cff6ec4a24227428f15eb72ef338",
-		"dest": "cargo/vendor/toml_edit-0.20.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"396e4d48bbb2b7554c944bde63101b5ae446cff6ec4a24227428f15eb72ef338\", \"files\": {}}",
-		"dest": "cargo/vendor/toml_edit-0.20.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/toml_edit/toml_edit-0.25.12+spec-1.1.0.crate",
-		"sha256": "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7",
-		"dest": "cargo/vendor/toml_edit-0.25.12+spec-1.1.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7\", \"files\": {}}",
-		"dest": "cargo/vendor/toml_edit-0.25.12+spec-1.1.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/toml_parser/toml_parser-1.1.2+spec-1.1.0.crate",
-		"sha256": "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526",
-		"dest": "cargo/vendor/toml_parser-1.1.2+spec-1.1.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526\", \"files\": {}}",
-		"dest": "cargo/vendor/toml_parser-1.1.2+spec-1.1.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/toml_writer/toml_writer-1.1.1+spec-1.1.0.crate",
-		"sha256": "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db",
-		"dest": "cargo/vendor/toml_writer-1.1.1+spec-1.1.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db\", \"files\": {}}",
-		"dest": "cargo/vendor/toml_writer-1.1.1+spec-1.1.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/tower/tower-0.5.3.crate",
-		"sha256": "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4",
-		"dest": "cargo/vendor/tower-0.5.3"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4\", \"files\": {}}",
-		"dest": "cargo/vendor/tower-0.5.3",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/tower-http/tower-http-0.6.11.crate",
-		"sha256": "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840",
-		"dest": "cargo/vendor/tower-http-0.6.11"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840\", \"files\": {}}",
-		"dest": "cargo/vendor/tower-http-0.6.11",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/tower-layer/tower-layer-0.3.3.crate",
-		"sha256": "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e",
-		"dest": "cargo/vendor/tower-layer-0.3.3"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e\", \"files\": {}}",
-		"dest": "cargo/vendor/tower-layer-0.3.3",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/tower-service/tower-service-0.3.3.crate",
-		"sha256": "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3",
-		"dest": "cargo/vendor/tower-service-0.3.3"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3\", \"files\": {}}",
-		"dest": "cargo/vendor/tower-service-0.3.3",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/tracing/tracing-0.1.44.crate",
-		"sha256": "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100",
-		"dest": "cargo/vendor/tracing-0.1.44"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100\", \"files\": {}}",
-		"dest": "cargo/vendor/tracing-0.1.44",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/tracing-attributes/tracing-attributes-0.1.31.crate",
-		"sha256": "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da",
-		"dest": "cargo/vendor/tracing-attributes-0.1.31"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da\", \"files\": {}}",
-		"dest": "cargo/vendor/tracing-attributes-0.1.31",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/tracing-core/tracing-core-0.1.36.crate",
-		"sha256": "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a",
-		"dest": "cargo/vendor/tracing-core-0.1.36"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a\", \"files\": {}}",
-		"dest": "cargo/vendor/tracing-core-0.1.36",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/tracing-log/tracing-log-0.2.0.crate",
-		"sha256": "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3",
-		"dest": "cargo/vendor/tracing-log-0.2.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3\", \"files\": {}}",
-		"dest": "cargo/vendor/tracing-log-0.2.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/tracing-subscriber/tracing-subscriber-0.3.23.crate",
-		"sha256": "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319",
-		"dest": "cargo/vendor/tracing-subscriber-0.3.23"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319\", \"files\": {}}",
-		"dest": "cargo/vendor/tracing-subscriber-0.3.23",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/tray-icon/tray-icon-0.21.3.crate",
-		"sha256": "a5e85aa143ceb072062fc4d6356c1b520a51d636e7bc8e77ec94be3608e5e80c",
-		"dest": "cargo/vendor/tray-icon-0.21.3"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"a5e85aa143ceb072062fc4d6356c1b520a51d636e7bc8e77ec94be3608e5e80c\", \"files\": {}}",
-		"dest": "cargo/vendor/tray-icon-0.21.3",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/try-lock/try-lock-0.2.5.crate",
-		"sha256": "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b",
-		"dest": "cargo/vendor/try-lock-0.2.5"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b\", \"files\": {}}",
-		"dest": "cargo/vendor/try-lock-0.2.5",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/typeid/typeid-1.0.3.crate",
-		"sha256": "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c",
-		"dest": "cargo/vendor/typeid-1.0.3"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c\", \"files\": {}}",
-		"dest": "cargo/vendor/typeid-1.0.3",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/typenum/typenum-1.20.1.crate",
-		"sha256": "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20",
-		"dest": "cargo/vendor/typenum-1.20.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20\", \"files\": {}}",
-		"dest": "cargo/vendor/typenum-1.20.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/uds_windows/uds_windows-1.2.1.crate",
-		"sha256": "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e",
-		"dest": "cargo/vendor/uds_windows-1.2.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e\", \"files\": {}}",
-		"dest": "cargo/vendor/uds_windows-1.2.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/unic-char-property/unic-char-property-0.9.0.crate",
-		"sha256": "a8c57a407d9b6fa02b4795eb81c5b6652060a15a7903ea981f3d723e6c0be221",
-		"dest": "cargo/vendor/unic-char-property-0.9.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"a8c57a407d9b6fa02b4795eb81c5b6652060a15a7903ea981f3d723e6c0be221\", \"files\": {}}",
-		"dest": "cargo/vendor/unic-char-property-0.9.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/unic-char-range/unic-char-range-0.9.0.crate",
-		"sha256": "0398022d5f700414f6b899e10b8348231abf9173fa93144cbc1a43b9793c1fbc",
-		"dest": "cargo/vendor/unic-char-range-0.9.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"0398022d5f700414f6b899e10b8348231abf9173fa93144cbc1a43b9793c1fbc\", \"files\": {}}",
-		"dest": "cargo/vendor/unic-char-range-0.9.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/unic-common/unic-common-0.9.0.crate",
-		"sha256": "80d7ff825a6a654ee85a63e80f92f054f904f21e7d12da4e22f9834a4aaa35bc",
-		"dest": "cargo/vendor/unic-common-0.9.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"80d7ff825a6a654ee85a63e80f92f054f904f21e7d12da4e22f9834a4aaa35bc\", \"files\": {}}",
-		"dest": "cargo/vendor/unic-common-0.9.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/unic-ucd-ident/unic-ucd-ident-0.9.0.crate",
-		"sha256": "e230a37c0381caa9219d67cf063aa3a375ffed5bf541a452db16e744bdab6987",
-		"dest": "cargo/vendor/unic-ucd-ident-0.9.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"e230a37c0381caa9219d67cf063aa3a375ffed5bf541a452db16e744bdab6987\", \"files\": {}}",
-		"dest": "cargo/vendor/unic-ucd-ident-0.9.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/unic-ucd-version/unic-ucd-version-0.9.0.crate",
-		"sha256": "96bd2f2237fe450fcd0a1d2f5f4e91711124f7857ba2e964247776ebeeb7b0c4",
-		"dest": "cargo/vendor/unic-ucd-version-0.9.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"96bd2f2237fe450fcd0a1d2f5f4e91711124f7857ba2e964247776ebeeb7b0c4\", \"files\": {}}",
-		"dest": "cargo/vendor/unic-ucd-version-0.9.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/unicase/unicase-2.9.0.crate",
-		"sha256": "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142",
-		"dest": "cargo/vendor/unicase-2.9.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142\", \"files\": {}}",
-		"dest": "cargo/vendor/unicase-2.9.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/unicode-ident/unicode-ident-1.0.24.crate",
-		"sha256": "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75",
-		"dest": "cargo/vendor/unicode-ident-1.0.24"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75\", \"files\": {}}",
-		"dest": "cargo/vendor/unicode-ident-1.0.24",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/unicode-segmentation/unicode-segmentation-1.13.3.crate",
-		"sha256": "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8",
-		"dest": "cargo/vendor/unicode-segmentation-1.13.3"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8\", \"files\": {}}",
-		"dest": "cargo/vendor/unicode-segmentation-1.13.3",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/unicode-width/unicode-width-0.2.2.crate",
-		"sha256": "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254",
-		"dest": "cargo/vendor/unicode-width-0.2.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254\", \"files\": {}}",
-		"dest": "cargo/vendor/unicode-width-0.2.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/unicode-xid/unicode-xid-0.2.6.crate",
-		"sha256": "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853",
-		"dest": "cargo/vendor/unicode-xid-0.2.6"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853\", \"files\": {}}",
-		"dest": "cargo/vendor/unicode-xid-0.2.6",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/universal-hash/universal-hash-0.5.1.crate",
-		"sha256": "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea",
-		"dest": "cargo/vendor/universal-hash-0.5.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea\", \"files\": {}}",
-		"dest": "cargo/vendor/universal-hash-0.5.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/untrusted/untrusted-0.9.0.crate",
-		"sha256": "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1",
-		"dest": "cargo/vendor/untrusted-0.9.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1\", \"files\": {}}",
-		"dest": "cargo/vendor/untrusted-0.9.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/url/url-2.5.8.crate",
-		"sha256": "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed",
-		"dest": "cargo/vendor/url-2.5.8"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed\", \"files\": {}}",
-		"dest": "cargo/vendor/url-2.5.8",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/urlencoding/urlencoding-2.1.3.crate",
-		"sha256": "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da",
-		"dest": "cargo/vendor/urlencoding-2.1.3"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da\", \"files\": {}}",
-		"dest": "cargo/vendor/urlencoding-2.1.3",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/urlpattern/urlpattern-0.3.0.crate",
-		"sha256": "70acd30e3aa1450bc2eece896ce2ad0d178e9c079493819301573dae3c37ba6d",
-		"dest": "cargo/vendor/urlpattern-0.3.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"70acd30e3aa1450bc2eece896ce2ad0d178e9c079493819301573dae3c37ba6d\", \"files\": {}}",
-		"dest": "cargo/vendor/urlpattern-0.3.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/utf-8/utf-8-0.7.6.crate",
-		"sha256": "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9",
-		"dest": "cargo/vendor/utf-8-0.7.6"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9\", \"files\": {}}",
-		"dest": "cargo/vendor/utf-8-0.7.6",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/utf8_iter/utf8_iter-1.0.4.crate",
-		"sha256": "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be",
-		"dest": "cargo/vendor/utf8_iter-1.0.4"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be\", \"files\": {}}",
-		"dest": "cargo/vendor/utf8_iter-1.0.4",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/utf8parse/utf8parse-0.2.2.crate",
-		"sha256": "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821",
-		"dest": "cargo/vendor/utf8parse-0.2.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821\", \"files\": {}}",
-		"dest": "cargo/vendor/utf8parse-0.2.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/uuid/uuid-1.23.4.crate",
-		"sha256": "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53",
-		"dest": "cargo/vendor/uuid-1.23.4"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53\", \"files\": {}}",
-		"dest": "cargo/vendor/uuid-1.23.4",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/v_frame/v_frame-0.3.9.crate",
-		"sha256": "666b7727c8875d6ab5db9533418d7c764233ac9c0cff1d469aec8fa127597be2",
-		"dest": "cargo/vendor/v_frame-0.3.9"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"666b7727c8875d6ab5db9533418d7c764233ac9c0cff1d469aec8fa127597be2\", \"files\": {}}",
-		"dest": "cargo/vendor/v_frame-0.3.9",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/valuable/valuable-0.1.1.crate",
-		"sha256": "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65",
-		"dest": "cargo/vendor/valuable-0.1.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65\", \"files\": {}}",
-		"dest": "cargo/vendor/valuable-0.1.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/vergen/vergen-9.1.0.crate",
-		"sha256": "b849a1f6d8639e8de261e81ee0fc881e3e3620db1af9f2e0da015d4382ceaf75",
-		"dest": "cargo/vendor/vergen-9.1.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"b849a1f6d8639e8de261e81ee0fc881e3e3620db1af9f2e0da015d4382ceaf75\", \"files\": {}}",
-		"dest": "cargo/vendor/vergen-9.1.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/vergen-gitcl/vergen-gitcl-9.1.0.crate",
-		"sha256": "77ff3b5300a085d6bcd8fc96a507f706a28ae3814693236c9b409db71a1d15b9",
-		"dest": "cargo/vendor/vergen-gitcl-9.1.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"77ff3b5300a085d6bcd8fc96a507f706a28ae3814693236c9b409db71a1d15b9\", \"files\": {}}",
-		"dest": "cargo/vendor/vergen-gitcl-9.1.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/vergen-lib/vergen-lib-9.1.0.crate",
-		"sha256": "b34a29ba7e9c59e62f229ae1932fb1b8fb8a6fdcc99215a641913f5f5a59a569",
-		"dest": "cargo/vendor/vergen-lib-9.1.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"b34a29ba7e9c59e62f229ae1932fb1b8fb8a6fdcc99215a641913f5f5a59a569\", \"files\": {}}",
-		"dest": "cargo/vendor/vergen-lib-9.1.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/version-compare/version-compare-0.2.1.crate",
-		"sha256": "03c2856837ef78f57382f06b2b8563a2f512f7185d732608fd9176cb3b8edf0e",
-		"dest": "cargo/vendor/version-compare-0.2.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"03c2856837ef78f57382f06b2b8563a2f512f7185d732608fd9176cb3b8edf0e\", \"files\": {}}",
-		"dest": "cargo/vendor/version-compare-0.2.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/version_check/version_check-0.9.5.crate",
-		"sha256": "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a",
-		"dest": "cargo/vendor/version_check-0.9.5"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a\", \"files\": {}}",
-		"dest": "cargo/vendor/version_check-0.9.5",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/vswhom/vswhom-0.1.0.crate",
-		"sha256": "be979b7f07507105799e854203b470ff7c78a1639e330a58f183b5fea574608b",
-		"dest": "cargo/vendor/vswhom-0.1.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"be979b7f07507105799e854203b470ff7c78a1639e330a58f183b5fea574608b\", \"files\": {}}",
-		"dest": "cargo/vendor/vswhom-0.1.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/vswhom-sys/vswhom-sys-0.1.3.crate",
-		"sha256": "fb067e4cbd1ff067d1df46c9194b5de0e98efd2810bbc95c5d5e5f25a3231150",
-		"dest": "cargo/vendor/vswhom-sys-0.1.3"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"fb067e4cbd1ff067d1df46c9194b5de0e98efd2810bbc95c5d5e5f25a3231150\", \"files\": {}}",
-		"dest": "cargo/vendor/vswhom-sys-0.1.3",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/walkdir/walkdir-2.5.0.crate",
-		"sha256": "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b",
-		"dest": "cargo/vendor/walkdir-2.5.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b\", \"files\": {}}",
-		"dest": "cargo/vendor/walkdir-2.5.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/want/want-0.3.1.crate",
-		"sha256": "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e",
-		"dest": "cargo/vendor/want-0.3.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e\", \"files\": {}}",
-		"dest": "cargo/vendor/want-0.3.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/wasi/wasi-0.9.0+wasi-snapshot-preview1.crate",
-		"sha256": "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519",
-		"dest": "cargo/vendor/wasi-0.9.0+wasi-snapshot-preview1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519\", \"files\": {}}",
-		"dest": "cargo/vendor/wasi-0.9.0+wasi-snapshot-preview1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/wasi/wasi-0.11.1+wasi-snapshot-preview1.crate",
-		"sha256": "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b",
-		"dest": "cargo/vendor/wasi-0.11.1+wasi-snapshot-preview1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b\", \"files\": {}}",
-		"dest": "cargo/vendor/wasi-0.11.1+wasi-snapshot-preview1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/wasip2/wasip2-1.0.4+wasi-0.2.12.crate",
-		"sha256": "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487",
-		"dest": "cargo/vendor/wasip2-1.0.4+wasi-0.2.12"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487\", \"files\": {}}",
-		"dest": "cargo/vendor/wasip2-1.0.4+wasi-0.2.12",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/wasm-bindgen/wasm-bindgen-0.2.126.crate",
-		"sha256": "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4",
-		"dest": "cargo/vendor/wasm-bindgen-0.2.126"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4\", \"files\": {}}",
-		"dest": "cargo/vendor/wasm-bindgen-0.2.126",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/wasm-bindgen-futures/wasm-bindgen-futures-0.4.76.crate",
-		"sha256": "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d",
-		"dest": "cargo/vendor/wasm-bindgen-futures-0.4.76"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d\", \"files\": {}}",
-		"dest": "cargo/vendor/wasm-bindgen-futures-0.4.76",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/wasm-bindgen-macro/wasm-bindgen-macro-0.2.126.crate",
-		"sha256": "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1",
-		"dest": "cargo/vendor/wasm-bindgen-macro-0.2.126"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1\", \"files\": {}}",
-		"dest": "cargo/vendor/wasm-bindgen-macro-0.2.126",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/wasm-bindgen-macro-support/wasm-bindgen-macro-support-0.2.126.crate",
-		"sha256": "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e",
-		"dest": "cargo/vendor/wasm-bindgen-macro-support-0.2.126"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e\", \"files\": {}}",
-		"dest": "cargo/vendor/wasm-bindgen-macro-support-0.2.126",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/wasm-bindgen-shared/wasm-bindgen-shared-0.2.126.crate",
-		"sha256": "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24",
-		"dest": "cargo/vendor/wasm-bindgen-shared-0.2.126"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24\", \"files\": {}}",
-		"dest": "cargo/vendor/wasm-bindgen-shared-0.2.126",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/wasm-streams/wasm-streams-0.5.0.crate",
-		"sha256": "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb",
-		"dest": "cargo/vendor/wasm-streams-0.5.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb\", \"files\": {}}",
-		"dest": "cargo/vendor/wasm-streams-0.5.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/wayland-backend/wayland-backend-0.3.16.crate",
-		"sha256": "016ccf01d1c58b6f8999612813e17c9b2390f7d70671428869913310f83f54b8",
-		"dest": "cargo/vendor/wayland-backend-0.3.16"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"016ccf01d1c58b6f8999612813e17c9b2390f7d70671428869913310f83f54b8\", \"files\": {}}",
-		"dest": "cargo/vendor/wayland-backend-0.3.16",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/wayland-client/wayland-client-0.31.15.crate",
-		"sha256": "e3c36a0f861ad76d0901f2800b46321410d9f73f2ea88aac0650d86c32688073",
-		"dest": "cargo/vendor/wayland-client-0.31.15"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"e3c36a0f861ad76d0901f2800b46321410d9f73f2ea88aac0650d86c32688073\", \"files\": {}}",
-		"dest": "cargo/vendor/wayland-client-0.31.15",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/wayland-protocols/wayland-protocols-0.32.13.crate",
-		"sha256": "23d0c813de3daa2ed6520af85a3bd49b0e722a3078506899aa9686fea58dc4b6",
-		"dest": "cargo/vendor/wayland-protocols-0.32.13"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"23d0c813de3daa2ed6520af85a3bd49b0e722a3078506899aa9686fea58dc4b6\", \"files\": {}}",
-		"dest": "cargo/vendor/wayland-protocols-0.32.13",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/wayland-scanner/wayland-scanner-0.31.11.crate",
-		"sha256": "338e30461b3a2b67d70eb30a6d89f8e0c93a833e07d2ae89085cd070c4a00ac0",
-		"dest": "cargo/vendor/wayland-scanner-0.31.11"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"338e30461b3a2b67d70eb30a6d89f8e0c93a833e07d2ae89085cd070c4a00ac0\", \"files\": {}}",
-		"dest": "cargo/vendor/wayland-scanner-0.31.11",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/wayland-sys/wayland-sys-0.31.11.crate",
-		"sha256": "d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be",
-		"dest": "cargo/vendor/wayland-sys-0.31.11"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be\", \"files\": {}}",
-		"dest": "cargo/vendor/wayland-sys-0.31.11",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/web-sys/web-sys-0.3.103.crate",
-		"sha256": "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141",
-		"dest": "cargo/vendor/web-sys-0.3.103"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141\", \"files\": {}}",
-		"dest": "cargo/vendor/web-sys-0.3.103",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/web-time/web-time-1.1.0.crate",
-		"sha256": "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb",
-		"dest": "cargo/vendor/web-time-1.1.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb\", \"files\": {}}",
-		"dest": "cargo/vendor/web-time-1.1.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/web_atoms/web_atoms-0.2.5.crate",
-		"sha256": "075474b12bcb3d2e3d4546580e9de478eeeead668a1761e2a8860c836b7ef297",
-		"dest": "cargo/vendor/web_atoms-0.2.5"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"075474b12bcb3d2e3d4546580e9de478eeeead668a1761e2a8860c836b7ef297\", \"files\": {}}",
-		"dest": "cargo/vendor/web_atoms-0.2.5",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/webkit2gtk/webkit2gtk-2.0.2.crate",
-		"sha256": "a1027150013530fb2eaf806408df88461ae4815a45c541c8975e61d6f2fc4793",
-		"dest": "cargo/vendor/webkit2gtk-2.0.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"a1027150013530fb2eaf806408df88461ae4815a45c541c8975e61d6f2fc4793\", \"files\": {}}",
-		"dest": "cargo/vendor/webkit2gtk-2.0.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/webkit2gtk-sys/webkit2gtk-sys-2.0.2.crate",
-		"sha256": "916a5f65c2ef0dfe12fff695960a2ec3d4565359fdbb2e9943c974e06c734ea5",
-		"dest": "cargo/vendor/webkit2gtk-sys-2.0.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"916a5f65c2ef0dfe12fff695960a2ec3d4565359fdbb2e9943c974e06c734ea5\", \"files\": {}}",
-		"dest": "cargo/vendor/webkit2gtk-sys-2.0.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/webpki-root-certs/webpki-root-certs-1.0.8.crate",
-		"sha256": "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267",
-		"dest": "cargo/vendor/webpki-root-certs-1.0.8"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267\", \"files\": {}}",
-		"dest": "cargo/vendor/webpki-root-certs-1.0.8",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/webpki-roots/webpki-roots-1.0.8.crate",
-		"sha256": "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf",
-		"dest": "cargo/vendor/webpki-roots-1.0.8"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf\", \"files\": {}}",
-		"dest": "cargo/vendor/webpki-roots-1.0.8",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/webview2-com/webview2-com-0.38.2.crate",
-		"sha256": "7130243a7a5b33c54a444e54842e6a9e133de08b5ad7b5861cd8ed9a6a5bc96a",
-		"dest": "cargo/vendor/webview2-com-0.38.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"7130243a7a5b33c54a444e54842e6a9e133de08b5ad7b5861cd8ed9a6a5bc96a\", \"files\": {}}",
-		"dest": "cargo/vendor/webview2-com-0.38.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/webview2-com-macros/webview2-com-macros-0.8.1.crate",
-		"sha256": "67a921c1b6914c367b2b823cd4cde6f96beec77d30a939c8199bb377cf9b9b54",
-		"dest": "cargo/vendor/webview2-com-macros-0.8.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"67a921c1b6914c367b2b823cd4cde6f96beec77d30a939c8199bb377cf9b9b54\", \"files\": {}}",
-		"dest": "cargo/vendor/webview2-com-macros-0.8.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/webview2-com-sys/webview2-com-sys-0.38.2.crate",
-		"sha256": "381336cfffd772377d291702245447a5251a2ffa5bad679c99e61bc48bacbf9c",
-		"dest": "cargo/vendor/webview2-com-sys-0.38.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"381336cfffd772377d291702245447a5251a2ffa5bad679c99e61bc48bacbf9c\", \"files\": {}}",
-		"dest": "cargo/vendor/webview2-com-sys-0.38.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/weezl/weezl-0.1.12.crate",
-		"sha256": "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88",
-		"dest": "cargo/vendor/weezl-0.1.12"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88\", \"files\": {}}",
-		"dest": "cargo/vendor/weezl-0.1.12",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/widestring/widestring-1.2.1.crate",
-		"sha256": "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471",
-		"dest": "cargo/vendor/widestring-1.2.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471\", \"files\": {}}",
-		"dest": "cargo/vendor/widestring-1.2.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/winapi/winapi-0.3.9.crate",
-		"sha256": "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419",
-		"dest": "cargo/vendor/winapi-0.3.9"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419\", \"files\": {}}",
-		"dest": "cargo/vendor/winapi-0.3.9",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/winapi-i686-pc-windows-gnu/winapi-i686-pc-windows-gnu-0.4.0.crate",
-		"sha256": "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6",
-		"dest": "cargo/vendor/winapi-i686-pc-windows-gnu-0.4.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6\", \"files\": {}}",
-		"dest": "cargo/vendor/winapi-i686-pc-windows-gnu-0.4.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/winapi-util/winapi-util-0.1.11.crate",
-		"sha256": "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22",
-		"dest": "cargo/vendor/winapi-util-0.1.11"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22\", \"files\": {}}",
-		"dest": "cargo/vendor/winapi-util-0.1.11",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/winapi-x86_64-pc-windows-gnu/winapi-x86_64-pc-windows-gnu-0.4.0.crate",
-		"sha256": "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f",
-		"dest": "cargo/vendor/winapi-x86_64-pc-windows-gnu-0.4.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f\", \"files\": {}}",
-		"dest": "cargo/vendor/winapi-x86_64-pc-windows-gnu-0.4.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/window-vibrancy/window-vibrancy-0.6.0.crate",
-		"sha256": "d9bec5a31f3f9362f2258fd0e9c9dd61a9ca432e7306cc78c444258f0dce9a9c",
-		"dest": "cargo/vendor/window-vibrancy-0.6.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"d9bec5a31f3f9362f2258fd0e9c9dd61a9ca432e7306cc78c444258f0dce9a9c\", \"files\": {}}",
-		"dest": "cargo/vendor/window-vibrancy-0.6.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/windows/windows-0.58.0.crate",
-		"sha256": "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6",
-		"dest": "cargo/vendor/windows-0.58.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6\", \"files\": {}}",
-		"dest": "cargo/vendor/windows-0.58.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/windows/windows-0.61.3.crate",
-		"sha256": "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893",
-		"dest": "cargo/vendor/windows-0.61.3"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893\", \"files\": {}}",
-		"dest": "cargo/vendor/windows-0.61.3",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/windows/windows-0.62.2.crate",
-		"sha256": "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580",
-		"dest": "cargo/vendor/windows-0.62.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580\", \"files\": {}}",
-		"dest": "cargo/vendor/windows-0.62.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/windows-collections/windows-collections-0.2.0.crate",
-		"sha256": "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8",
-		"dest": "cargo/vendor/windows-collections-0.2.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8\", \"files\": {}}",
-		"dest": "cargo/vendor/windows-collections-0.2.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/windows-collections/windows-collections-0.3.2.crate",
-		"sha256": "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610",
-		"dest": "cargo/vendor/windows-collections-0.3.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610\", \"files\": {}}",
-		"dest": "cargo/vendor/windows-collections-0.3.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/windows-core/windows-core-0.58.0.crate",
-		"sha256": "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99",
-		"dest": "cargo/vendor/windows-core-0.58.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99\", \"files\": {}}",
-		"dest": "cargo/vendor/windows-core-0.58.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/windows-core/windows-core-0.61.2.crate",
-		"sha256": "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3",
-		"dest": "cargo/vendor/windows-core-0.61.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3\", \"files\": {}}",
-		"dest": "cargo/vendor/windows-core-0.61.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/windows-core/windows-core-0.62.2.crate",
-		"sha256": "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb",
-		"dest": "cargo/vendor/windows-core-0.62.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb\", \"files\": {}}",
-		"dest": "cargo/vendor/windows-core-0.62.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/windows-future/windows-future-0.2.1.crate",
-		"sha256": "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e",
-		"dest": "cargo/vendor/windows-future-0.2.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e\", \"files\": {}}",
-		"dest": "cargo/vendor/windows-future-0.2.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/windows-future/windows-future-0.3.2.crate",
-		"sha256": "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb",
-		"dest": "cargo/vendor/windows-future-0.3.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb\", \"files\": {}}",
-		"dest": "cargo/vendor/windows-future-0.3.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/windows-implement/windows-implement-0.58.0.crate",
-		"sha256": "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b",
-		"dest": "cargo/vendor/windows-implement-0.58.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b\", \"files\": {}}",
-		"dest": "cargo/vendor/windows-implement-0.58.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/windows-implement/windows-implement-0.60.2.crate",
-		"sha256": "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf",
-		"dest": "cargo/vendor/windows-implement-0.60.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf\", \"files\": {}}",
-		"dest": "cargo/vendor/windows-implement-0.60.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/windows-interface/windows-interface-0.58.0.crate",
-		"sha256": "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515",
-		"dest": "cargo/vendor/windows-interface-0.58.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515\", \"files\": {}}",
-		"dest": "cargo/vendor/windows-interface-0.58.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/windows-interface/windows-interface-0.59.3.crate",
-		"sha256": "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358",
-		"dest": "cargo/vendor/windows-interface-0.59.3"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358\", \"files\": {}}",
-		"dest": "cargo/vendor/windows-interface-0.59.3",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/windows-link/windows-link-0.1.3.crate",
-		"sha256": "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a",
-		"dest": "cargo/vendor/windows-link-0.1.3"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a\", \"files\": {}}",
-		"dest": "cargo/vendor/windows-link-0.1.3",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/windows-link/windows-link-0.2.1.crate",
-		"sha256": "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5",
-		"dest": "cargo/vendor/windows-link-0.2.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5\", \"files\": {}}",
-		"dest": "cargo/vendor/windows-link-0.2.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/windows-numerics/windows-numerics-0.2.0.crate",
-		"sha256": "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1",
-		"dest": "cargo/vendor/windows-numerics-0.2.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1\", \"files\": {}}",
-		"dest": "cargo/vendor/windows-numerics-0.2.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/windows-numerics/windows-numerics-0.3.1.crate",
-		"sha256": "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26",
-		"dest": "cargo/vendor/windows-numerics-0.3.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26\", \"files\": {}}",
-		"dest": "cargo/vendor/windows-numerics-0.3.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/windows-registry/windows-registry-0.6.1.crate",
-		"sha256": "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720",
-		"dest": "cargo/vendor/windows-registry-0.6.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720\", \"files\": {}}",
-		"dest": "cargo/vendor/windows-registry-0.6.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/windows-result/windows-result-0.2.0.crate",
-		"sha256": "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e",
-		"dest": "cargo/vendor/windows-result-0.2.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e\", \"files\": {}}",
-		"dest": "cargo/vendor/windows-result-0.2.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/windows-result/windows-result-0.3.4.crate",
-		"sha256": "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6",
-		"dest": "cargo/vendor/windows-result-0.3.4"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6\", \"files\": {}}",
-		"dest": "cargo/vendor/windows-result-0.3.4",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/windows-result/windows-result-0.4.1.crate",
-		"sha256": "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5",
-		"dest": "cargo/vendor/windows-result-0.4.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5\", \"files\": {}}",
-		"dest": "cargo/vendor/windows-result-0.4.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/windows-strings/windows-strings-0.1.0.crate",
-		"sha256": "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10",
-		"dest": "cargo/vendor/windows-strings-0.1.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10\", \"files\": {}}",
-		"dest": "cargo/vendor/windows-strings-0.1.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/windows-strings/windows-strings-0.4.2.crate",
-		"sha256": "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57",
-		"dest": "cargo/vendor/windows-strings-0.4.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57\", \"files\": {}}",
-		"dest": "cargo/vendor/windows-strings-0.4.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/windows-strings/windows-strings-0.5.1.crate",
-		"sha256": "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091",
-		"dest": "cargo/vendor/windows-strings-0.5.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091\", \"files\": {}}",
-		"dest": "cargo/vendor/windows-strings-0.5.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/windows-sys/windows-sys-0.45.0.crate",
-		"sha256": "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0",
-		"dest": "cargo/vendor/windows-sys-0.45.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0\", \"files\": {}}",
-		"dest": "cargo/vendor/windows-sys-0.45.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/windows-sys/windows-sys-0.48.0.crate",
-		"sha256": "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9",
-		"dest": "cargo/vendor/windows-sys-0.48.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9\", \"files\": {}}",
-		"dest": "cargo/vendor/windows-sys-0.48.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/windows-sys/windows-sys-0.52.0.crate",
-		"sha256": "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d",
-		"dest": "cargo/vendor/windows-sys-0.52.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d\", \"files\": {}}",
-		"dest": "cargo/vendor/windows-sys-0.52.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/windows-sys/windows-sys-0.59.0.crate",
-		"sha256": "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b",
-		"dest": "cargo/vendor/windows-sys-0.59.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b\", \"files\": {}}",
-		"dest": "cargo/vendor/windows-sys-0.59.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/windows-sys/windows-sys-0.60.2.crate",
-		"sha256": "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb",
-		"dest": "cargo/vendor/windows-sys-0.60.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb\", \"files\": {}}",
-		"dest": "cargo/vendor/windows-sys-0.60.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/windows-sys/windows-sys-0.61.2.crate",
-		"sha256": "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc",
-		"dest": "cargo/vendor/windows-sys-0.61.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc\", \"files\": {}}",
-		"dest": "cargo/vendor/windows-sys-0.61.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/windows-targets/windows-targets-0.42.2.crate",
-		"sha256": "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071",
-		"dest": "cargo/vendor/windows-targets-0.42.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071\", \"files\": {}}",
-		"dest": "cargo/vendor/windows-targets-0.42.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/windows-targets/windows-targets-0.48.5.crate",
-		"sha256": "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c",
-		"dest": "cargo/vendor/windows-targets-0.48.5"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c\", \"files\": {}}",
-		"dest": "cargo/vendor/windows-targets-0.48.5",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/windows-targets/windows-targets-0.52.6.crate",
-		"sha256": "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973",
-		"dest": "cargo/vendor/windows-targets-0.52.6"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973\", \"files\": {}}",
-		"dest": "cargo/vendor/windows-targets-0.52.6",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/windows-targets/windows-targets-0.53.5.crate",
-		"sha256": "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3",
-		"dest": "cargo/vendor/windows-targets-0.53.5"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3\", \"files\": {}}",
-		"dest": "cargo/vendor/windows-targets-0.53.5",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/windows-threading/windows-threading-0.1.0.crate",
-		"sha256": "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6",
-		"dest": "cargo/vendor/windows-threading-0.1.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6\", \"files\": {}}",
-		"dest": "cargo/vendor/windows-threading-0.1.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/windows-threading/windows-threading-0.2.1.crate",
-		"sha256": "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37",
-		"dest": "cargo/vendor/windows-threading-0.2.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37\", \"files\": {}}",
-		"dest": "cargo/vendor/windows-threading-0.2.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/windows-version/windows-version-0.1.7.crate",
-		"sha256": "e4060a1da109b9d0326b7262c8e12c84df67cc0dbc9e33cf49e01ccc2eb63631",
-		"dest": "cargo/vendor/windows-version-0.1.7"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"e4060a1da109b9d0326b7262c8e12c84df67cc0dbc9e33cf49e01ccc2eb63631\", \"files\": {}}",
-		"dest": "cargo/vendor/windows-version-0.1.7",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/windows_aarch64_gnullvm/windows_aarch64_gnullvm-0.42.2.crate",
-		"sha256": "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8",
-		"dest": "cargo/vendor/windows_aarch64_gnullvm-0.42.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8\", \"files\": {}}",
-		"dest": "cargo/vendor/windows_aarch64_gnullvm-0.42.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/windows_aarch64_gnullvm/windows_aarch64_gnullvm-0.48.5.crate",
-		"sha256": "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8",
-		"dest": "cargo/vendor/windows_aarch64_gnullvm-0.48.5"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8\", \"files\": {}}",
-		"dest": "cargo/vendor/windows_aarch64_gnullvm-0.48.5",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/windows_aarch64_gnullvm/windows_aarch64_gnullvm-0.52.6.crate",
-		"sha256": "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3",
-		"dest": "cargo/vendor/windows_aarch64_gnullvm-0.52.6"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3\", \"files\": {}}",
-		"dest": "cargo/vendor/windows_aarch64_gnullvm-0.52.6",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/windows_aarch64_gnullvm/windows_aarch64_gnullvm-0.53.1.crate",
-		"sha256": "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53",
-		"dest": "cargo/vendor/windows_aarch64_gnullvm-0.53.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53\", \"files\": {}}",
-		"dest": "cargo/vendor/windows_aarch64_gnullvm-0.53.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/windows_aarch64_msvc/windows_aarch64_msvc-0.42.2.crate",
-		"sha256": "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43",
-		"dest": "cargo/vendor/windows_aarch64_msvc-0.42.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43\", \"files\": {}}",
-		"dest": "cargo/vendor/windows_aarch64_msvc-0.42.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/windows_aarch64_msvc/windows_aarch64_msvc-0.48.5.crate",
-		"sha256": "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc",
-		"dest": "cargo/vendor/windows_aarch64_msvc-0.48.5"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc\", \"files\": {}}",
-		"dest": "cargo/vendor/windows_aarch64_msvc-0.48.5",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/windows_aarch64_msvc/windows_aarch64_msvc-0.52.6.crate",
-		"sha256": "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469",
-		"dest": "cargo/vendor/windows_aarch64_msvc-0.52.6"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469\", \"files\": {}}",
-		"dest": "cargo/vendor/windows_aarch64_msvc-0.52.6",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/windows_aarch64_msvc/windows_aarch64_msvc-0.53.1.crate",
-		"sha256": "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006",
-		"dest": "cargo/vendor/windows_aarch64_msvc-0.53.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006\", \"files\": {}}",
-		"dest": "cargo/vendor/windows_aarch64_msvc-0.53.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/windows_i686_gnu/windows_i686_gnu-0.42.2.crate",
-		"sha256": "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f",
-		"dest": "cargo/vendor/windows_i686_gnu-0.42.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f\", \"files\": {}}",
-		"dest": "cargo/vendor/windows_i686_gnu-0.42.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/windows_i686_gnu/windows_i686_gnu-0.48.5.crate",
-		"sha256": "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e",
-		"dest": "cargo/vendor/windows_i686_gnu-0.48.5"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e\", \"files\": {}}",
-		"dest": "cargo/vendor/windows_i686_gnu-0.48.5",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/windows_i686_gnu/windows_i686_gnu-0.52.6.crate",
-		"sha256": "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b",
-		"dest": "cargo/vendor/windows_i686_gnu-0.52.6"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b\", \"files\": {}}",
-		"dest": "cargo/vendor/windows_i686_gnu-0.52.6",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/windows_i686_gnu/windows_i686_gnu-0.53.1.crate",
-		"sha256": "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3",
-		"dest": "cargo/vendor/windows_i686_gnu-0.53.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3\", \"files\": {}}",
-		"dest": "cargo/vendor/windows_i686_gnu-0.53.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/windows_i686_gnullvm/windows_i686_gnullvm-0.52.6.crate",
-		"sha256": "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66",
-		"dest": "cargo/vendor/windows_i686_gnullvm-0.52.6"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66\", \"files\": {}}",
-		"dest": "cargo/vendor/windows_i686_gnullvm-0.52.6",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/windows_i686_gnullvm/windows_i686_gnullvm-0.53.1.crate",
-		"sha256": "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c",
-		"dest": "cargo/vendor/windows_i686_gnullvm-0.53.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c\", \"files\": {}}",
-		"dest": "cargo/vendor/windows_i686_gnullvm-0.53.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/windows_i686_msvc/windows_i686_msvc-0.42.2.crate",
-		"sha256": "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060",
-		"dest": "cargo/vendor/windows_i686_msvc-0.42.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060\", \"files\": {}}",
-		"dest": "cargo/vendor/windows_i686_msvc-0.42.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/windows_i686_msvc/windows_i686_msvc-0.48.5.crate",
-		"sha256": "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406",
-		"dest": "cargo/vendor/windows_i686_msvc-0.48.5"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406\", \"files\": {}}",
-		"dest": "cargo/vendor/windows_i686_msvc-0.48.5",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/windows_i686_msvc/windows_i686_msvc-0.52.6.crate",
-		"sha256": "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66",
-		"dest": "cargo/vendor/windows_i686_msvc-0.52.6"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66\", \"files\": {}}",
-		"dest": "cargo/vendor/windows_i686_msvc-0.52.6",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/windows_i686_msvc/windows_i686_msvc-0.53.1.crate",
-		"sha256": "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2",
-		"dest": "cargo/vendor/windows_i686_msvc-0.53.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2\", \"files\": {}}",
-		"dest": "cargo/vendor/windows_i686_msvc-0.53.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/windows_x86_64_gnu/windows_x86_64_gnu-0.42.2.crate",
-		"sha256": "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36",
-		"dest": "cargo/vendor/windows_x86_64_gnu-0.42.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36\", \"files\": {}}",
-		"dest": "cargo/vendor/windows_x86_64_gnu-0.42.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/windows_x86_64_gnu/windows_x86_64_gnu-0.48.5.crate",
-		"sha256": "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e",
-		"dest": "cargo/vendor/windows_x86_64_gnu-0.48.5"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e\", \"files\": {}}",
-		"dest": "cargo/vendor/windows_x86_64_gnu-0.48.5",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/windows_x86_64_gnu/windows_x86_64_gnu-0.52.6.crate",
-		"sha256": "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78",
-		"dest": "cargo/vendor/windows_x86_64_gnu-0.52.6"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78\", \"files\": {}}",
-		"dest": "cargo/vendor/windows_x86_64_gnu-0.52.6",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/windows_x86_64_gnu/windows_x86_64_gnu-0.53.1.crate",
-		"sha256": "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499",
-		"dest": "cargo/vendor/windows_x86_64_gnu-0.53.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499\", \"files\": {}}",
-		"dest": "cargo/vendor/windows_x86_64_gnu-0.53.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/windows_x86_64_gnullvm/windows_x86_64_gnullvm-0.42.2.crate",
-		"sha256": "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3",
-		"dest": "cargo/vendor/windows_x86_64_gnullvm-0.42.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3\", \"files\": {}}",
-		"dest": "cargo/vendor/windows_x86_64_gnullvm-0.42.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/windows_x86_64_gnullvm/windows_x86_64_gnullvm-0.48.5.crate",
-		"sha256": "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc",
-		"dest": "cargo/vendor/windows_x86_64_gnullvm-0.48.5"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc\", \"files\": {}}",
-		"dest": "cargo/vendor/windows_x86_64_gnullvm-0.48.5",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/windows_x86_64_gnullvm/windows_x86_64_gnullvm-0.52.6.crate",
-		"sha256": "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d",
-		"dest": "cargo/vendor/windows_x86_64_gnullvm-0.52.6"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d\", \"files\": {}}",
-		"dest": "cargo/vendor/windows_x86_64_gnullvm-0.52.6",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/windows_x86_64_gnullvm/windows_x86_64_gnullvm-0.53.1.crate",
-		"sha256": "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1",
-		"dest": "cargo/vendor/windows_x86_64_gnullvm-0.53.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1\", \"files\": {}}",
-		"dest": "cargo/vendor/windows_x86_64_gnullvm-0.53.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/windows_x86_64_msvc/windows_x86_64_msvc-0.42.2.crate",
-		"sha256": "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0",
-		"dest": "cargo/vendor/windows_x86_64_msvc-0.42.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0\", \"files\": {}}",
-		"dest": "cargo/vendor/windows_x86_64_msvc-0.42.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/windows_x86_64_msvc/windows_x86_64_msvc-0.48.5.crate",
-		"sha256": "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538",
-		"dest": "cargo/vendor/windows_x86_64_msvc-0.48.5"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538\", \"files\": {}}",
-		"dest": "cargo/vendor/windows_x86_64_msvc-0.48.5",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/windows_x86_64_msvc/windows_x86_64_msvc-0.52.6.crate",
-		"sha256": "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec",
-		"dest": "cargo/vendor/windows_x86_64_msvc-0.52.6"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec\", \"files\": {}}",
-		"dest": "cargo/vendor/windows_x86_64_msvc-0.52.6",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/windows_x86_64_msvc/windows_x86_64_msvc-0.53.1.crate",
-		"sha256": "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650",
-		"dest": "cargo/vendor/windows_x86_64_msvc-0.53.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650\", \"files\": {}}",
-		"dest": "cargo/vendor/windows_x86_64_msvc-0.53.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/winnow/winnow-0.5.40.crate",
-		"sha256": "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876",
-		"dest": "cargo/vendor/winnow-0.5.40"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876\", \"files\": {}}",
-		"dest": "cargo/vendor/winnow-0.5.40",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/winnow/winnow-0.7.15.crate",
-		"sha256": "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945",
-		"dest": "cargo/vendor/winnow-0.7.15"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945\", \"files\": {}}",
-		"dest": "cargo/vendor/winnow-0.7.15",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/winnow/winnow-1.0.3.crate",
-		"sha256": "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1",
-		"dest": "cargo/vendor/winnow-1.0.3"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1\", \"files\": {}}",
-		"dest": "cargo/vendor/winnow-1.0.3",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/winreg/winreg-0.52.0.crate",
-		"sha256": "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5",
-		"dest": "cargo/vendor/winreg-0.52.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5\", \"files\": {}}",
-		"dest": "cargo/vendor/winreg-0.52.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/winreg/winreg-0.55.0.crate",
-		"sha256": "cb5a765337c50e9ec252c2069be9bf91c7df47afb103b642ba3a53bf8101be97",
-		"dest": "cargo/vendor/winreg-0.55.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"cb5a765337c50e9ec252c2069be9bf91c7df47afb103b642ba3a53bf8101be97\", \"files\": {}}",
-		"dest": "cargo/vendor/winreg-0.55.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/wit-bindgen/wit-bindgen-0.57.1.crate",
-		"sha256": "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e",
-		"dest": "cargo/vendor/wit-bindgen-0.57.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e\", \"files\": {}}",
-		"dest": "cargo/vendor/wit-bindgen-0.57.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/wmi/wmi-0.18.4.crate",
-		"sha256": "7c81b85c57a57500e56669586496bf2abd5cf082b9d32995251185d105208b64",
-		"dest": "cargo/vendor/wmi-0.18.4"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"7c81b85c57a57500e56669586496bf2abd5cf082b9d32995251185d105208b64\", \"files\": {}}",
-		"dest": "cargo/vendor/wmi-0.18.4",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/writeable/writeable-0.6.3.crate",
-		"sha256": "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4",
-		"dest": "cargo/vendor/writeable-0.6.3"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4\", \"files\": {}}",
-		"dest": "cargo/vendor/writeable-0.6.3",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/wry/wry-0.54.4.crate",
-		"sha256": "e5a8135d8676225e5744de000d4dff5a082501bf7db6a1c1495034f8c314edbc",
-		"dest": "cargo/vendor/wry-0.54.4"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"e5a8135d8676225e5744de000d4dff5a082501bf7db6a1c1495034f8c314edbc\", \"files\": {}}",
-		"dest": "cargo/vendor/wry-0.54.4",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/ws_stream_wasm/ws_stream_wasm-0.7.5.crate",
-		"sha256": "6c173014acad22e83f16403ee360115b38846fe754e735c5d9d3803fe70c6abc",
-		"dest": "cargo/vendor/ws_stream_wasm-0.7.5"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"6c173014acad22e83f16403ee360115b38846fe754e735c5d9d3803fe70c6abc\", \"files\": {}}",
-		"dest": "cargo/vendor/ws_stream_wasm-0.7.5",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/x11/x11-2.21.0.crate",
-		"sha256": "502da5464ccd04011667b11c435cb992822c2c0dbde1770c988480d312a0db2e",
-		"dest": "cargo/vendor/x11-2.21.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"502da5464ccd04011667b11c435cb992822c2c0dbde1770c988480d312a0db2e\", \"files\": {}}",
-		"dest": "cargo/vendor/x11-2.21.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/x11-dl/x11-dl-2.21.0.crate",
-		"sha256": "38735924fedd5314a6e548792904ed8c6de6636285cb9fec04d5b1db85c1516f",
-		"dest": "cargo/vendor/x11-dl-2.21.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"38735924fedd5314a6e548792904ed8c6de6636285cb9fec04d5b1db85c1516f\", \"files\": {}}",
-		"dest": "cargo/vendor/x11-dl-2.21.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/x509-parser/x509-parser-0.18.1.crate",
-		"sha256": "d43b0f71ce057da06bc0851b23ee24f3f86190b07203dd8f567d0b706a185202",
-		"dest": "cargo/vendor/x509-parser-0.18.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"d43b0f71ce057da06bc0851b23ee24f3f86190b07203dd8f567d0b706a185202\", \"files\": {}}",
-		"dest": "cargo/vendor/x509-parser-0.18.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/xattr/xattr-1.6.1.crate",
-		"sha256": "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156",
-		"dest": "cargo/vendor/xattr-1.6.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156\", \"files\": {}}",
-		"dest": "cargo/vendor/xattr-1.6.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/xml-rs/xml-rs-0.8.28.crate",
-		"sha256": "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f",
-		"dest": "cargo/vendor/xml-rs-0.8.28"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f\", \"files\": {}}",
-		"dest": "cargo/vendor/xml-rs-0.8.28",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/xmltree/xmltree-0.10.3.crate",
-		"sha256": "d7d8a75eaf6557bb84a65ace8609883db44a29951042ada9b393151532e41fcb",
-		"dest": "cargo/vendor/xmltree-0.10.3"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"d7d8a75eaf6557bb84a65ace8609883db44a29951042ada9b393151532e41fcb\", \"files\": {}}",
-		"dest": "cargo/vendor/xmltree-0.10.3",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/y4m/y4m-0.8.0.crate",
-		"sha256": "7a5a4b21e1a62b67a2970e6831bc091d7b87e119e7f9791aef9702e3bef04448",
-		"dest": "cargo/vendor/y4m-0.8.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"7a5a4b21e1a62b67a2970e6831bc091d7b87e119e7f9791aef9702e3bef04448\", \"files\": {}}",
-		"dest": "cargo/vendor/y4m-0.8.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/yasna/yasna-0.6.0.crate",
-		"sha256": "b5f6765e852b9b4dc8e2a76843e4d64d1cea8e79bcde0b6901aea8e7c7f08282",
-		"dest": "cargo/vendor/yasna-0.6.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"b5f6765e852b9b4dc8e2a76843e4d64d1cea8e79bcde0b6901aea8e7c7f08282\", \"files\": {}}",
-		"dest": "cargo/vendor/yasna-0.6.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/yoke/yoke-0.8.3.crate",
-		"sha256": "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5",
-		"dest": "cargo/vendor/yoke-0.8.3"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5\", \"files\": {}}",
-		"dest": "cargo/vendor/yoke-0.8.3",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/yoke-derive/yoke-derive-0.8.2.crate",
-		"sha256": "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e",
-		"dest": "cargo/vendor/yoke-derive-0.8.2"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e\", \"files\": {}}",
-		"dest": "cargo/vendor/yoke-derive-0.8.2",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/zbus/zbus-5.17.0.crate",
-		"sha256": "a28b97f866896a4be7aefd2b5a8e01bb6773d19a775d54ab28b4d094b9a4480e",
-		"dest": "cargo/vendor/zbus-5.17.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"a28b97f866896a4be7aefd2b5a8e01bb6773d19a775d54ab28b4d094b9a4480e\", \"files\": {}}",
-		"dest": "cargo/vendor/zbus-5.17.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/zbus_macros/zbus_macros-5.17.0.crate",
-		"sha256": "5e05ad887425eecf5e8384dc2406a4a9313eb73468712fc1cdea362eb4fe0469",
-		"dest": "cargo/vendor/zbus_macros-5.17.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"5e05ad887425eecf5e8384dc2406a4a9313eb73468712fc1cdea362eb4fe0469\", \"files\": {}}",
-		"dest": "cargo/vendor/zbus_macros-5.17.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/zbus_names/zbus_names-4.3.3.crate",
-		"sha256": "1039ca249fee9559680f3a9f05b55e0761fee51af4f6c1e7d8c1f31e549721d2",
-		"dest": "cargo/vendor/zbus_names-4.3.3"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"1039ca249fee9559680f3a9f05b55e0761fee51af4f6c1e7d8c1f31e549721d2\", \"files\": {}}",
-		"dest": "cargo/vendor/zbus_names-4.3.3",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/zerocopy/zerocopy-0.8.53.crate",
-		"sha256": "75726053136156d419e285b9b7eddaaea9e3fea6ce32eed44a89901f0bd98de1",
-		"dest": "cargo/vendor/zerocopy-0.8.53"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"75726053136156d419e285b9b7eddaaea9e3fea6ce32eed44a89901f0bd98de1\", \"files\": {}}",
-		"dest": "cargo/vendor/zerocopy-0.8.53",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/zerocopy-derive/zerocopy-derive-0.8.53.crate",
-		"sha256": "4714fd92cf900833d49538023a9b3915155210801d1c1169eba513b2addefd71",
-		"dest": "cargo/vendor/zerocopy-derive-0.8.53"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"4714fd92cf900833d49538023a9b3915155210801d1c1169eba513b2addefd71\", \"files\": {}}",
-		"dest": "cargo/vendor/zerocopy-derive-0.8.53",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/zerofrom/zerofrom-0.1.8.crate",
-		"sha256": "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272",
-		"dest": "cargo/vendor/zerofrom-0.1.8"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272\", \"files\": {}}",
-		"dest": "cargo/vendor/zerofrom-0.1.8",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/zerofrom-derive/zerofrom-derive-0.1.7.crate",
-		"sha256": "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1",
-		"dest": "cargo/vendor/zerofrom-derive-0.1.7"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1\", \"files\": {}}",
-		"dest": "cargo/vendor/zerofrom-derive-0.1.7",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/zeroize/zeroize-1.9.0.crate",
-		"sha256": "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e",
-		"dest": "cargo/vendor/zeroize-1.9.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e\", \"files\": {}}",
-		"dest": "cargo/vendor/zeroize-1.9.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/zeroize_derive/zeroize_derive-1.5.0.crate",
-		"sha256": "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328",
-		"dest": "cargo/vendor/zeroize_derive-1.5.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328\", \"files\": {}}",
-		"dest": "cargo/vendor/zeroize_derive-1.5.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/zerotrie/zerotrie-0.2.4.crate",
-		"sha256": "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf",
-		"dest": "cargo/vendor/zerotrie-0.2.4"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf\", \"files\": {}}",
-		"dest": "cargo/vendor/zerotrie-0.2.4",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/zerovec/zerovec-0.11.6.crate",
-		"sha256": "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239",
-		"dest": "cargo/vendor/zerovec-0.11.6"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239\", \"files\": {}}",
-		"dest": "cargo/vendor/zerovec-0.11.6",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/zerovec-derive/zerovec-derive-0.11.3.crate",
-		"sha256": "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555",
-		"dest": "cargo/vendor/zerovec-derive-0.11.3"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555\", \"files\": {}}",
-		"dest": "cargo/vendor/zerovec-derive-0.11.3",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/zip/zip-4.6.1.crate",
-		"sha256": "caa8cd6af31c3b31c6631b8f483848b91589021b28fffe50adada48d4f4d2ed1",
-		"dest": "cargo/vendor/zip-4.6.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"caa8cd6af31c3b31c6631b8f483848b91589021b28fffe50adada48d4f4d2ed1\", \"files\": {}}",
-		"dest": "cargo/vendor/zip-4.6.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/zmij/zmij-1.0.21.crate",
-		"sha256": "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa",
-		"dest": "cargo/vendor/zmij-1.0.21"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa\", \"files\": {}}",
-		"dest": "cargo/vendor/zmij-1.0.21",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/zune-core/zune-core-0.5.1.crate",
-		"sha256": "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9",
-		"dest": "cargo/vendor/zune-core-0.5.1"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9\", \"files\": {}}",
-		"dest": "cargo/vendor/zune-core-0.5.1",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/zune-inflate/zune-inflate-0.2.54.crate",
-		"sha256": "73ab332fe2f6680068f3582b16a24f90ad7096d5d39b974d1c0aff0125116f02",
-		"dest": "cargo/vendor/zune-inflate-0.2.54"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"73ab332fe2f6680068f3582b16a24f90ad7096d5d39b974d1c0aff0125116f02\", \"files\": {}}",
-		"dest": "cargo/vendor/zune-inflate-0.2.54",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/zune-jpeg/zune-jpeg-0.5.15.crate",
-		"sha256": "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296",
-		"dest": "cargo/vendor/zune-jpeg-0.5.15"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296\", \"files\": {}}",
-		"dest": "cargo/vendor/zune-jpeg-0.5.15",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/zvariant/zvariant-5.13.0.crate",
-		"sha256": "7cf057bb00bf5c9ad77abb6147b0ca4818236a1858416e9d988e40d6322fefa7",
-		"dest": "cargo/vendor/zvariant-5.13.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"7cf057bb00bf5c9ad77abb6147b0ca4818236a1858416e9d988e40d6322fefa7\", \"files\": {}}",
-		"dest": "cargo/vendor/zvariant-5.13.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/zvariant_derive/zvariant_derive-5.13.0.crate",
-		"sha256": "8118ca6bda77bfc0ab51d660db0c955f2505eef854c9a449435bccb616933b31",
-		"dest": "cargo/vendor/zvariant_derive-5.13.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"8118ca6bda77bfc0ab51d660db0c955f2505eef854c9a449435bccb616933b31\", \"files\": {}}",
-		"dest": "cargo/vendor/zvariant_derive-5.13.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "archive",
-		"archive-type": "tar-gzip",
-		"url": "https://static.crates.io/crates/zvariant_utils/zvariant_utils-3.5.0.crate",
-		"sha256": "90cb9383f9b45290407a1258b202d3f8f01db719eb60b4e4055c6375af4fc7c7",
-		"dest": "cargo/vendor/zvariant_utils-3.5.0"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"package\": \"90cb9383f9b45290407a1258b202d3f8f01db719eb60b4e4055c6375af4fc7c7\", \"files\": {}}",
-		"dest": "cargo/vendor/zvariant_utils-3.5.0",
-		"dest-filename": ".cargo-checksum.json"
-	},
-	{
-		"type": "inline",
-		"contents": "[source.vendored-sources]\ndirectory = \"cargo/vendor\"\n\n[source.crates-io]\nreplace-with = \"vendored-sources\"\n",
-		"dest": "cargo",
-		"dest-filename": "config"
-	}
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/adler2/adler2-2.0.1.crate",
+        "sha256": "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa",
+        "dest": "cargo/vendor/adler2-2.0.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa\", \"files\": {}}",
+        "dest": "cargo/vendor/adler2-2.0.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/aead/aead-0.5.2.crate",
+        "sha256": "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0",
+        "dest": "cargo/vendor/aead-0.5.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0\", \"files\": {}}",
+        "dest": "cargo/vendor/aead-0.5.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/aes/aes-0.8.4.crate",
+        "sha256": "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0",
+        "dest": "cargo/vendor/aes-0.8.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0\", \"files\": {}}",
+        "dest": "cargo/vendor/aes-0.8.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/aes-gcm/aes-gcm-0.10.3.crate",
+        "sha256": "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1",
+        "dest": "cargo/vendor/aes-gcm-0.10.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1\", \"files\": {}}",
+        "dest": "cargo/vendor/aes-gcm-0.10.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/aho-corasick/aho-corasick-1.1.4.crate",
+        "sha256": "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301",
+        "dest": "cargo/vendor/aho-corasick-1.1.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301\", \"files\": {}}",
+        "dest": "cargo/vendor/aho-corasick-1.1.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/aligned/aligned-0.4.3.crate",
+        "sha256": "ee4508988c62edf04abd8d92897fca0c2995d907ce1dfeaf369dac3716a40685",
+        "dest": "cargo/vendor/aligned-0.4.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"ee4508988c62edf04abd8d92897fca0c2995d907ce1dfeaf369dac3716a40685\", \"files\": {}}",
+        "dest": "cargo/vendor/aligned-0.4.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/aligned-vec/aligned-vec-0.6.4.crate",
+        "sha256": "dc890384c8602f339876ded803c97ad529f3842aba97f6392b3dba0dd171769b",
+        "dest": "cargo/vendor/aligned-vec-0.6.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"dc890384c8602f339876ded803c97ad529f3842aba97f6392b3dba0dd171769b\", \"files\": {}}",
+        "dest": "cargo/vendor/aligned-vec-0.6.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/alloc-no-stdlib/alloc-no-stdlib-2.0.4.crate",
+        "sha256": "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3",
+        "dest": "cargo/vendor/alloc-no-stdlib-2.0.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3\", \"files\": {}}",
+        "dest": "cargo/vendor/alloc-no-stdlib-2.0.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/alloc-stdlib/alloc-stdlib-0.2.4.crate",
+        "sha256": "0e76a019e91224d279006ff972f1e984179a6e9feb050adba6ce8274aef23195",
+        "dest": "cargo/vendor/alloc-stdlib-0.2.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"0e76a019e91224d279006ff972f1e984179a6e9feb050adba6ce8274aef23195\", \"files\": {}}",
+        "dest": "cargo/vendor/alloc-stdlib-0.2.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/allocator-api2/allocator-api2-0.2.21.crate",
+        "sha256": "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923",
+        "dest": "cargo/vendor/allocator-api2-0.2.21"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923\", \"files\": {}}",
+        "dest": "cargo/vendor/allocator-api2-0.2.21",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/android_system_properties/android_system_properties-0.1.5.crate",
+        "sha256": "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311",
+        "dest": "cargo/vendor/android_system_properties-0.1.5"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311\", \"files\": {}}",
+        "dest": "cargo/vendor/android_system_properties-0.1.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/anstream/anstream-1.0.0.crate",
+        "sha256": "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d",
+        "dest": "cargo/vendor/anstream-1.0.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d\", \"files\": {}}",
+        "dest": "cargo/vendor/anstream-1.0.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/anstyle/anstyle-1.0.14.crate",
+        "sha256": "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000",
+        "dest": "cargo/vendor/anstyle-1.0.14"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000\", \"files\": {}}",
+        "dest": "cargo/vendor/anstyle-1.0.14",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/anstyle-parse/anstyle-parse-1.0.0.crate",
+        "sha256": "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e",
+        "dest": "cargo/vendor/anstyle-parse-1.0.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e\", \"files\": {}}",
+        "dest": "cargo/vendor/anstyle-parse-1.0.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/anstyle-query/anstyle-query-1.1.5.crate",
+        "sha256": "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc",
+        "dest": "cargo/vendor/anstyle-query-1.1.5"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc\", \"files\": {}}",
+        "dest": "cargo/vendor/anstyle-query-1.1.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/anstyle-wincon/anstyle-wincon-3.0.11.crate",
+        "sha256": "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d",
+        "dest": "cargo/vendor/anstyle-wincon-3.0.11"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d\", \"files\": {}}",
+        "dest": "cargo/vendor/anstyle-wincon-3.0.11",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/anyhow/anyhow-1.0.103.crate",
+        "sha256": "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3",
+        "dest": "cargo/vendor/anyhow-1.0.103"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3\", \"files\": {}}",
+        "dest": "cargo/vendor/anyhow-1.0.103",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/arbitrary/arbitrary-1.4.2.crate",
+        "sha256": "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1",
+        "dest": "cargo/vendor/arbitrary-1.4.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1\", \"files\": {}}",
+        "dest": "cargo/vendor/arbitrary-1.4.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/arc-swap/arc-swap-1.9.2.crate",
+        "sha256": "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b",
+        "dest": "cargo/vendor/arc-swap-1.9.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b\", \"files\": {}}",
+        "dest": "cargo/vendor/arc-swap-1.9.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/arg_enum_proc_macro/arg_enum_proc_macro-0.3.4.crate",
+        "sha256": "0ae92a5119aa49cdbcf6b9f893fe4e1d98b04ccbf82ee0584ad948a44a734dea",
+        "dest": "cargo/vendor/arg_enum_proc_macro-0.3.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"0ae92a5119aa49cdbcf6b9f893fe4e1d98b04ccbf82ee0584ad948a44a734dea\", \"files\": {}}",
+        "dest": "cargo/vendor/arg_enum_proc_macro-0.3.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/arrayref/arrayref-0.3.9.crate",
+        "sha256": "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb",
+        "dest": "cargo/vendor/arrayref-0.3.9"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb\", \"files\": {}}",
+        "dest": "cargo/vendor/arrayref-0.3.9",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/arrayvec/arrayvec-0.7.8.crate",
+        "sha256": "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56",
+        "dest": "cargo/vendor/arrayvec-0.7.8"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56\", \"files\": {}}",
+        "dest": "cargo/vendor/arrayvec-0.7.8",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/as-slice/as-slice-0.2.1.crate",
+        "sha256": "516b6b4f0e40d50dcda9365d53964ec74560ad4284da2e7fc97122cd83174516",
+        "dest": "cargo/vendor/as-slice-0.2.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"516b6b4f0e40d50dcda9365d53964ec74560ad4284da2e7fc97122cd83174516\", \"files\": {}}",
+        "dest": "cargo/vendor/as-slice-0.2.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/ashpd/ashpd-0.11.1.crate",
+        "sha256": "d2f3f79755c74fd155000314eb349864caa787c6592eace6c6882dad873d9c39",
+        "dest": "cargo/vendor/ashpd-0.11.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"d2f3f79755c74fd155000314eb349864caa787c6592eace6c6882dad873d9c39\", \"files\": {}}",
+        "dest": "cargo/vendor/ashpd-0.11.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/asn1-rs/asn1-rs-0.7.2.crate",
+        "sha256": "b7f43a50ac4fdca5df8e885c21b835997f0a1cdee65494a6847694a98652d9d8",
+        "dest": "cargo/vendor/asn1-rs-0.7.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"b7f43a50ac4fdca5df8e885c21b835997f0a1cdee65494a6847694a98652d9d8\", \"files\": {}}",
+        "dest": "cargo/vendor/asn1-rs-0.7.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/asn1-rs-derive/asn1-rs-derive-0.6.0.crate",
+        "sha256": "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c",
+        "dest": "cargo/vendor/asn1-rs-derive-0.6.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c\", \"files\": {}}",
+        "dest": "cargo/vendor/asn1-rs-derive-0.6.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/asn1-rs-impl/asn1-rs-impl-0.2.0.crate",
+        "sha256": "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7",
+        "dest": "cargo/vendor/asn1-rs-impl-0.2.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7\", \"files\": {}}",
+        "dest": "cargo/vendor/asn1-rs-impl-0.2.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/async-broadcast/async-broadcast-0.7.2.crate",
+        "sha256": "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532",
+        "dest": "cargo/vendor/async-broadcast-0.7.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532\", \"files\": {}}",
+        "dest": "cargo/vendor/async-broadcast-0.7.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/async-channel/async-channel-2.5.0.crate",
+        "sha256": "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2",
+        "dest": "cargo/vendor/async-channel-2.5.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2\", \"files\": {}}",
+        "dest": "cargo/vendor/async-channel-2.5.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/async-executor/async-executor-1.14.0.crate",
+        "sha256": "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a",
+        "dest": "cargo/vendor/async-executor-1.14.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a\", \"files\": {}}",
+        "dest": "cargo/vendor/async-executor-1.14.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/async-io/async-io-2.6.0.crate",
+        "sha256": "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc",
+        "dest": "cargo/vendor/async-io-2.6.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc\", \"files\": {}}",
+        "dest": "cargo/vendor/async-io-2.6.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/async-lock/async-lock-3.4.2.crate",
+        "sha256": "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311",
+        "dest": "cargo/vendor/async-lock-3.4.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311\", \"files\": {}}",
+        "dest": "cargo/vendor/async-lock-3.4.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/async-process/async-process-2.5.0.crate",
+        "sha256": "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75",
+        "dest": "cargo/vendor/async-process-2.5.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75\", \"files\": {}}",
+        "dest": "cargo/vendor/async-process-2.5.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/async-recursion/async-recursion-1.1.1.crate",
+        "sha256": "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11",
+        "dest": "cargo/vendor/async-recursion-1.1.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11\", \"files\": {}}",
+        "dest": "cargo/vendor/async-recursion-1.1.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/async-signal/async-signal-0.2.14.crate",
+        "sha256": "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485",
+        "dest": "cargo/vendor/async-signal-0.2.14"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485\", \"files\": {}}",
+        "dest": "cargo/vendor/async-signal-0.2.14",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/async-task/async-task-4.7.1.crate",
+        "sha256": "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de",
+        "dest": "cargo/vendor/async-task-4.7.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de\", \"files\": {}}",
+        "dest": "cargo/vendor/async-task-4.7.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/async-trait/async-trait-0.1.89.crate",
+        "sha256": "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb",
+        "dest": "cargo/vendor/async-trait-0.1.89"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb\", \"files\": {}}",
+        "dest": "cargo/vendor/async-trait-0.1.89",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/async_io_stream/async_io_stream-0.3.3.crate",
+        "sha256": "b6d7b9decdf35d8908a7e3ef02f64c5e9b1695e230154c0e8de3969142d9b94c",
+        "dest": "cargo/vendor/async_io_stream-0.3.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"b6d7b9decdf35d8908a7e3ef02f64c5e9b1695e230154c0e8de3969142d9b94c\", \"files\": {}}",
+        "dest": "cargo/vendor/async_io_stream-0.3.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/atk/atk-0.18.2.crate",
+        "sha256": "241b621213072e993be4f6f3a9e4b45f65b7e6faad43001be957184b7bb1824b",
+        "dest": "cargo/vendor/atk-0.18.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"241b621213072e993be4f6f3a9e4b45f65b7e6faad43001be957184b7bb1824b\", \"files\": {}}",
+        "dest": "cargo/vendor/atk-0.18.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/atk-sys/atk-sys-0.18.2.crate",
+        "sha256": "c5e48b684b0ca77d2bbadeef17424c2ea3c897d44d566a1617e7e8f30614d086",
+        "dest": "cargo/vendor/atk-sys-0.18.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"c5e48b684b0ca77d2bbadeef17424c2ea3c897d44d566a1617e7e8f30614d086\", \"files\": {}}",
+        "dest": "cargo/vendor/atk-sys-0.18.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/atomic-polyfill/atomic-polyfill-1.0.3.crate",
+        "sha256": "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4",
+        "dest": "cargo/vendor/atomic-polyfill-1.0.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4\", \"files\": {}}",
+        "dest": "cargo/vendor/atomic-polyfill-1.0.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/atomic-waker/atomic-waker-1.1.2.crate",
+        "sha256": "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0",
+        "dest": "cargo/vendor/atomic-waker-1.1.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0\", \"files\": {}}",
+        "dest": "cargo/vendor/atomic-waker-1.1.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/atomic_refcell/atomic_refcell-0.1.14.crate",
+        "sha256": "21e4227379beff4205943696e6c3e0cd809bacdf3f0edd6e3dd153e2269571a4",
+        "dest": "cargo/vendor/atomic_refcell-0.1.14"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"21e4227379beff4205943696e6c3e0cd809bacdf3f0edd6e3dd153e2269571a4\", \"files\": {}}",
+        "dest": "cargo/vendor/atomic_refcell-0.1.14",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/attohttpc/attohttpc-0.30.1.crate",
+        "sha256": "16e2cdb6d5ed835199484bb92bb8b3edd526effe995c61732580439c1a67e2e9",
+        "dest": "cargo/vendor/attohttpc-0.30.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"16e2cdb6d5ed835199484bb92bb8b3edd526effe995c61732580439c1a67e2e9\", \"files\": {}}",
+        "dest": "cargo/vendor/attohttpc-0.30.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/autocfg/autocfg-1.5.1.crate",
+        "sha256": "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53",
+        "dest": "cargo/vendor/autocfg-1.5.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53\", \"files\": {}}",
+        "dest": "cargo/vendor/autocfg-1.5.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/av-scenechange/av-scenechange-0.14.1.crate",
+        "sha256": "0f321d77c20e19b92c39e7471cf986812cbb46659d2af674adc4331ef3f18394",
+        "dest": "cargo/vendor/av-scenechange-0.14.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"0f321d77c20e19b92c39e7471cf986812cbb46659d2af674adc4331ef3f18394\", \"files\": {}}",
+        "dest": "cargo/vendor/av-scenechange-0.14.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/av1-grain/av1-grain-0.2.5.crate",
+        "sha256": "8cfddb07216410377231960af4fcab838eaa12e013417781b78bd95ee22077f8",
+        "dest": "cargo/vendor/av1-grain-0.2.5"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"8cfddb07216410377231960af4fcab838eaa12e013417781b78bd95ee22077f8\", \"files\": {}}",
+        "dest": "cargo/vendor/av1-grain-0.2.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/avif-serialize/avif-serialize-0.8.9.crate",
+        "sha256": "e7178fe5f7d460b13895ebb9dcb28a3a6216d2df2574a0806cb51b555d297f38",
+        "dest": "cargo/vendor/avif-serialize-0.8.9"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"e7178fe5f7d460b13895ebb9dcb28a3a6216d2df2574a0806cb51b555d297f38\", \"files\": {}}",
+        "dest": "cargo/vendor/avif-serialize-0.8.9",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/aws-lc-rs/aws-lc-rs-1.17.1.crate",
+        "sha256": "4342d8937fc7e5dd9b1c60292261c0670c882a2cd1719cfc11b1af41731e32ad",
+        "dest": "cargo/vendor/aws-lc-rs-1.17.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"4342d8937fc7e5dd9b1c60292261c0670c882a2cd1719cfc11b1af41731e32ad\", \"files\": {}}",
+        "dest": "cargo/vendor/aws-lc-rs-1.17.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/aws-lc-sys/aws-lc-sys-0.42.0.crate",
+        "sha256": "6d9ceb1da931507a12f4fccea479dccd00da1943e1b4ae72d8e502d707361444",
+        "dest": "cargo/vendor/aws-lc-sys-0.42.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"6d9ceb1da931507a12f4fccea479dccd00da1943e1b4ae72d8e502d707361444\", \"files\": {}}",
+        "dest": "cargo/vendor/aws-lc-sys-0.42.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/backon/backon-1.6.0.crate",
+        "sha256": "cffb0e931875b666fc4fcb20fee52e9bbd1ef836fd9e9e04ec21555f9f85f7ef",
+        "dest": "cargo/vendor/backon-1.6.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"cffb0e931875b666fc4fcb20fee52e9bbd1ef836fd9e9e04ec21555f9f85f7ef\", \"files\": {}}",
+        "dest": "cargo/vendor/backon-1.6.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/bao-tree/bao-tree-0.16.0.crate",
+        "sha256": "06384416b1825e6e04fde63262fda2dc408f5b64c02d04e0d8b70ae72c17a52b",
+        "dest": "cargo/vendor/bao-tree-0.16.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"06384416b1825e6e04fde63262fda2dc408f5b64c02d04e0d8b70ae72c17a52b\", \"files\": {}}",
+        "dest": "cargo/vendor/bao-tree-0.16.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/base16ct/base16ct-1.0.0.crate",
+        "sha256": "fd307490d624467aa6f74b0eabb77633d1f758a7b25f12bceb0b22e08d9726f6",
+        "dest": "cargo/vendor/base16ct-1.0.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"fd307490d624467aa6f74b0eabb77633d1f758a7b25f12bceb0b22e08d9726f6\", \"files\": {}}",
+        "dest": "cargo/vendor/base16ct-1.0.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/base64/base64-0.21.7.crate",
+        "sha256": "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567",
+        "dest": "cargo/vendor/base64-0.21.7"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567\", \"files\": {}}",
+        "dest": "cargo/vendor/base64-0.21.7",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/base64/base64-0.22.1.crate",
+        "sha256": "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6",
+        "dest": "cargo/vendor/base64-0.22.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6\", \"files\": {}}",
+        "dest": "cargo/vendor/base64-0.22.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/base64ct/base64ct-1.8.3.crate",
+        "sha256": "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06",
+        "dest": "cargo/vendor/base64ct-1.8.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06\", \"files\": {}}",
+        "dest": "cargo/vendor/base64ct-1.8.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/binary-merge/binary-merge-0.1.2.crate",
+        "sha256": "597bb81c80a54b6a4381b23faba8d7774b144c94cbd1d6fe3f1329bd776554ab",
+        "dest": "cargo/vendor/binary-merge-0.1.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"597bb81c80a54b6a4381b23faba8d7774b144c94cbd1d6fe3f1329bd776554ab\", \"files\": {}}",
+        "dest": "cargo/vendor/binary-merge-0.1.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/bit-set/bit-set-0.8.0.crate",
+        "sha256": "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3",
+        "dest": "cargo/vendor/bit-set-0.8.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3\", \"files\": {}}",
+        "dest": "cargo/vendor/bit-set-0.8.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/bit-vec/bit-vec-0.8.0.crate",
+        "sha256": "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7",
+        "dest": "cargo/vendor/bit-vec-0.8.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7\", \"files\": {}}",
+        "dest": "cargo/vendor/bit-vec-0.8.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/bit-vec/bit-vec-0.9.1.crate",
+        "sha256": "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51",
+        "dest": "cargo/vendor/bit-vec-0.9.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51\", \"files\": {}}",
+        "dest": "cargo/vendor/bit-vec-0.9.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/bit_field/bit_field-0.10.3.crate",
+        "sha256": "1e4b40c7323adcfc0a41c4b88143ed58346ff65a288fc144329c5c45e05d70c6",
+        "dest": "cargo/vendor/bit_field-0.10.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"1e4b40c7323adcfc0a41c4b88143ed58346ff65a288fc144329c5c45e05d70c6\", \"files\": {}}",
+        "dest": "cargo/vendor/bit_field-0.10.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/bitflags/bitflags-1.3.2.crate",
+        "sha256": "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a",
+        "dest": "cargo/vendor/bitflags-1.3.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a\", \"files\": {}}",
+        "dest": "cargo/vendor/bitflags-1.3.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/bitflags/bitflags-2.13.0.crate",
+        "sha256": "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8",
+        "dest": "cargo/vendor/bitflags-2.13.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8\", \"files\": {}}",
+        "dest": "cargo/vendor/bitflags-2.13.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/bitstream-io/bitstream-io-4.10.0.crate",
+        "sha256": "7eff00be299a18769011411c9def0d827e8f2d7bf0c3dbf53633147a8867fd1f",
+        "dest": "cargo/vendor/bitstream-io-4.10.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"7eff00be299a18769011411c9def0d827e8f2d7bf0c3dbf53633147a8867fd1f\", \"files\": {}}",
+        "dest": "cargo/vendor/bitstream-io-4.10.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/blake3/blake3-1.8.5.crate",
+        "sha256": "0aa83c34e62843d924f905e0f5c866eb1dd6545fc4d719e803d9ba6030371fce",
+        "dest": "cargo/vendor/blake3-1.8.5"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"0aa83c34e62843d924f905e0f5c866eb1dd6545fc4d719e803d9ba6030371fce\", \"files\": {}}",
+        "dest": "cargo/vendor/blake3-1.8.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/block-buffer/block-buffer-0.10.4.crate",
+        "sha256": "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71",
+        "dest": "cargo/vendor/block-buffer-0.10.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71\", \"files\": {}}",
+        "dest": "cargo/vendor/block-buffer-0.10.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/block-buffer/block-buffer-0.12.1.crate",
+        "sha256": "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa",
+        "dest": "cargo/vendor/block-buffer-0.12.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa\", \"files\": {}}",
+        "dest": "cargo/vendor/block-buffer-0.12.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/block2/block2-0.6.2.crate",
+        "sha256": "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5",
+        "dest": "cargo/vendor/block2-0.6.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5\", \"files\": {}}",
+        "dest": "cargo/vendor/block2-0.6.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/blocking/blocking-1.6.2.crate",
+        "sha256": "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21",
+        "dest": "cargo/vendor/blocking-1.6.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21\", \"files\": {}}",
+        "dest": "cargo/vendor/blocking-1.6.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/brotli/brotli-8.0.4.crate",
+        "sha256": "5cc91aac060a7a1e25823bdccbfb6af1875b88f17c6daac97894eed8207166b3",
+        "dest": "cargo/vendor/brotli-8.0.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"5cc91aac060a7a1e25823bdccbfb6af1875b88f17c6daac97894eed8207166b3\", \"files\": {}}",
+        "dest": "cargo/vendor/brotli-8.0.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/brotli-decompressor/brotli-decompressor-5.0.3.crate",
+        "sha256": "3a32acac15fe1967bc3986b2a6347dffc965602354ea6f450ad07e8bfd253583",
+        "dest": "cargo/vendor/brotli-decompressor-5.0.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"3a32acac15fe1967bc3986b2a6347dffc965602354ea6f450ad07e8bfd253583\", \"files\": {}}",
+        "dest": "cargo/vendor/brotli-decompressor-5.0.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/bs58/bs58-0.5.1.crate",
+        "sha256": "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4",
+        "dest": "cargo/vendor/bs58-0.5.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4\", \"files\": {}}",
+        "dest": "cargo/vendor/bs58-0.5.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/built/built-0.8.1.crate",
+        "sha256": "5c0e531d93d39c34eef561e929e8a7f86d77a5af08aac4f6d6e39976c51858e9",
+        "dest": "cargo/vendor/built-0.8.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"5c0e531d93d39c34eef561e929e8a7f86d77a5af08aac4f6d6e39976c51858e9\", \"files\": {}}",
+        "dest": "cargo/vendor/built-0.8.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/bumpalo/bumpalo-3.20.3.crate",
+        "sha256": "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649",
+        "dest": "cargo/vendor/bumpalo-3.20.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649\", \"files\": {}}",
+        "dest": "cargo/vendor/bumpalo-3.20.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/bytemuck/bytemuck-1.25.0.crate",
+        "sha256": "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec",
+        "dest": "cargo/vendor/bytemuck-1.25.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec\", \"files\": {}}",
+        "dest": "cargo/vendor/bytemuck-1.25.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/byteorder/byteorder-1.5.0.crate",
+        "sha256": "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b",
+        "dest": "cargo/vendor/byteorder-1.5.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b\", \"files\": {}}",
+        "dest": "cargo/vendor/byteorder-1.5.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/byteorder-lite/byteorder-lite-0.1.0.crate",
+        "sha256": "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495",
+        "dest": "cargo/vendor/byteorder-lite-0.1.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495\", \"files\": {}}",
+        "dest": "cargo/vendor/byteorder-lite-0.1.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/bytes/bytes-1.11.1.crate",
+        "sha256": "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33",
+        "dest": "cargo/vendor/bytes-1.11.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33\", \"files\": {}}",
+        "dest": "cargo/vendor/bytes-1.11.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/cairo-rs/cairo-rs-0.18.5.crate",
+        "sha256": "8ca26ef0159422fb77631dc9d17b102f253b876fe1586b03b803e63a309b4ee2",
+        "dest": "cargo/vendor/cairo-rs-0.18.5"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"8ca26ef0159422fb77631dc9d17b102f253b876fe1586b03b803e63a309b4ee2\", \"files\": {}}",
+        "dest": "cargo/vendor/cairo-rs-0.18.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/cairo-sys-rs/cairo-sys-rs-0.18.2.crate",
+        "sha256": "685c9fa8e590b8b3d678873528d83411db17242a73fccaed827770ea0fedda51",
+        "dest": "cargo/vendor/cairo-sys-rs-0.18.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"685c9fa8e590b8b3d678873528d83411db17242a73fccaed827770ea0fedda51\", \"files\": {}}",
+        "dest": "cargo/vendor/cairo-sys-rs-0.18.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/camino/camino-1.2.4.crate",
+        "sha256": "5f2d30e4173c4026932d51d31d6b0613b1fd3014bf3f9f8943d4ba139c437ba0",
+        "dest": "cargo/vendor/camino-1.2.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"5f2d30e4173c4026932d51d31d6b0613b1fd3014bf3f9f8943d4ba139c437ba0\", \"files\": {}}",
+        "dest": "cargo/vendor/camino-1.2.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/cargo-platform/cargo-platform-0.1.9.crate",
+        "sha256": "e35af189006b9c0f00a064685c727031e3ed2d8020f7ba284d78cc2671bd36ea",
+        "dest": "cargo/vendor/cargo-platform-0.1.9"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"e35af189006b9c0f00a064685c727031e3ed2d8020f7ba284d78cc2671bd36ea\", \"files\": {}}",
+        "dest": "cargo/vendor/cargo-platform-0.1.9",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/cargo_metadata/cargo_metadata-0.19.2.crate",
+        "sha256": "dd5eb614ed4c27c5d706420e4320fbe3216ab31fa1c33cd8246ac36dae4479ba",
+        "dest": "cargo/vendor/cargo_metadata-0.19.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"dd5eb614ed4c27c5d706420e4320fbe3216ab31fa1c33cd8246ac36dae4479ba\", \"files\": {}}",
+        "dest": "cargo/vendor/cargo_metadata-0.19.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/cargo_toml/cargo_toml-0.22.3.crate",
+        "sha256": "374b7c592d9c00c1f4972ea58390ac6b18cbb6ab79011f3bdc90a0b82ca06b77",
+        "dest": "cargo/vendor/cargo_toml-0.22.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"374b7c592d9c00c1f4972ea58390ac6b18cbb6ab79011f3bdc90a0b82ca06b77\", \"files\": {}}",
+        "dest": "cargo/vendor/cargo_toml-0.22.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/cc/cc-1.2.66.crate",
+        "sha256": "f5d6cac793997bd970000024b2934968efe83b382de4fdcf4fcb46b6ee4ad996",
+        "dest": "cargo/vendor/cc-1.2.66"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"f5d6cac793997bd970000024b2934968efe83b382de4fdcf4fcb46b6ee4ad996\", \"files\": {}}",
+        "dest": "cargo/vendor/cc-1.2.66",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/cesu8/cesu8-1.1.0.crate",
+        "sha256": "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c",
+        "dest": "cargo/vendor/cesu8-1.1.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c\", \"files\": {}}",
+        "dest": "cargo/vendor/cesu8-1.1.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/cfb/cfb-0.7.3.crate",
+        "sha256": "d38f2da7a0a2c4ccf0065be06397cc26a81f4e528be095826eee9d4adbb8c60f",
+        "dest": "cargo/vendor/cfb-0.7.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"d38f2da7a0a2c4ccf0065be06397cc26a81f4e528be095826eee9d4adbb8c60f\", \"files\": {}}",
+        "dest": "cargo/vendor/cfb-0.7.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/cfg-expr/cfg-expr-0.15.8.crate",
+        "sha256": "d067ad48b8650848b989a59a86c6c36a995d02d2bf778d45c3c5d57bc2718f02",
+        "dest": "cargo/vendor/cfg-expr-0.15.8"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"d067ad48b8650848b989a59a86c6c36a995d02d2bf778d45c3c5d57bc2718f02\", \"files\": {}}",
+        "dest": "cargo/vendor/cfg-expr-0.15.8",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/cfg-expr/cfg-expr-0.20.8.crate",
+        "sha256": "fb693542bcafa528e198be0ebd9d3632ca5b7c93dbe7237460e199910835997c",
+        "dest": "cargo/vendor/cfg-expr-0.20.8"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"fb693542bcafa528e198be0ebd9d3632ca5b7c93dbe7237460e199910835997c\", \"files\": {}}",
+        "dest": "cargo/vendor/cfg-expr-0.20.8",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/cfg-if/cfg-if-1.0.4.crate",
+        "sha256": "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801",
+        "dest": "cargo/vendor/cfg-if-1.0.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801\", \"files\": {}}",
+        "dest": "cargo/vendor/cfg-if-1.0.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/cfg_aliases/cfg_aliases-0.2.2.crate",
+        "sha256": "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527",
+        "dest": "cargo/vendor/cfg_aliases-0.2.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527\", \"files\": {}}",
+        "dest": "cargo/vendor/cfg_aliases-0.2.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/chacha20/chacha20-0.10.1.crate",
+        "sha256": "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81",
+        "dest": "cargo/vendor/chacha20-0.10.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81\", \"files\": {}}",
+        "dest": "cargo/vendor/chacha20-0.10.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/chrono/chrono-0.4.45.crate",
+        "sha256": "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327",
+        "dest": "cargo/vendor/chrono-0.4.45"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327\", \"files\": {}}",
+        "dest": "cargo/vendor/chrono-0.4.45",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/cipher/cipher-0.4.4.crate",
+        "sha256": "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad",
+        "dest": "cargo/vendor/cipher-0.4.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad\", \"files\": {}}",
+        "dest": "cargo/vendor/cipher-0.4.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/clap/clap-4.6.1.crate",
+        "sha256": "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51",
+        "dest": "cargo/vendor/clap-4.6.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51\", \"files\": {}}",
+        "dest": "cargo/vendor/clap-4.6.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/clap_builder/clap_builder-4.6.0.crate",
+        "sha256": "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f",
+        "dest": "cargo/vendor/clap_builder-4.6.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f\", \"files\": {}}",
+        "dest": "cargo/vendor/clap_builder-4.6.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/clap_derive/clap_derive-4.6.1.crate",
+        "sha256": "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9",
+        "dest": "cargo/vendor/clap_derive-4.6.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9\", \"files\": {}}",
+        "dest": "cargo/vendor/clap_derive-4.6.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/clap_lex/clap_lex-1.1.0.crate",
+        "sha256": "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9",
+        "dest": "cargo/vendor/clap_lex-1.1.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9\", \"files\": {}}",
+        "dest": "cargo/vendor/clap_lex-1.1.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/cmake/cmake-0.1.58.crate",
+        "sha256": "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678",
+        "dest": "cargo/vendor/cmake-0.1.58"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678\", \"files\": {}}",
+        "dest": "cargo/vendor/cmake-0.1.58",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/cmov/cmov-0.5.4.crate",
+        "sha256": "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a",
+        "dest": "cargo/vendor/cmov-0.5.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a\", \"files\": {}}",
+        "dest": "cargo/vendor/cmov-0.5.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/cobs/cobs-0.3.0.crate",
+        "sha256": "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1",
+        "dest": "cargo/vendor/cobs-0.3.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1\", \"files\": {}}",
+        "dest": "cargo/vendor/cobs-0.3.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/color_quant/color_quant-1.1.0.crate",
+        "sha256": "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b",
+        "dest": "cargo/vendor/color_quant-1.1.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b\", \"files\": {}}",
+        "dest": "cargo/vendor/color_quant-1.1.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/colorchoice/colorchoice-1.0.5.crate",
+        "sha256": "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570",
+        "dest": "cargo/vendor/colorchoice-1.0.5"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570\", \"files\": {}}",
+        "dest": "cargo/vendor/colorchoice-1.0.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/combine/combine-4.6.7.crate",
+        "sha256": "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd",
+        "dest": "cargo/vendor/combine-4.6.7"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd\", \"files\": {}}",
+        "dest": "cargo/vendor/combine-4.6.7",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/concurrent-queue/concurrent-queue-2.5.0.crate",
+        "sha256": "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973",
+        "dest": "cargo/vendor/concurrent-queue-2.5.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973\", \"files\": {}}",
+        "dest": "cargo/vendor/concurrent-queue-2.5.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/console/console-0.15.11.crate",
+        "sha256": "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8",
+        "dest": "cargo/vendor/console-0.15.11"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8\", \"files\": {}}",
+        "dest": "cargo/vendor/console-0.15.11",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/const-oid/const-oid-0.10.2.crate",
+        "sha256": "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c",
+        "dest": "cargo/vendor/const-oid-0.10.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c\", \"files\": {}}",
+        "dest": "cargo/vendor/const-oid-0.10.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/const-random/const-random-0.1.18.crate",
+        "sha256": "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359",
+        "dest": "cargo/vendor/const-random-0.1.18"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359\", \"files\": {}}",
+        "dest": "cargo/vendor/const-random-0.1.18",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/const-random-macro/const-random-macro-0.1.16.crate",
+        "sha256": "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e",
+        "dest": "cargo/vendor/const-random-macro-0.1.16"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e\", \"files\": {}}",
+        "dest": "cargo/vendor/const-random-macro-0.1.16",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/constant_time_eq/constant_time_eq-0.4.2.crate",
+        "sha256": "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b",
+        "dest": "cargo/vendor/constant_time_eq-0.4.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b\", \"files\": {}}",
+        "dest": "cargo/vendor/constant_time_eq-0.4.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/convert_case/convert_case-0.4.0.crate",
+        "sha256": "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e",
+        "dest": "cargo/vendor/convert_case-0.4.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e\", \"files\": {}}",
+        "dest": "cargo/vendor/convert_case-0.4.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/convert_case/convert_case-0.10.0.crate",
+        "sha256": "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9",
+        "dest": "cargo/vendor/convert_case-0.10.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9\", \"files\": {}}",
+        "dest": "cargo/vendor/convert_case-0.10.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/cookie/cookie-0.18.1.crate",
+        "sha256": "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747",
+        "dest": "cargo/vendor/cookie-0.18.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747\", \"files\": {}}",
+        "dest": "cargo/vendor/cookie-0.18.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/cordyceps/cordyceps-0.3.4.crate",
+        "sha256": "688d7fbb8092b8de775ef2536f36c8c31f2bc4006ece2e8d8ad2d17d00ce0a2a",
+        "dest": "cargo/vendor/cordyceps-0.3.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"688d7fbb8092b8de775ef2536f36c8c31f2bc4006ece2e8d8ad2d17d00ce0a2a\", \"files\": {}}",
+        "dest": "cargo/vendor/cordyceps-0.3.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/core-foundation/core-foundation-0.9.4.crate",
+        "sha256": "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f",
+        "dest": "cargo/vendor/core-foundation-0.9.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f\", \"files\": {}}",
+        "dest": "cargo/vendor/core-foundation-0.9.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/core-foundation/core-foundation-0.10.1.crate",
+        "sha256": "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6",
+        "dest": "cargo/vendor/core-foundation-0.10.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6\", \"files\": {}}",
+        "dest": "cargo/vendor/core-foundation-0.10.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/core-foundation-sys/core-foundation-sys-0.8.7.crate",
+        "sha256": "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b",
+        "dest": "cargo/vendor/core-foundation-sys-0.8.7"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b\", \"files\": {}}",
+        "dest": "cargo/vendor/core-foundation-sys-0.8.7",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/core-graphics/core-graphics-0.24.0.crate",
+        "sha256": "fa95a34622365fa5bbf40b20b75dba8dfa8c94c734aea8ac9a5ca38af14316f1",
+        "dest": "cargo/vendor/core-graphics-0.24.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"fa95a34622365fa5bbf40b20b75dba8dfa8c94c734aea8ac9a5ca38af14316f1\", \"files\": {}}",
+        "dest": "cargo/vendor/core-graphics-0.24.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/core-graphics/core-graphics-0.25.0.crate",
+        "sha256": "064badf302c3194842cf2c5d61f56cc88e54a759313879cdf03abdd27d0c3b97",
+        "dest": "cargo/vendor/core-graphics-0.25.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"064badf302c3194842cf2c5d61f56cc88e54a759313879cdf03abdd27d0c3b97\", \"files\": {}}",
+        "dest": "cargo/vendor/core-graphics-0.25.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/core-graphics-types/core-graphics-types-0.2.0.crate",
+        "sha256": "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb",
+        "dest": "cargo/vendor/core-graphics-types-0.2.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb\", \"files\": {}}",
+        "dest": "cargo/vendor/core-graphics-types-0.2.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/cpufeatures/cpufeatures-0.2.17.crate",
+        "sha256": "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280",
+        "dest": "cargo/vendor/cpufeatures-0.2.17"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280\", \"files\": {}}",
+        "dest": "cargo/vendor/cpufeatures-0.2.17",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/cpufeatures/cpufeatures-0.3.0.crate",
+        "sha256": "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201",
+        "dest": "cargo/vendor/cpufeatures-0.3.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201\", \"files\": {}}",
+        "dest": "cargo/vendor/cpufeatures-0.3.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/crc32fast/crc32fast-1.5.0.crate",
+        "sha256": "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511",
+        "dest": "cargo/vendor/crc32fast-1.5.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511\", \"files\": {}}",
+        "dest": "cargo/vendor/crc32fast-1.5.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/critical-section/critical-section-1.2.0.crate",
+        "sha256": "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b",
+        "dest": "cargo/vendor/critical-section-1.2.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b\", \"files\": {}}",
+        "dest": "cargo/vendor/critical-section-1.2.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/crossbeam-channel/crossbeam-channel-0.5.16.crate",
+        "sha256": "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e",
+        "dest": "cargo/vendor/crossbeam-channel-0.5.16"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e\", \"files\": {}}",
+        "dest": "cargo/vendor/crossbeam-channel-0.5.16",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/crossbeam-deque/crossbeam-deque-0.8.7.crate",
+        "sha256": "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb",
+        "dest": "cargo/vendor/crossbeam-deque-0.8.7"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb\", \"files\": {}}",
+        "dest": "cargo/vendor/crossbeam-deque-0.8.7",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/crossbeam-epoch/crossbeam-epoch-0.9.20.crate",
+        "sha256": "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f",
+        "dest": "cargo/vendor/crossbeam-epoch-0.9.20"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f\", \"files\": {}}",
+        "dest": "cargo/vendor/crossbeam-epoch-0.9.20",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/crossbeam-utils/crossbeam-utils-0.8.22.crate",
+        "sha256": "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17",
+        "dest": "cargo/vendor/crossbeam-utils-0.8.22"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17\", \"files\": {}}",
+        "dest": "cargo/vendor/crossbeam-utils-0.8.22",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/crossterm/crossterm-0.29.0.crate",
+        "sha256": "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b",
+        "dest": "cargo/vendor/crossterm-0.29.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b\", \"files\": {}}",
+        "dest": "cargo/vendor/crossterm-0.29.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/crossterm_winapi/crossterm_winapi-0.9.1.crate",
+        "sha256": "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b",
+        "dest": "cargo/vendor/crossterm_winapi-0.9.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b\", \"files\": {}}",
+        "dest": "cargo/vendor/crossterm_winapi-0.9.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/crunchy/crunchy-0.2.4.crate",
+        "sha256": "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5",
+        "dest": "cargo/vendor/crunchy-0.2.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5\", \"files\": {}}",
+        "dest": "cargo/vendor/crunchy-0.2.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/crypto-common/crypto-common-0.1.7.crate",
+        "sha256": "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a",
+        "dest": "cargo/vendor/crypto-common-0.1.7"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a\", \"files\": {}}",
+        "dest": "cargo/vendor/crypto-common-0.1.7",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/crypto-common/crypto-common-0.2.2.crate",
+        "sha256": "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453",
+        "dest": "cargo/vendor/crypto-common-0.2.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453\", \"files\": {}}",
+        "dest": "cargo/vendor/crypto-common-0.2.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/cssparser/cssparser-0.29.6.crate",
+        "sha256": "f93d03419cb5950ccfd3daf3ff1c7a36ace64609a1a8746d493df1ca0afde0fa",
+        "dest": "cargo/vendor/cssparser-0.29.6"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"f93d03419cb5950ccfd3daf3ff1c7a36ace64609a1a8746d493df1ca0afde0fa\", \"files\": {}}",
+        "dest": "cargo/vendor/cssparser-0.29.6",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/cssparser/cssparser-0.36.0.crate",
+        "sha256": "dae61cf9c0abb83bd659dab65b7e4e38d8236824c85f0f804f173567bda257d2",
+        "dest": "cargo/vendor/cssparser-0.36.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"dae61cf9c0abb83bd659dab65b7e4e38d8236824c85f0f804f173567bda257d2\", \"files\": {}}",
+        "dest": "cargo/vendor/cssparser-0.36.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/cssparser-macros/cssparser-macros-0.6.1.crate",
+        "sha256": "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331",
+        "dest": "cargo/vendor/cssparser-macros-0.6.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331\", \"files\": {}}",
+        "dest": "cargo/vendor/cssparser-macros-0.6.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/ctor/ctor-0.8.0.crate",
+        "sha256": "352d39c2f7bef1d6ad73db6f5160efcaed66d94ef8c6c573a8410c00bf909a98",
+        "dest": "cargo/vendor/ctor-0.8.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"352d39c2f7bef1d6ad73db6f5160efcaed66d94ef8c6c573a8410c00bf909a98\", \"files\": {}}",
+        "dest": "cargo/vendor/ctor-0.8.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/ctor-proc-macro/ctor-proc-macro-0.0.7.crate",
+        "sha256": "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1",
+        "dest": "cargo/vendor/ctor-proc-macro-0.0.7"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1\", \"files\": {}}",
+        "dest": "cargo/vendor/ctor-proc-macro-0.0.7",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/ctr/ctr-0.9.2.crate",
+        "sha256": "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835",
+        "dest": "cargo/vendor/ctr-0.9.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835\", \"files\": {}}",
+        "dest": "cargo/vendor/ctr-0.9.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/ctutils/ctutils-0.4.2.crate",
+        "sha256": "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e",
+        "dest": "cargo/vendor/ctutils-0.4.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e\", \"files\": {}}",
+        "dest": "cargo/vendor/ctutils-0.4.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/curve25519-dalek/curve25519-dalek-5.0.0-rc.0.crate",
+        "sha256": "4f359e08ca85e7bd759e1fd933ff2bccd81864c60a8fba0e259c7f822b0924bf",
+        "dest": "cargo/vendor/curve25519-dalek-5.0.0-rc.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"4f359e08ca85e7bd759e1fd933ff2bccd81864c60a8fba0e259c7f822b0924bf\", \"files\": {}}",
+        "dest": "cargo/vendor/curve25519-dalek-5.0.0-rc.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/curve25519-dalek-derive/curve25519-dalek-derive-0.1.1.crate",
+        "sha256": "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3",
+        "dest": "cargo/vendor/curve25519-dalek-derive-0.1.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3\", \"files\": {}}",
+        "dest": "cargo/vendor/curve25519-dalek-derive-0.1.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/darling/darling-0.23.0.crate",
+        "sha256": "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d",
+        "dest": "cargo/vendor/darling-0.23.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d\", \"files\": {}}",
+        "dest": "cargo/vendor/darling-0.23.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/darling_core/darling_core-0.23.0.crate",
+        "sha256": "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0",
+        "dest": "cargo/vendor/darling_core-0.23.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0\", \"files\": {}}",
+        "dest": "cargo/vendor/darling_core-0.23.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/darling_macro/darling_macro-0.23.0.crate",
+        "sha256": "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d",
+        "dest": "cargo/vendor/darling_macro-0.23.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d\", \"files\": {}}",
+        "dest": "cargo/vendor/darling_macro-0.23.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/data-encoding/data-encoding-2.11.0.crate",
+        "sha256": "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8",
+        "dest": "cargo/vendor/data-encoding-2.11.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8\", \"files\": {}}",
+        "dest": "cargo/vendor/data-encoding-2.11.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/data-encoding-macro/data-encoding-macro-0.1.20.crate",
+        "sha256": "3259c913752a86488b501ed8680446a5ed2d5aeac6e596cb23ba3800768ea32c",
+        "dest": "cargo/vendor/data-encoding-macro-0.1.20"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"3259c913752a86488b501ed8680446a5ed2d5aeac6e596cb23ba3800768ea32c\", \"files\": {}}",
+        "dest": "cargo/vendor/data-encoding-macro-0.1.20",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/data-encoding-macro-internal/data-encoding-macro-internal-0.1.18.crate",
+        "sha256": "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090",
+        "dest": "cargo/vendor/data-encoding-macro-internal-0.1.18"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090\", \"files\": {}}",
+        "dest": "cargo/vendor/data-encoding-macro-internal-0.1.18",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/der/der-0.8.0.crate",
+        "sha256": "71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b",
+        "dest": "cargo/vendor/der-0.8.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b\", \"files\": {}}",
+        "dest": "cargo/vendor/der-0.8.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/der-parser/der-parser-10.0.0.crate",
+        "sha256": "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6",
+        "dest": "cargo/vendor/der-parser-10.0.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6\", \"files\": {}}",
+        "dest": "cargo/vendor/der-parser-10.0.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/deranged/deranged-0.5.8.crate",
+        "sha256": "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c",
+        "dest": "cargo/vendor/deranged-0.5.8"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c\", \"files\": {}}",
+        "dest": "cargo/vendor/deranged-0.5.8",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/derive_arbitrary/derive_arbitrary-1.4.2.crate",
+        "sha256": "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a",
+        "dest": "cargo/vendor/derive_arbitrary-1.4.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a\", \"files\": {}}",
+        "dest": "cargo/vendor/derive_arbitrary-1.4.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/derive_more/derive_more-0.99.20.crate",
+        "sha256": "6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f",
+        "dest": "cargo/vendor/derive_more-0.99.20"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f\", \"files\": {}}",
+        "dest": "cargo/vendor/derive_more-0.99.20",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/derive_more/derive_more-2.1.1.crate",
+        "sha256": "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134",
+        "dest": "cargo/vendor/derive_more-2.1.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134\", \"files\": {}}",
+        "dest": "cargo/vendor/derive_more-2.1.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/derive_more-impl/derive_more-impl-2.1.1.crate",
+        "sha256": "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb",
+        "dest": "cargo/vendor/derive_more-impl-2.1.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb\", \"files\": {}}",
+        "dest": "cargo/vendor/derive_more-impl-2.1.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/diatomic-waker/diatomic-waker-0.2.3.crate",
+        "sha256": "ab03c107fafeb3ee9f5925686dbb7a73bc76e3932abb0d2b365cb64b169cf04c",
+        "dest": "cargo/vendor/diatomic-waker-0.2.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"ab03c107fafeb3ee9f5925686dbb7a73bc76e3932abb0d2b365cb64b169cf04c\", \"files\": {}}",
+        "dest": "cargo/vendor/diatomic-waker-0.2.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/digest/digest-0.10.7.crate",
+        "sha256": "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292",
+        "dest": "cargo/vendor/digest-0.10.7"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292\", \"files\": {}}",
+        "dest": "cargo/vendor/digest-0.10.7",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/digest/digest-0.11.3.crate",
+        "sha256": "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2",
+        "dest": "cargo/vendor/digest-0.11.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2\", \"files\": {}}",
+        "dest": "cargo/vendor/digest-0.11.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/dirs/dirs-6.0.0.crate",
+        "sha256": "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e",
+        "dest": "cargo/vendor/dirs-6.0.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e\", \"files\": {}}",
+        "dest": "cargo/vendor/dirs-6.0.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/dirs-sys/dirs-sys-0.5.0.crate",
+        "sha256": "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab",
+        "dest": "cargo/vendor/dirs-sys-0.5.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab\", \"files\": {}}",
+        "dest": "cargo/vendor/dirs-sys-0.5.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/dispatch2/dispatch2-0.3.1.crate",
+        "sha256": "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38",
+        "dest": "cargo/vendor/dispatch2-0.3.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38\", \"files\": {}}",
+        "dest": "cargo/vendor/dispatch2-0.3.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/displaydoc/displaydoc-0.2.6.crate",
+        "sha256": "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f",
+        "dest": "cargo/vendor/displaydoc-0.2.6"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f\", \"files\": {}}",
+        "dest": "cargo/vendor/displaydoc-0.2.6",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/dlib/dlib-0.5.3.crate",
+        "sha256": "ab8ecd87370524b461f8557c119c405552c396ed91fc0a8eec68679eab26f94a",
+        "dest": "cargo/vendor/dlib-0.5.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"ab8ecd87370524b461f8557c119c405552c396ed91fc0a8eec68679eab26f94a\", \"files\": {}}",
+        "dest": "cargo/vendor/dlib-0.5.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/dlopen2/dlopen2-0.8.2.crate",
+        "sha256": "5e2c5bd4158e66d1e215c49b837e11d62f3267b30c92f1d171c4d3105e3dc4d4",
+        "dest": "cargo/vendor/dlopen2-0.8.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"5e2c5bd4158e66d1e215c49b837e11d62f3267b30c92f1d171c4d3105e3dc4d4\", \"files\": {}}",
+        "dest": "cargo/vendor/dlopen2-0.8.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/dlopen2_derive/dlopen2_derive-0.4.3.crate",
+        "sha256": "0fbbb781877580993a8707ec48672673ec7b81eeba04cfd2310bd28c08e47c8f",
+        "dest": "cargo/vendor/dlopen2_derive-0.4.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"0fbbb781877580993a8707ec48672673ec7b81eeba04cfd2310bd28c08e47c8f\", \"files\": {}}",
+        "dest": "cargo/vendor/dlopen2_derive-0.4.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/dlv-list/dlv-list-0.5.2.crate",
+        "sha256": "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f",
+        "dest": "cargo/vendor/dlv-list-0.5.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f\", \"files\": {}}",
+        "dest": "cargo/vendor/dlv-list-0.5.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/document-features/document-features-0.2.12.crate",
+        "sha256": "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61",
+        "dest": "cargo/vendor/document-features-0.2.12"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61\", \"files\": {}}",
+        "dest": "cargo/vendor/document-features-0.2.12",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/dom_query/dom_query-0.27.0.crate",
+        "sha256": "521e380c0c8afb8d9a1e83a1822ee03556fc3e3e7dbc1fd30be14e37f9cb3f89",
+        "dest": "cargo/vendor/dom_query-0.27.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"521e380c0c8afb8d9a1e83a1822ee03556fc3e3e7dbc1fd30be14e37f9cb3f89\", \"files\": {}}",
+        "dest": "cargo/vendor/dom_query-0.27.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/downcast-rs/downcast-rs-1.2.1.crate",
+        "sha256": "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2",
+        "dest": "cargo/vendor/downcast-rs-1.2.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2\", \"files\": {}}",
+        "dest": "cargo/vendor/downcast-rs-1.2.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/dpi/dpi-0.1.2.crate",
+        "sha256": "d8b14ccef22fc6f5a8f4d7d768562a182c04ce9a3b3157b91390b52ddfdf1a76",
+        "dest": "cargo/vendor/dpi-0.1.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"d8b14ccef22fc6f5a8f4d7d768562a182c04ce9a3b3157b91390b52ddfdf1a76\", \"files\": {}}",
+        "dest": "cargo/vendor/dpi-0.1.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/dtoa/dtoa-1.0.11.crate",
+        "sha256": "4c3cf4824e2d5f025c7b531afcb2325364084a16806f6d47fbc1f5fbd9960590",
+        "dest": "cargo/vendor/dtoa-1.0.11"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"4c3cf4824e2d5f025c7b531afcb2325364084a16806f6d47fbc1f5fbd9960590\", \"files\": {}}",
+        "dest": "cargo/vendor/dtoa-1.0.11",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/dtoa-short/dtoa-short-0.3.5.crate",
+        "sha256": "cd1511a7b6a56299bd043a9c167a6d2bfb37bf84a6dfceaba651168adfb43c87",
+        "dest": "cargo/vendor/dtoa-short-0.3.5"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"cd1511a7b6a56299bd043a9c167a6d2bfb37bf84a6dfceaba651168adfb43c87\", \"files\": {}}",
+        "dest": "cargo/vendor/dtoa-short-0.3.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/dtor/dtor-0.3.0.crate",
+        "sha256": "f1057d6c64987086ff8ed0fd3fbf377a6b7d205cc7715868cd401705f715cbe4",
+        "dest": "cargo/vendor/dtor-0.3.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"f1057d6c64987086ff8ed0fd3fbf377a6b7d205cc7715868cd401705f715cbe4\", \"files\": {}}",
+        "dest": "cargo/vendor/dtor-0.3.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/dtor-proc-macro/dtor-proc-macro-0.0.6.crate",
+        "sha256": "f678cf4a922c215c63e0de95eb1ff08a958a81d47e485cf9da1e27bf6305cfa5",
+        "dest": "cargo/vendor/dtor-proc-macro-0.0.6"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"f678cf4a922c215c63e0de95eb1ff08a958a81d47e485cf9da1e27bf6305cfa5\", \"files\": {}}",
+        "dest": "cargo/vendor/dtor-proc-macro-0.0.6",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/dunce/dunce-1.0.5.crate",
+        "sha256": "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813",
+        "dest": "cargo/vendor/dunce-1.0.5"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813\", \"files\": {}}",
+        "dest": "cargo/vendor/dunce-1.0.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/dyn-clone/dyn-clone-1.0.20.crate",
+        "sha256": "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555",
+        "dest": "cargo/vendor/dyn-clone-1.0.20"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555\", \"files\": {}}",
+        "dest": "cargo/vendor/dyn-clone-1.0.20",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/ed25519/ed25519-3.0.0.crate",
+        "sha256": "29fcf32e6c73d1079f83ab4d782de2d81620346a5f38c6237a86a22f8368980a",
+        "dest": "cargo/vendor/ed25519-3.0.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"29fcf32e6c73d1079f83ab4d782de2d81620346a5f38c6237a86a22f8368980a\", \"files\": {}}",
+        "dest": "cargo/vendor/ed25519-3.0.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/ed25519-dalek/ed25519-dalek-3.0.0-rc.0.crate",
+        "sha256": "b011170fe4f04665565b4110afef66774fe9ffff278f3eb5b81cc73d26e27d60",
+        "dest": "cargo/vendor/ed25519-dalek-3.0.0-rc.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"b011170fe4f04665565b4110afef66774fe9ffff278f3eb5b81cc73d26e27d60\", \"files\": {}}",
+        "dest": "cargo/vendor/ed25519-dalek-3.0.0-rc.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/either/either-1.16.0.crate",
+        "sha256": "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e",
+        "dest": "cargo/vendor/either-1.16.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e\", \"files\": {}}",
+        "dest": "cargo/vendor/either-1.16.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/embed-resource/embed-resource-3.0.11.crate",
+        "sha256": "fbfdaacccebec3b28e4866b8973543c7647797db5ada1bdab552e48fe665fbbd",
+        "dest": "cargo/vendor/embed-resource-3.0.11"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"fbfdaacccebec3b28e4866b8973543c7647797db5ada1bdab552e48fe665fbbd\", \"files\": {}}",
+        "dest": "cargo/vendor/embed-resource-3.0.11",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/embed_plist/embed_plist-1.2.2.crate",
+        "sha256": "4ef6b89e5b37196644d8796de5268852ff179b44e96276cf4290264843743bb7",
+        "dest": "cargo/vendor/embed_plist-1.2.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"4ef6b89e5b37196644d8796de5268852ff179b44e96276cf4290264843743bb7\", \"files\": {}}",
+        "dest": "cargo/vendor/embed_plist-1.2.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/embedded-io/embedded-io-0.4.0.crate",
+        "sha256": "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced",
+        "dest": "cargo/vendor/embedded-io-0.4.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced\", \"files\": {}}",
+        "dest": "cargo/vendor/embedded-io-0.4.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/embedded-io/embedded-io-0.6.1.crate",
+        "sha256": "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d",
+        "dest": "cargo/vendor/embedded-io-0.6.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d\", \"files\": {}}",
+        "dest": "cargo/vendor/embedded-io-0.6.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/encode_unicode/encode_unicode-1.0.0.crate",
+        "sha256": "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0",
+        "dest": "cargo/vendor/encode_unicode-1.0.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0\", \"files\": {}}",
+        "dest": "cargo/vendor/encode_unicode-1.0.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/encoding_rs/encoding_rs-0.8.35.crate",
+        "sha256": "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3",
+        "dest": "cargo/vendor/encoding_rs-0.8.35"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3\", \"files\": {}}",
+        "dest": "cargo/vendor/encoding_rs-0.8.35",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/endi/endi-1.1.1.crate",
+        "sha256": "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099",
+        "dest": "cargo/vendor/endi-1.1.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099\", \"files\": {}}",
+        "dest": "cargo/vendor/endi-1.1.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/enum-assoc/enum-assoc-1.3.0.crate",
+        "sha256": "3ed8956bd5c1f0415200516e78ff07ec9e16415ade83c056c230d7b7ea0d55b7",
+        "dest": "cargo/vendor/enum-assoc-1.3.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"3ed8956bd5c1f0415200516e78ff07ec9e16415ade83c056c230d7b7ea0d55b7\", \"files\": {}}",
+        "dest": "cargo/vendor/enum-assoc-1.3.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/enumflags2/enumflags2-0.7.12.crate",
+        "sha256": "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef",
+        "dest": "cargo/vendor/enumflags2-0.7.12"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef\", \"files\": {}}",
+        "dest": "cargo/vendor/enumflags2-0.7.12",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/enumflags2_derive/enumflags2_derive-0.7.12.crate",
+        "sha256": "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827",
+        "dest": "cargo/vendor/enumflags2_derive-0.7.12"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827\", \"files\": {}}",
+        "dest": "cargo/vendor/enumflags2_derive-0.7.12",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/equator/equator-0.4.2.crate",
+        "sha256": "4711b213838dfee0117e3be6ac926007d7f433d7bbe33595975d4190cb07e6fc",
+        "dest": "cargo/vendor/equator-0.4.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"4711b213838dfee0117e3be6ac926007d7f433d7bbe33595975d4190cb07e6fc\", \"files\": {}}",
+        "dest": "cargo/vendor/equator-0.4.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/equator-macro/equator-macro-0.4.2.crate",
+        "sha256": "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3",
+        "dest": "cargo/vendor/equator-macro-0.4.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3\", \"files\": {}}",
+        "dest": "cargo/vendor/equator-macro-0.4.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/equivalent/equivalent-1.0.2.crate",
+        "sha256": "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f",
+        "dest": "cargo/vendor/equivalent-1.0.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f\", \"files\": {}}",
+        "dest": "cargo/vendor/equivalent-1.0.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/erased-serde/erased-serde-0.4.10.crate",
+        "sha256": "d2add8a07dd6a8d93ff627029c51de145e12686fbc36ecb298ac22e74cf02dec",
+        "dest": "cargo/vendor/erased-serde-0.4.10"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"d2add8a07dd6a8d93ff627029c51de145e12686fbc36ecb298ac22e74cf02dec\", \"files\": {}}",
+        "dest": "cargo/vendor/erased-serde-0.4.10",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/errno/errno-0.3.14.crate",
+        "sha256": "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb",
+        "dest": "cargo/vendor/errno-0.3.14"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb\", \"files\": {}}",
+        "dest": "cargo/vendor/errno-0.3.14",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/event-listener/event-listener-5.4.1.crate",
+        "sha256": "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab",
+        "dest": "cargo/vendor/event-listener-5.4.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab\", \"files\": {}}",
+        "dest": "cargo/vendor/event-listener-5.4.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/event-listener-strategy/event-listener-strategy-0.5.4.crate",
+        "sha256": "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93",
+        "dest": "cargo/vendor/event-listener-strategy-0.5.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93\", \"files\": {}}",
+        "dest": "cargo/vendor/event-listener-strategy-0.5.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/exr/exr-1.74.1.crate",
+        "sha256": "6be87932f10230a4339ab394edd8e4611fcb72553d8295b4d52ea55249b3daa5",
+        "dest": "cargo/vendor/exr-1.74.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"6be87932f10230a4339ab394edd8e4611fcb72553d8295b4d52ea55249b3daa5\", \"files\": {}}",
+        "dest": "cargo/vendor/exr-1.74.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/fastbloom/fastbloom-0.17.0.crate",
+        "sha256": "ef975e30683b2d965054bb0a836f8973857c4ebf6acf274fe46617cd285060d8",
+        "dest": "cargo/vendor/fastbloom-0.17.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"ef975e30683b2d965054bb0a836f8973857c4ebf6acf274fe46617cd285060d8\", \"files\": {}}",
+        "dest": "cargo/vendor/fastbloom-0.17.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/fastrand/fastrand-2.4.1.crate",
+        "sha256": "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6",
+        "dest": "cargo/vendor/fastrand-2.4.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6\", \"files\": {}}",
+        "dest": "cargo/vendor/fastrand-2.4.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/fax/fax-0.2.7.crate",
+        "sha256": "caf1079563223d5d59d83c85886a56e586cfd5c1a26292e971a0fa266531ac5a",
+        "dest": "cargo/vendor/fax-0.2.7"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"caf1079563223d5d59d83c85886a56e586cfd5c1a26292e971a0fa266531ac5a\", \"files\": {}}",
+        "dest": "cargo/vendor/fax-0.2.7",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/fdeflate/fdeflate-0.3.7.crate",
+        "sha256": "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c",
+        "dest": "cargo/vendor/fdeflate-0.3.7"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c\", \"files\": {}}",
+        "dest": "cargo/vendor/fdeflate-0.3.7",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/fiat-crypto/fiat-crypto-0.3.0.crate",
+        "sha256": "64cd1e32ddd350061ae6edb1b082d7c54915b5c672c389143b9a63403a109f24",
+        "dest": "cargo/vendor/fiat-crypto-0.3.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"64cd1e32ddd350061ae6edb1b082d7c54915b5c672c389143b9a63403a109f24\", \"files\": {}}",
+        "dest": "cargo/vendor/fiat-crypto-0.3.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/field-offset/field-offset-0.3.6.crate",
+        "sha256": "38e2275cc4e4fc009b0669731a1e5ab7ebf11f469eaede2bab9309a5b4d6057f",
+        "dest": "cargo/vendor/field-offset-0.3.6"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"38e2275cc4e4fc009b0669731a1e5ab7ebf11f469eaede2bab9309a5b4d6057f\", \"files\": {}}",
+        "dest": "cargo/vendor/field-offset-0.3.6",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/filetime/filetime-0.2.29.crate",
+        "sha256": "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759",
+        "dest": "cargo/vendor/filetime-0.2.29"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759\", \"files\": {}}",
+        "dest": "cargo/vendor/filetime-0.2.29",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/find-msvc-tools/find-msvc-tools-0.1.9.crate",
+        "sha256": "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582",
+        "dest": "cargo/vendor/find-msvc-tools-0.1.9"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582\", \"files\": {}}",
+        "dest": "cargo/vendor/find-msvc-tools-0.1.9",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/flate2/flate2-1.1.9.crate",
+        "sha256": "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c",
+        "dest": "cargo/vendor/flate2-1.1.9"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c\", \"files\": {}}",
+        "dest": "cargo/vendor/flate2-1.1.9",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/fnv/fnv-1.0.7.crate",
+        "sha256": "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1",
+        "dest": "cargo/vendor/fnv-1.0.7"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1\", \"files\": {}}",
+        "dest": "cargo/vendor/fnv-1.0.7",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/foldhash/foldhash-0.2.0.crate",
+        "sha256": "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb",
+        "dest": "cargo/vendor/foldhash-0.2.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb\", \"files\": {}}",
+        "dest": "cargo/vendor/foldhash-0.2.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/foreign-types/foreign-types-0.5.0.crate",
+        "sha256": "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965",
+        "dest": "cargo/vendor/foreign-types-0.5.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965\", \"files\": {}}",
+        "dest": "cargo/vendor/foreign-types-0.5.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/foreign-types-macros/foreign-types-macros-0.2.3.crate",
+        "sha256": "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742",
+        "dest": "cargo/vendor/foreign-types-macros-0.2.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742\", \"files\": {}}",
+        "dest": "cargo/vendor/foreign-types-macros-0.2.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/foreign-types-shared/foreign-types-shared-0.3.1.crate",
+        "sha256": "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b",
+        "dest": "cargo/vendor/foreign-types-shared-0.3.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b\", \"files\": {}}",
+        "dest": "cargo/vendor/foreign-types-shared-0.3.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/form_urlencoded/form_urlencoded-1.2.2.crate",
+        "sha256": "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf",
+        "dest": "cargo/vendor/form_urlencoded-1.2.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf\", \"files\": {}}",
+        "dest": "cargo/vendor/form_urlencoded-1.2.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/fs_extra/fs_extra-1.3.0.crate",
+        "sha256": "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c",
+        "dest": "cargo/vendor/fs_extra-1.3.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c\", \"files\": {}}",
+        "dest": "cargo/vendor/fs_extra-1.3.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/futf/futf-0.1.5.crate",
+        "sha256": "df420e2e84819663797d1ec6544b13c5be84629e7bb00dc960d6917db2987843",
+        "dest": "cargo/vendor/futf-0.1.5"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"df420e2e84819663797d1ec6544b13c5be84629e7bb00dc960d6917db2987843\", \"files\": {}}",
+        "dest": "cargo/vendor/futf-0.1.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/futures/futures-0.3.32.crate",
+        "sha256": "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d",
+        "dest": "cargo/vendor/futures-0.3.32"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d\", \"files\": {}}",
+        "dest": "cargo/vendor/futures-0.3.32",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/futures-buffered/futures-buffered-0.2.13.crate",
+        "sha256": "4421cb78ee172b6b06080093479d3c50f058e7c81b7d577bbb8d118d551d4cd5",
+        "dest": "cargo/vendor/futures-buffered-0.2.13"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"4421cb78ee172b6b06080093479d3c50f058e7c81b7d577bbb8d118d551d4cd5\", \"files\": {}}",
+        "dest": "cargo/vendor/futures-buffered-0.2.13",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/futures-channel/futures-channel-0.3.32.crate",
+        "sha256": "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d",
+        "dest": "cargo/vendor/futures-channel-0.3.32"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d\", \"files\": {}}",
+        "dest": "cargo/vendor/futures-channel-0.3.32",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/futures-core/futures-core-0.3.32.crate",
+        "sha256": "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d",
+        "dest": "cargo/vendor/futures-core-0.3.32"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d\", \"files\": {}}",
+        "dest": "cargo/vendor/futures-core-0.3.32",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/futures-executor/futures-executor-0.3.32.crate",
+        "sha256": "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d",
+        "dest": "cargo/vendor/futures-executor-0.3.32"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d\", \"files\": {}}",
+        "dest": "cargo/vendor/futures-executor-0.3.32",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/futures-io/futures-io-0.3.32.crate",
+        "sha256": "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718",
+        "dest": "cargo/vendor/futures-io-0.3.32"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718\", \"files\": {}}",
+        "dest": "cargo/vendor/futures-io-0.3.32",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/futures-lite/futures-lite-2.6.1.crate",
+        "sha256": "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad",
+        "dest": "cargo/vendor/futures-lite-2.6.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad\", \"files\": {}}",
+        "dest": "cargo/vendor/futures-lite-2.6.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/futures-macro/futures-macro-0.3.32.crate",
+        "sha256": "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b",
+        "dest": "cargo/vendor/futures-macro-0.3.32"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b\", \"files\": {}}",
+        "dest": "cargo/vendor/futures-macro-0.3.32",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/futures-sink/futures-sink-0.3.32.crate",
+        "sha256": "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893",
+        "dest": "cargo/vendor/futures-sink-0.3.32"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893\", \"files\": {}}",
+        "dest": "cargo/vendor/futures-sink-0.3.32",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/futures-task/futures-task-0.3.32.crate",
+        "sha256": "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393",
+        "dest": "cargo/vendor/futures-task-0.3.32"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393\", \"files\": {}}",
+        "dest": "cargo/vendor/futures-task-0.3.32",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/futures-util/futures-util-0.3.32.crate",
+        "sha256": "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6",
+        "dest": "cargo/vendor/futures-util-0.3.32"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6\", \"files\": {}}",
+        "dest": "cargo/vendor/futures-util-0.3.32",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/fxhash/fxhash-0.2.1.crate",
+        "sha256": "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c",
+        "dest": "cargo/vendor/fxhash-0.2.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c\", \"files\": {}}",
+        "dest": "cargo/vendor/fxhash-0.2.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/gdk/gdk-0.18.2.crate",
+        "sha256": "d9f245958c627ac99d8e529166f9823fb3b838d1d41fd2b297af3075093c2691",
+        "dest": "cargo/vendor/gdk-0.18.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"d9f245958c627ac99d8e529166f9823fb3b838d1d41fd2b297af3075093c2691\", \"files\": {}}",
+        "dest": "cargo/vendor/gdk-0.18.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/gdk-pixbuf/gdk-pixbuf-0.18.5.crate",
+        "sha256": "50e1f5f1b0bfb830d6ccc8066d18db35c487b1b2b1e8589b5dfe9f07e8defaec",
+        "dest": "cargo/vendor/gdk-pixbuf-0.18.5"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"50e1f5f1b0bfb830d6ccc8066d18db35c487b1b2b1e8589b5dfe9f07e8defaec\", \"files\": {}}",
+        "dest": "cargo/vendor/gdk-pixbuf-0.18.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/gdk-pixbuf-sys/gdk-pixbuf-sys-0.18.0.crate",
+        "sha256": "3f9839ea644ed9c97a34d129ad56d38a25e6756f99f3a88e15cd39c20629caf7",
+        "dest": "cargo/vendor/gdk-pixbuf-sys-0.18.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"3f9839ea644ed9c97a34d129ad56d38a25e6756f99f3a88e15cd39c20629caf7\", \"files\": {}}",
+        "dest": "cargo/vendor/gdk-pixbuf-sys-0.18.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/gdk-sys/gdk-sys-0.18.2.crate",
+        "sha256": "5c2d13f38594ac1e66619e188c6d5a1adb98d11b2fcf7894fc416ad76aa2f3f7",
+        "dest": "cargo/vendor/gdk-sys-0.18.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"5c2d13f38594ac1e66619e188c6d5a1adb98d11b2fcf7894fc416ad76aa2f3f7\", \"files\": {}}",
+        "dest": "cargo/vendor/gdk-sys-0.18.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/gdkwayland-sys/gdkwayland-sys-0.18.2.crate",
+        "sha256": "140071d506d223f7572b9f09b5e155afbd77428cd5cc7af8f2694c41d98dfe69",
+        "dest": "cargo/vendor/gdkwayland-sys-0.18.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"140071d506d223f7572b9f09b5e155afbd77428cd5cc7af8f2694c41d98dfe69\", \"files\": {}}",
+        "dest": "cargo/vendor/gdkwayland-sys-0.18.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/gdkx11/gdkx11-0.18.2.crate",
+        "sha256": "3caa00e14351bebbc8183b3c36690327eb77c49abc2268dd4bd36b856db3fbfe",
+        "dest": "cargo/vendor/gdkx11-0.18.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"3caa00e14351bebbc8183b3c36690327eb77c49abc2268dd4bd36b856db3fbfe\", \"files\": {}}",
+        "dest": "cargo/vendor/gdkx11-0.18.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/gdkx11-sys/gdkx11-sys-0.18.2.crate",
+        "sha256": "6e2e7445fe01ac26f11601db260dd8608fe172514eb63b3b5e261ea6b0f4428d",
+        "dest": "cargo/vendor/gdkx11-sys-0.18.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"6e2e7445fe01ac26f11601db260dd8608fe172514eb63b3b5e261ea6b0f4428d\", \"files\": {}}",
+        "dest": "cargo/vendor/gdkx11-sys-0.18.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/genawaiter/genawaiter-0.99.1.crate",
+        "sha256": "c86bd0361bcbde39b13475e6e36cb24c329964aa2611be285289d1e4b751c1a0",
+        "dest": "cargo/vendor/genawaiter-0.99.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"c86bd0361bcbde39b13475e6e36cb24c329964aa2611be285289d1e4b751c1a0\", \"files\": {}}",
+        "dest": "cargo/vendor/genawaiter-0.99.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/genawaiter-macro/genawaiter-macro-0.99.1.crate",
+        "sha256": "0b32dfe1fdfc0bbde1f22a5da25355514b5e450c33a6af6770884c8750aedfbc",
+        "dest": "cargo/vendor/genawaiter-macro-0.99.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"0b32dfe1fdfc0bbde1f22a5da25355514b5e450c33a6af6770884c8750aedfbc\", \"files\": {}}",
+        "dest": "cargo/vendor/genawaiter-macro-0.99.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/genawaiter-proc-macro/genawaiter-proc-macro-0.99.1.crate",
+        "sha256": "784f84eebc366e15251c4a8c3acee82a6a6f427949776ecb88377362a9621738",
+        "dest": "cargo/vendor/genawaiter-proc-macro-0.99.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"784f84eebc366e15251c4a8c3acee82a6a6f427949776ecb88377362a9621738\", \"files\": {}}",
+        "dest": "cargo/vendor/genawaiter-proc-macro-0.99.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/generator/generator-0.8.9.crate",
+        "sha256": "b3b854b0e584ead1a33f18b2fcad7cf7be18b3875c78816b753639aa501513ae",
+        "dest": "cargo/vendor/generator-0.8.9"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"b3b854b0e584ead1a33f18b2fcad7cf7be18b3875c78816b753639aa501513ae\", \"files\": {}}",
+        "dest": "cargo/vendor/generator-0.8.9",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/generic-array/generic-array-0.14.7.crate",
+        "sha256": "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a",
+        "dest": "cargo/vendor/generic-array-0.14.7"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a\", \"files\": {}}",
+        "dest": "cargo/vendor/generic-array-0.14.7",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/gethostname/gethostname-1.1.0.crate",
+        "sha256": "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8",
+        "dest": "cargo/vendor/gethostname-1.1.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8\", \"files\": {}}",
+        "dest": "cargo/vendor/gethostname-1.1.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/getrandom/getrandom-0.1.16.crate",
+        "sha256": "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce",
+        "dest": "cargo/vendor/getrandom-0.1.16"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce\", \"files\": {}}",
+        "dest": "cargo/vendor/getrandom-0.1.16",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/getrandom/getrandom-0.2.17.crate",
+        "sha256": "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0",
+        "dest": "cargo/vendor/getrandom-0.2.17"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0\", \"files\": {}}",
+        "dest": "cargo/vendor/getrandom-0.2.17",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/getrandom/getrandom-0.3.4.crate",
+        "sha256": "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd",
+        "dest": "cargo/vendor/getrandom-0.3.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd\", \"files\": {}}",
+        "dest": "cargo/vendor/getrandom-0.3.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/getrandom/getrandom-0.4.3.crate",
+        "sha256": "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099",
+        "dest": "cargo/vendor/getrandom-0.4.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099\", \"files\": {}}",
+        "dest": "cargo/vendor/getrandom-0.4.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/ghash/ghash-0.5.1.crate",
+        "sha256": "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1",
+        "dest": "cargo/vendor/ghash-0.5.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1\", \"files\": {}}",
+        "dest": "cargo/vendor/ghash-0.5.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/gif/gif-0.14.2.crate",
+        "sha256": "ee8cfcc411d9adbbaba82fb72661cc1bcca13e8bba98b364e62b2dba8f960159",
+        "dest": "cargo/vendor/gif-0.14.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"ee8cfcc411d9adbbaba82fb72661cc1bcca13e8bba98b364e62b2dba8f960159\", \"files\": {}}",
+        "dest": "cargo/vendor/gif-0.14.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/gio/gio-0.18.4.crate",
+        "sha256": "d4fc8f532f87b79cbc51a79748f16a6828fb784be93145a322fa14d06d354c73",
+        "dest": "cargo/vendor/gio-0.18.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"d4fc8f532f87b79cbc51a79748f16a6828fb784be93145a322fa14d06d354c73\", \"files\": {}}",
+        "dest": "cargo/vendor/gio-0.18.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/gio-sys/gio-sys-0.18.1.crate",
+        "sha256": "37566df850baf5e4cb0dfb78af2e4b9898d817ed9263d1090a2df958c64737d2",
+        "dest": "cargo/vendor/gio-sys-0.18.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"37566df850baf5e4cb0dfb78af2e4b9898d817ed9263d1090a2df958c64737d2\", \"files\": {}}",
+        "dest": "cargo/vendor/gio-sys-0.18.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/gio-sys/gio-sys-0.20.10.crate",
+        "sha256": "521e93a7e56fc89e84aea9a52cfc9436816a4b363b030260b699950ff1336c83",
+        "dest": "cargo/vendor/gio-sys-0.20.10"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"521e93a7e56fc89e84aea9a52cfc9436816a4b363b030260b699950ff1336c83\", \"files\": {}}",
+        "dest": "cargo/vendor/gio-sys-0.20.10",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/glib/glib-0.18.5.crate",
+        "sha256": "233daaf6e83ae6a12a52055f568f9d7cf4671dabb78ff9560ab6da230ce00ee5",
+        "dest": "cargo/vendor/glib-0.18.5"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"233daaf6e83ae6a12a52055f568f9d7cf4671dabb78ff9560ab6da230ce00ee5\", \"files\": {}}",
+        "dest": "cargo/vendor/glib-0.18.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/glib/glib-0.20.12.crate",
+        "sha256": "ffc4b6e352d4716d84d7dde562dd9aee2a7d48beb872dd9ece7f2d1515b2d683",
+        "dest": "cargo/vendor/glib-0.20.12"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"ffc4b6e352d4716d84d7dde562dd9aee2a7d48beb872dd9ece7f2d1515b2d683\", \"files\": {}}",
+        "dest": "cargo/vendor/glib-0.20.12",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/glib-macros/glib-macros-0.18.5.crate",
+        "sha256": "0bb0228f477c0900c880fd78c8759b95c7636dbd7842707f49e132378aa2acdc",
+        "dest": "cargo/vendor/glib-macros-0.18.5"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"0bb0228f477c0900c880fd78c8759b95c7636dbd7842707f49e132378aa2acdc\", \"files\": {}}",
+        "dest": "cargo/vendor/glib-macros-0.18.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/glib-macros/glib-macros-0.20.12.crate",
+        "sha256": "e8084af62f09475a3f529b1629c10c429d7600ee1398ae12dd3bf175d74e7145",
+        "dest": "cargo/vendor/glib-macros-0.20.12"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"e8084af62f09475a3f529b1629c10c429d7600ee1398ae12dd3bf175d74e7145\", \"files\": {}}",
+        "dest": "cargo/vendor/glib-macros-0.20.12",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/glib-sys/glib-sys-0.18.1.crate",
+        "sha256": "063ce2eb6a8d0ea93d2bf8ba1957e78dbab6be1c2220dd3daca57d5a9d869898",
+        "dest": "cargo/vendor/glib-sys-0.18.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"063ce2eb6a8d0ea93d2bf8ba1957e78dbab6be1c2220dd3daca57d5a9d869898\", \"files\": {}}",
+        "dest": "cargo/vendor/glib-sys-0.18.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/glib-sys/glib-sys-0.20.10.crate",
+        "sha256": "8ab79e1ed126803a8fb827e3de0e2ff95191912b8db65cee467edb56fc4cc215",
+        "dest": "cargo/vendor/glib-sys-0.20.10"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"8ab79e1ed126803a8fb827e3de0e2ff95191912b8db65cee467edb56fc4cc215\", \"files\": {}}",
+        "dest": "cargo/vendor/glib-sys-0.20.10",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/glob/glob-0.3.3.crate",
+        "sha256": "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280",
+        "dest": "cargo/vendor/glob-0.3.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280\", \"files\": {}}",
+        "dest": "cargo/vendor/glob-0.3.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/gloo-timers/gloo-timers-0.3.0.crate",
+        "sha256": "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994",
+        "dest": "cargo/vendor/gloo-timers-0.3.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994\", \"files\": {}}",
+        "dest": "cargo/vendor/gloo-timers-0.3.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/gobject-sys/gobject-sys-0.18.0.crate",
+        "sha256": "0850127b514d1c4a4654ead6dedadb18198999985908e6ffe4436f53c785ce44",
+        "dest": "cargo/vendor/gobject-sys-0.18.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"0850127b514d1c4a4654ead6dedadb18198999985908e6ffe4436f53c785ce44\", \"files\": {}}",
+        "dest": "cargo/vendor/gobject-sys-0.18.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/gobject-sys/gobject-sys-0.20.10.crate",
+        "sha256": "ec9aca94bb73989e3cfdbf8f2e0f1f6da04db4d291c431f444838925c4c63eda",
+        "dest": "cargo/vendor/gobject-sys-0.20.10"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"ec9aca94bb73989e3cfdbf8f2e0f1f6da04db4d291c431f444838925c4c63eda\", \"files\": {}}",
+        "dest": "cargo/vendor/gobject-sys-0.20.10",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/gstreamer/gstreamer-0.23.7.crate",
+        "sha256": "8757a87f3706560037a01a9f06a59fcc7bdb0864744dcf73546606e60c4316e1",
+        "dest": "cargo/vendor/gstreamer-0.23.7"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"8757a87f3706560037a01a9f06a59fcc7bdb0864744dcf73546606e60c4316e1\", \"files\": {}}",
+        "dest": "cargo/vendor/gstreamer-0.23.7",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/gstreamer-app/gstreamer-app-0.23.5.crate",
+        "sha256": "2e9a883eb21aebcf1289158225c05f7aea5da6ecf71fa7f0ff1ce4d25baf004e",
+        "dest": "cargo/vendor/gstreamer-app-0.23.5"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"2e9a883eb21aebcf1289158225c05f7aea5da6ecf71fa7f0ff1ce4d25baf004e\", \"files\": {}}",
+        "dest": "cargo/vendor/gstreamer-app-0.23.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/gstreamer-app-sys/gstreamer-app-sys-0.23.5.crate",
+        "sha256": "94f7ef838306fe51852d503a14dc79ac42de005a59008a05098de3ecdaf05455",
+        "dest": "cargo/vendor/gstreamer-app-sys-0.23.5"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"94f7ef838306fe51852d503a14dc79ac42de005a59008a05098de3ecdaf05455\", \"files\": {}}",
+        "dest": "cargo/vendor/gstreamer-app-sys-0.23.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/gstreamer-base/gstreamer-base-0.23.6.crate",
+        "sha256": "f19a74fd04ffdcb847dd322640f2cf520897129d00a7bcb92fd62a63f3e27404",
+        "dest": "cargo/vendor/gstreamer-base-0.23.6"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"f19a74fd04ffdcb847dd322640f2cf520897129d00a7bcb92fd62a63f3e27404\", \"files\": {}}",
+        "dest": "cargo/vendor/gstreamer-base-0.23.6",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/gstreamer-base-sys/gstreamer-base-sys-0.23.6.crate",
+        "sha256": "87f2fb0037b6d3c5b51f60dea11e667910f33be222308ca5a101450018a09840",
+        "dest": "cargo/vendor/gstreamer-base-sys-0.23.6"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"87f2fb0037b6d3c5b51f60dea11e667910f33be222308ca5a101450018a09840\", \"files\": {}}",
+        "dest": "cargo/vendor/gstreamer-base-sys-0.23.6",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/gstreamer-sys/gstreamer-sys-0.23.6.crate",
+        "sha256": "feea73b4d92dbf9c24a203c9cd0bcc740d584f6b5960d5faf359febf288919b2",
+        "dest": "cargo/vendor/gstreamer-sys-0.23.6"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"feea73b4d92dbf9c24a203c9cd0bcc740d584f6b5960d5faf359febf288919b2\", \"files\": {}}",
+        "dest": "cargo/vendor/gstreamer-sys-0.23.6",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/gstreamer-video/gstreamer-video-0.23.6.crate",
+        "sha256": "1318b599d77ca4f7702ecbdeac1672d6304cb16b7e5752fabb3ee8260449a666",
+        "dest": "cargo/vendor/gstreamer-video-0.23.6"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"1318b599d77ca4f7702ecbdeac1672d6304cb16b7e5752fabb3ee8260449a666\", \"files\": {}}",
+        "dest": "cargo/vendor/gstreamer-video-0.23.6",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/gstreamer-video-sys/gstreamer-video-sys-0.23.6.crate",
+        "sha256": "0a70f0947f12d253b9de9bc3fd92f981e4d025336c18389c7f08cdf388a99f5c",
+        "dest": "cargo/vendor/gstreamer-video-sys-0.23.6"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"0a70f0947f12d253b9de9bc3fd92f981e4d025336c18389c7f08cdf388a99f5c\", \"files\": {}}",
+        "dest": "cargo/vendor/gstreamer-video-sys-0.23.6",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/gtk/gtk-0.18.2.crate",
+        "sha256": "fd56fb197bfc42bd5d2751f4f017d44ff59fbb58140c6b49f9b3b2bdab08506a",
+        "dest": "cargo/vendor/gtk-0.18.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"fd56fb197bfc42bd5d2751f4f017d44ff59fbb58140c6b49f9b3b2bdab08506a\", \"files\": {}}",
+        "dest": "cargo/vendor/gtk-0.18.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/gtk-sys/gtk-sys-0.18.2.crate",
+        "sha256": "8f29a1c21c59553eb7dd40e918be54dccd60c52b049b75119d5d96ce6b624414",
+        "dest": "cargo/vendor/gtk-sys-0.18.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"8f29a1c21c59553eb7dd40e918be54dccd60c52b049b75119d5d96ce6b624414\", \"files\": {}}",
+        "dest": "cargo/vendor/gtk-sys-0.18.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/gtk3-macros/gtk3-macros-0.18.2.crate",
+        "sha256": "52ff3c5b21f14f0736fed6dcfc0bfb4225ebf5725f3c0209edeec181e4d73e9d",
+        "dest": "cargo/vendor/gtk3-macros-0.18.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"52ff3c5b21f14f0736fed6dcfc0bfb4225ebf5725f3c0209edeec181e4d73e9d\", \"files\": {}}",
+        "dest": "cargo/vendor/gtk3-macros-0.18.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/h2/h2-0.4.15.crate",
+        "sha256": "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155",
+        "dest": "cargo/vendor/h2-0.4.15"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155\", \"files\": {}}",
+        "dest": "cargo/vendor/h2-0.4.15",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/half/half-2.7.1.crate",
+        "sha256": "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b",
+        "dest": "cargo/vendor/half-2.7.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b\", \"files\": {}}",
+        "dest": "cargo/vendor/half-2.7.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/hash32/hash32-0.2.1.crate",
+        "sha256": "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67",
+        "dest": "cargo/vendor/hash32-0.2.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67\", \"files\": {}}",
+        "dest": "cargo/vendor/hash32-0.2.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/hashbrown/hashbrown-0.12.3.crate",
+        "sha256": "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888",
+        "dest": "cargo/vendor/hashbrown-0.12.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888\", \"files\": {}}",
+        "dest": "cargo/vendor/hashbrown-0.12.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/hashbrown/hashbrown-0.14.5.crate",
+        "sha256": "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1",
+        "dest": "cargo/vendor/hashbrown-0.14.5"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1\", \"files\": {}}",
+        "dest": "cargo/vendor/hashbrown-0.14.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/hashbrown/hashbrown-0.17.1.crate",
+        "sha256": "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a",
+        "dest": "cargo/vendor/hashbrown-0.17.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a\", \"files\": {}}",
+        "dest": "cargo/vendor/hashbrown-0.17.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/heapless/heapless-0.7.17.crate",
+        "sha256": "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f",
+        "dest": "cargo/vendor/heapless-0.7.17"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f\", \"files\": {}}",
+        "dest": "cargo/vendor/heapless-0.7.17",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/heck/heck-0.4.1.crate",
+        "sha256": "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8",
+        "dest": "cargo/vendor/heck-0.4.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8\", \"files\": {}}",
+        "dest": "cargo/vendor/heck-0.4.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/heck/heck-0.5.0.crate",
+        "sha256": "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea",
+        "dest": "cargo/vendor/heck-0.5.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea\", \"files\": {}}",
+        "dest": "cargo/vendor/heck-0.5.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/hermit-abi/hermit-abi-0.5.2.crate",
+        "sha256": "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c",
+        "dest": "cargo/vendor/hermit-abi-0.5.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c\", \"files\": {}}",
+        "dest": "cargo/vendor/hermit-abi-0.5.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/hex/hex-0.4.3.crate",
+        "sha256": "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70",
+        "dest": "cargo/vendor/hex-0.4.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70\", \"files\": {}}",
+        "dest": "cargo/vendor/hex-0.4.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/hickory-net/hickory-net-0.26.1.crate",
+        "sha256": "e2295ed2f9c31e471e1428a8f88a3f0e1f4b27c15049592138d1eebe9c35b183",
+        "dest": "cargo/vendor/hickory-net-0.26.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"e2295ed2f9c31e471e1428a8f88a3f0e1f4b27c15049592138d1eebe9c35b183\", \"files\": {}}",
+        "dest": "cargo/vendor/hickory-net-0.26.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/hickory-proto/hickory-proto-0.26.1.crate",
+        "sha256": "0bab31817bfb44672a252e97fe81cd0c18d1b2cf892108922f6818820df8c643",
+        "dest": "cargo/vendor/hickory-proto-0.26.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"0bab31817bfb44672a252e97fe81cd0c18d1b2cf892108922f6818820df8c643\", \"files\": {}}",
+        "dest": "cargo/vendor/hickory-proto-0.26.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/hickory-resolver/hickory-resolver-0.26.1.crate",
+        "sha256": "f0d58d28879ceecde6607729660c2667a081ccdc082e082675042793960f178c",
+        "dest": "cargo/vendor/hickory-resolver-0.26.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"f0d58d28879ceecde6607729660c2667a081ccdc082e082675042793960f178c\", \"files\": {}}",
+        "dest": "cargo/vendor/hickory-resolver-0.26.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/html5ever/html5ever-0.29.1.crate",
+        "sha256": "3b7410cae13cbc75623c98ac4cbfd1f0bedddf3227afc24f370cf0f50a44a11c",
+        "dest": "cargo/vendor/html5ever-0.29.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"3b7410cae13cbc75623c98ac4cbfd1f0bedddf3227afc24f370cf0f50a44a11c\", \"files\": {}}",
+        "dest": "cargo/vendor/html5ever-0.29.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/html5ever/html5ever-0.38.0.crate",
+        "sha256": "1054432bae2f14e0061e33d23402fbaa67a921d319d56adc6bcf887ddad1cbc2",
+        "dest": "cargo/vendor/html5ever-0.38.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"1054432bae2f14e0061e33d23402fbaa67a921d319d56adc6bcf887ddad1cbc2\", \"files\": {}}",
+        "dest": "cargo/vendor/html5ever-0.38.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/http/http-1.4.2.crate",
+        "sha256": "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425",
+        "dest": "cargo/vendor/http-1.4.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425\", \"files\": {}}",
+        "dest": "cargo/vendor/http-1.4.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/http-body/http-body-1.0.1.crate",
+        "sha256": "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184",
+        "dest": "cargo/vendor/http-body-1.0.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184\", \"files\": {}}",
+        "dest": "cargo/vendor/http-body-1.0.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/http-body-util/http-body-util-0.1.3.crate",
+        "sha256": "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a",
+        "dest": "cargo/vendor/http-body-util-0.1.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a\", \"files\": {}}",
+        "dest": "cargo/vendor/http-body-util-0.1.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/httparse/httparse-1.10.1.crate",
+        "sha256": "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87",
+        "dest": "cargo/vendor/httparse-1.10.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87\", \"files\": {}}",
+        "dest": "cargo/vendor/httparse-1.10.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/httpdate/httpdate-1.0.3.crate",
+        "sha256": "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9",
+        "dest": "cargo/vendor/httpdate-1.0.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9\", \"files\": {}}",
+        "dest": "cargo/vendor/httpdate-1.0.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/hybrid-array/hybrid-array-0.4.13.crate",
+        "sha256": "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c",
+        "dest": "cargo/vendor/hybrid-array-0.4.13"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c\", \"files\": {}}",
+        "dest": "cargo/vendor/hybrid-array-0.4.13",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/hyper/hyper-1.10.1.crate",
+        "sha256": "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498",
+        "dest": "cargo/vendor/hyper-1.10.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498\", \"files\": {}}",
+        "dest": "cargo/vendor/hyper-1.10.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/hyper-rustls/hyper-rustls-0.27.9.crate",
+        "sha256": "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f",
+        "dest": "cargo/vendor/hyper-rustls-0.27.9"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f\", \"files\": {}}",
+        "dest": "cargo/vendor/hyper-rustls-0.27.9",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/hyper-util/hyper-util-0.1.20.crate",
+        "sha256": "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0",
+        "dest": "cargo/vendor/hyper-util-0.1.20"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0\", \"files\": {}}",
+        "dest": "cargo/vendor/hyper-util-0.1.20",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/iana-time-zone/iana-time-zone-0.1.65.crate",
+        "sha256": "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470",
+        "dest": "cargo/vendor/iana-time-zone-0.1.65"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470\", \"files\": {}}",
+        "dest": "cargo/vendor/iana-time-zone-0.1.65",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/iana-time-zone-haiku/iana-time-zone-haiku-0.1.2.crate",
+        "sha256": "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f",
+        "dest": "cargo/vendor/iana-time-zone-haiku-0.1.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f\", \"files\": {}}",
+        "dest": "cargo/vendor/iana-time-zone-haiku-0.1.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/ico/ico-0.5.0.crate",
+        "sha256": "3e795dff5605e0f04bff85ca41b51a96b83e80b281e96231bcaaf1ac35103371",
+        "dest": "cargo/vendor/ico-0.5.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"3e795dff5605e0f04bff85ca41b51a96b83e80b281e96231bcaaf1ac35103371\", \"files\": {}}",
+        "dest": "cargo/vendor/ico-0.5.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/icu_collections/icu_collections-2.2.0.crate",
+        "sha256": "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c",
+        "dest": "cargo/vendor/icu_collections-2.2.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c\", \"files\": {}}",
+        "dest": "cargo/vendor/icu_collections-2.2.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/icu_locale_core/icu_locale_core-2.2.0.crate",
+        "sha256": "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29",
+        "dest": "cargo/vendor/icu_locale_core-2.2.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29\", \"files\": {}}",
+        "dest": "cargo/vendor/icu_locale_core-2.2.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/icu_normalizer/icu_normalizer-2.2.0.crate",
+        "sha256": "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4",
+        "dest": "cargo/vendor/icu_normalizer-2.2.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4\", \"files\": {}}",
+        "dest": "cargo/vendor/icu_normalizer-2.2.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/icu_normalizer_data/icu_normalizer_data-2.2.0.crate",
+        "sha256": "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38",
+        "dest": "cargo/vendor/icu_normalizer_data-2.2.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38\", \"files\": {}}",
+        "dest": "cargo/vendor/icu_normalizer_data-2.2.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/icu_properties/icu_properties-2.2.0.crate",
+        "sha256": "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de",
+        "dest": "cargo/vendor/icu_properties-2.2.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de\", \"files\": {}}",
+        "dest": "cargo/vendor/icu_properties-2.2.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/icu_properties_data/icu_properties_data-2.2.0.crate",
+        "sha256": "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14",
+        "dest": "cargo/vendor/icu_properties_data-2.2.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14\", \"files\": {}}",
+        "dest": "cargo/vendor/icu_properties_data-2.2.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/icu_provider/icu_provider-2.2.0.crate",
+        "sha256": "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421",
+        "dest": "cargo/vendor/icu_provider-2.2.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421\", \"files\": {}}",
+        "dest": "cargo/vendor/icu_provider-2.2.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/ident_case/ident_case-1.0.1.crate",
+        "sha256": "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39",
+        "dest": "cargo/vendor/ident_case-1.0.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39\", \"files\": {}}",
+        "dest": "cargo/vendor/ident_case-1.0.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/identity-hash/identity-hash-0.1.0.crate",
+        "sha256": "dfdd7caa900436d8f13b2346fe10257e0c05c1f1f9e351f4f5d57c03bd5f45da",
+        "dest": "cargo/vendor/identity-hash-0.1.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"dfdd7caa900436d8f13b2346fe10257e0c05c1f1f9e351f4f5d57c03bd5f45da\", \"files\": {}}",
+        "dest": "cargo/vendor/identity-hash-0.1.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/idna/idna-1.1.0.crate",
+        "sha256": "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de",
+        "dest": "cargo/vendor/idna-1.1.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de\", \"files\": {}}",
+        "dest": "cargo/vendor/idna-1.1.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/idna_adapter/idna_adapter-1.2.2.crate",
+        "sha256": "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714",
+        "dest": "cargo/vendor/idna_adapter-1.2.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714\", \"files\": {}}",
+        "dest": "cargo/vendor/idna_adapter-1.2.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/igd-next/igd-next-0.17.1.crate",
+        "sha256": "de7238d487a9aff61f81b5ab41c0a841532a115a398b5fa92a2fadd0885e2581",
+        "dest": "cargo/vendor/igd-next-0.17.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"de7238d487a9aff61f81b5ab41c0a841532a115a398b5fa92a2fadd0885e2581\", \"files\": {}}",
+        "dest": "cargo/vendor/igd-next-0.17.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/image/image-0.25.10.crate",
+        "sha256": "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104",
+        "dest": "cargo/vendor/image-0.25.10"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104\", \"files\": {}}",
+        "dest": "cargo/vendor/image-0.25.10",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/image-webp/image-webp-0.2.4.crate",
+        "sha256": "525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3",
+        "dest": "cargo/vendor/image-webp-0.2.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3\", \"files\": {}}",
+        "dest": "cargo/vendor/image-webp-0.2.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/imgref/imgref-1.12.2.crate",
+        "sha256": "89194689a993ab15268672e99e7b0e19da2da3268ac682e8f02d29d4d1434cd7",
+        "dest": "cargo/vendor/imgref-1.12.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"89194689a993ab15268672e99e7b0e19da2da3268ac682e8f02d29d4d1434cd7\", \"files\": {}}",
+        "dest": "cargo/vendor/imgref-1.12.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/indexmap/indexmap-1.9.3.crate",
+        "sha256": "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99",
+        "dest": "cargo/vendor/indexmap-1.9.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99\", \"files\": {}}",
+        "dest": "cargo/vendor/indexmap-1.9.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/indexmap/indexmap-2.14.0.crate",
+        "sha256": "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9",
+        "dest": "cargo/vendor/indexmap-2.14.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9\", \"files\": {}}",
+        "dest": "cargo/vendor/indexmap-2.14.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/indicatif/indicatif-0.17.11.crate",
+        "sha256": "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235",
+        "dest": "cargo/vendor/indicatif-0.17.11"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235\", \"files\": {}}",
+        "dest": "cargo/vendor/indicatif-0.17.11",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/infer/infer-0.19.0.crate",
+        "sha256": "a588916bfdfd92e71cacef98a63d9b1f0d74d6599980d11894290e7ddefffcf7",
+        "dest": "cargo/vendor/infer-0.19.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"a588916bfdfd92e71cacef98a63d9b1f0d74d6599980d11894290e7ddefffcf7\", \"files\": {}}",
+        "dest": "cargo/vendor/infer-0.19.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/inout/inout-0.1.4.crate",
+        "sha256": "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01",
+        "dest": "cargo/vendor/inout-0.1.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01\", \"files\": {}}",
+        "dest": "cargo/vendor/inout-0.1.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/inplace-vec-builder/inplace-vec-builder-0.1.1.crate",
+        "sha256": "cf64c2edc8226891a71f127587a2861b132d2b942310843814d5001d99a1d307",
+        "dest": "cargo/vendor/inplace-vec-builder-0.1.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"cf64c2edc8226891a71f127587a2861b132d2b942310843814d5001d99a1d307\", \"files\": {}}",
+        "dest": "cargo/vendor/inplace-vec-builder-0.1.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/interpolate_name/interpolate_name-0.2.4.crate",
+        "sha256": "c34819042dc3d3971c46c2190835914dfbe0c3c13f61449b2997f4e9722dfa60",
+        "dest": "cargo/vendor/interpolate_name-0.2.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"c34819042dc3d3971c46c2190835914dfbe0c3c13f61449b2997f4e9722dfa60\", \"files\": {}}",
+        "dest": "cargo/vendor/interpolate_name-0.2.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/ipconfig/ipconfig-0.3.4.crate",
+        "sha256": "4d40460c0ce33d6ce4b0630ad68ff63d6661961c48b6dba35e5a4d81cfb48222",
+        "dest": "cargo/vendor/ipconfig-0.3.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"4d40460c0ce33d6ce4b0630ad68ff63d6661961c48b6dba35e5a4d81cfb48222\", \"files\": {}}",
+        "dest": "cargo/vendor/ipconfig-0.3.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/ipnet/ipnet-2.12.0.crate",
+        "sha256": "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2",
+        "dest": "cargo/vendor/ipnet-2.12.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2\", \"files\": {}}",
+        "dest": "cargo/vendor/ipnet-2.12.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/iroh/iroh-1.0.3.crate",
+        "sha256": "460de6bc52163b41b1646931f2897e5ab986f0966ade444467fec25024751a72",
+        "dest": "cargo/vendor/iroh-1.0.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"460de6bc52163b41b1646931f2897e5ab986f0966ade444467fec25024751a72\", \"files\": {}}",
+        "dest": "cargo/vendor/iroh-1.0.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/iroh-base/iroh-base-1.0.3.crate",
+        "sha256": "6be73e16ee21c923aca9b3121aaa0db936f7c7ecc156ff47b8dac944c68d59a8",
+        "dest": "cargo/vendor/iroh-base-1.0.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"6be73e16ee21c923aca9b3121aaa0db936f7c7ecc156ff47b8dac944c68d59a8\", \"files\": {}}",
+        "dest": "cargo/vendor/iroh-base-1.0.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/iroh-blobs/iroh-blobs-0.103.0.crate",
+        "sha256": "5be50b0e2d0a9ba65cee4e0dfb708b3704e02ad12bd4c14c6307e94245943126",
+        "dest": "cargo/vendor/iroh-blobs-0.103.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"5be50b0e2d0a9ba65cee4e0dfb708b3704e02ad12bd4c14c6307e94245943126\", \"files\": {}}",
+        "dest": "cargo/vendor/iroh-blobs-0.103.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/iroh-dns/iroh-dns-1.0.3.crate",
+        "sha256": "46f6a9b39d18e6345f5c151afd299f2488e2cb5c520fe41b107b6bd3dc4c3349",
+        "dest": "cargo/vendor/iroh-dns-1.0.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"46f6a9b39d18e6345f5c151afd299f2488e2cb5c520fe41b107b6bd3dc4c3349\", \"files\": {}}",
+        "dest": "cargo/vendor/iroh-dns-1.0.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/iroh-io/iroh-io-0.6.2.crate",
+        "sha256": "e0a5feb781017b983ff1b155cd1faf8174da2acafd807aa482876da2d7e6577a",
+        "dest": "cargo/vendor/iroh-io-0.6.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"e0a5feb781017b983ff1b155cd1faf8174da2acafd807aa482876da2d7e6577a\", \"files\": {}}",
+        "dest": "cargo/vendor/iroh-io-0.6.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/iroh-metrics/iroh-metrics-1.0.1.crate",
+        "sha256": "291065721ad7c477b972e581bbc528df031dc8eb5e39fe1ff3300ae5dfb157ef",
+        "dest": "cargo/vendor/iroh-metrics-1.0.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"291065721ad7c477b972e581bbc528df031dc8eb5e39fe1ff3300ae5dfb157ef\", \"files\": {}}",
+        "dest": "cargo/vendor/iroh-metrics-1.0.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/iroh-metrics-derive/iroh-metrics-derive-1.0.1.crate",
+        "sha256": "1ae5f0c4405d1fbc9fb16ff422ca40620e93dc36c30ecaba0c2aee3992b7bd48",
+        "dest": "cargo/vendor/iroh-metrics-derive-1.0.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"1ae5f0c4405d1fbc9fb16ff422ca40620e93dc36c30ecaba0c2aee3992b7bd48\", \"files\": {}}",
+        "dest": "cargo/vendor/iroh-metrics-derive-1.0.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/iroh-relay/iroh-relay-1.0.3.crate",
+        "sha256": "24bd586cf927f7b700f56ec3639b53cb5fa901ce284784051ff71092bfbf8193",
+        "dest": "cargo/vendor/iroh-relay-1.0.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"24bd586cf927f7b700f56ec3639b53cb5fa901ce284784051ff71092bfbf8193\", \"files\": {}}",
+        "dest": "cargo/vendor/iroh-relay-1.0.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/iroh-tickets/iroh-tickets-1.0.0.crate",
+        "sha256": "da53233419ca36bf521ed45683b7748366f9b233032891eefc2d70567a84ac54",
+        "dest": "cargo/vendor/iroh-tickets-1.0.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"da53233419ca36bf521ed45683b7748366f9b233032891eefc2d70567a84ac54\", \"files\": {}}",
+        "dest": "cargo/vendor/iroh-tickets-1.0.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/iroh-util/iroh-util-0.6.0.crate",
+        "sha256": "20e41eb982f15230c55f0a70a74a514360e1f565b07861924fd0e8db172b3d00",
+        "dest": "cargo/vendor/iroh-util-0.6.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"20e41eb982f15230c55f0a70a74a514360e1f565b07861924fd0e8db172b3d00\", \"files\": {}}",
+        "dest": "cargo/vendor/iroh-util-0.6.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/irpc/irpc-0.17.0.crate",
+        "sha256": "3623d6ff582b415904b29bbe6ebcb4a4f9a262ccdee05a45fdd003ef0950c386",
+        "dest": "cargo/vendor/irpc-0.17.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"3623d6ff582b415904b29bbe6ebcb4a4f9a262ccdee05a45fdd003ef0950c386\", \"files\": {}}",
+        "dest": "cargo/vendor/irpc-0.17.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/irpc-derive/irpc-derive-0.17.0.crate",
+        "sha256": "35c254013736de16472140d26904e6ac98e8f3887284dcf4af40f88c77411b56",
+        "dest": "cargo/vendor/irpc-derive-0.17.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"35c254013736de16472140d26904e6ac98e8f3887284dcf4af40f88c77411b56\", \"files\": {}}",
+        "dest": "cargo/vendor/irpc-derive-0.17.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/is-docker/is-docker-0.2.0.crate",
+        "sha256": "928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3",
+        "dest": "cargo/vendor/is-docker-0.2.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3\", \"files\": {}}",
+        "dest": "cargo/vendor/is-docker-0.2.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/is-wsl/is-wsl-0.4.0.crate",
+        "sha256": "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5",
+        "dest": "cargo/vendor/is-wsl-0.4.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5\", \"files\": {}}",
+        "dest": "cargo/vendor/is-wsl-0.4.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/is_terminal_polyfill/is_terminal_polyfill-1.70.2.crate",
+        "sha256": "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695",
+        "dest": "cargo/vendor/is_terminal_polyfill-1.70.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695\", \"files\": {}}",
+        "dest": "cargo/vendor/is_terminal_polyfill-1.70.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/itertools/itertools-0.14.0.crate",
+        "sha256": "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285",
+        "dest": "cargo/vendor/itertools-0.14.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285\", \"files\": {}}",
+        "dest": "cargo/vendor/itertools-0.14.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/itoa/itoa-1.0.18.crate",
+        "sha256": "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682",
+        "dest": "cargo/vendor/itoa-1.0.18"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682\", \"files\": {}}",
+        "dest": "cargo/vendor/itoa-1.0.18",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/javascriptcore-rs/javascriptcore-rs-1.1.2.crate",
+        "sha256": "ca5671e9ffce8ffba57afc24070e906da7fc4b1ba66f2cabebf61bf2ea257fcc",
+        "dest": "cargo/vendor/javascriptcore-rs-1.1.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"ca5671e9ffce8ffba57afc24070e906da7fc4b1ba66f2cabebf61bf2ea257fcc\", \"files\": {}}",
+        "dest": "cargo/vendor/javascriptcore-rs-1.1.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/javascriptcore-rs-sys/javascriptcore-rs-sys-1.1.1.crate",
+        "sha256": "af1be78d14ffa4b75b66df31840478fef72b51f8c2465d4ca7c194da9f7a5124",
+        "dest": "cargo/vendor/javascriptcore-rs-sys-1.1.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"af1be78d14ffa4b75b66df31840478fef72b51f8c2465d4ca7c194da9f7a5124\", \"files\": {}}",
+        "dest": "cargo/vendor/javascriptcore-rs-sys-1.1.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/jni/jni-0.21.1.crate",
+        "sha256": "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97",
+        "dest": "cargo/vendor/jni-0.21.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97\", \"files\": {}}",
+        "dest": "cargo/vendor/jni-0.21.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/jni/jni-0.22.4.crate",
+        "sha256": "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498",
+        "dest": "cargo/vendor/jni-0.22.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498\", \"files\": {}}",
+        "dest": "cargo/vendor/jni-0.22.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/jni-macros/jni-macros-0.22.4.crate",
+        "sha256": "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3",
+        "dest": "cargo/vendor/jni-macros-0.22.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3\", \"files\": {}}",
+        "dest": "cargo/vendor/jni-macros-0.22.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/jni-sys/jni-sys-0.3.1.crate",
+        "sha256": "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258",
+        "dest": "cargo/vendor/jni-sys-0.3.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258\", \"files\": {}}",
+        "dest": "cargo/vendor/jni-sys-0.3.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/jni-sys/jni-sys-0.4.1.crate",
+        "sha256": "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2",
+        "dest": "cargo/vendor/jni-sys-0.4.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2\", \"files\": {}}",
+        "dest": "cargo/vendor/jni-sys-0.4.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/jni-sys-macros/jni-sys-macros-0.4.1.crate",
+        "sha256": "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264",
+        "dest": "cargo/vendor/jni-sys-macros-0.4.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264\", \"files\": {}}",
+        "dest": "cargo/vendor/jni-sys-macros-0.4.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/jobserver/jobserver-0.1.35.crate",
+        "sha256": "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3",
+        "dest": "cargo/vendor/jobserver-0.1.35"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3\", \"files\": {}}",
+        "dest": "cargo/vendor/jobserver-0.1.35",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/js-sys/js-sys-0.3.103.crate",
+        "sha256": "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102",
+        "dest": "cargo/vendor/js-sys-0.3.103"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102\", \"files\": {}}",
+        "dest": "cargo/vendor/js-sys-0.3.103",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/json-patch/json-patch-3.0.1.crate",
+        "sha256": "863726d7afb6bc2590eeff7135d923545e5e964f004c2ccf8716c25e70a86f08",
+        "dest": "cargo/vendor/json-patch-3.0.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"863726d7afb6bc2590eeff7135d923545e5e964f004c2ccf8716c25e70a86f08\", \"files\": {}}",
+        "dest": "cargo/vendor/json-patch-3.0.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/jsonptr/jsonptr-0.6.3.crate",
+        "sha256": "5dea2b27dd239b2556ed7a25ba842fe47fd602e7fc7433c2a8d6106d4d9edd70",
+        "dest": "cargo/vendor/jsonptr-0.6.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"5dea2b27dd239b2556ed7a25ba842fe47fd602e7fc7433c2a8d6106d4d9edd70\", \"files\": {}}",
+        "dest": "cargo/vendor/jsonptr-0.6.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/keyboard-types/keyboard-types-0.7.0.crate",
+        "sha256": "b750dcadc39a09dbadd74e118f6dd6598df77fa01df0cfcdc52c28dece74528a",
+        "dest": "cargo/vendor/keyboard-types-0.7.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"b750dcadc39a09dbadd74e118f6dd6598df77fa01df0cfcdc52c28dece74528a\", \"files\": {}}",
+        "dest": "cargo/vendor/keyboard-types-0.7.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/keyring/keyring-3.6.3.crate",
+        "sha256": "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c",
+        "dest": "cargo/vendor/keyring-3.6.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c\", \"files\": {}}",
+        "dest": "cargo/vendor/keyring-3.6.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/kuchikiki/kuchikiki-0.8.8-speedreader.crate",
+        "sha256": "02cb977175687f33fa4afa0c95c112b987ea1443e5a51c8f8ff27dc618270cc2",
+        "dest": "cargo/vendor/kuchikiki-0.8.8-speedreader"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"02cb977175687f33fa4afa0c95c112b987ea1443e5a51c8f8ff27dc618270cc2\", \"files\": {}}",
+        "dest": "cargo/vendor/kuchikiki-0.8.8-speedreader",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/lazy_static/lazy_static-1.5.0.crate",
+        "sha256": "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe",
+        "dest": "cargo/vendor/lazy_static-1.5.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe\", \"files\": {}}",
+        "dest": "cargo/vendor/lazy_static-1.5.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/lebe/lebe-0.5.3.crate",
+        "sha256": "7a79a3332a6609480d7d0c9eab957bca6b455b91bb84e66d19f5ff66294b85b8",
+        "dest": "cargo/vendor/lebe-0.5.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"7a79a3332a6609480d7d0c9eab957bca6b455b91bb84e66d19f5ff66294b85b8\", \"files\": {}}",
+        "dest": "cargo/vendor/lebe-0.5.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/libappindicator/libappindicator-0.9.0.crate",
+        "sha256": "03589b9607c868cc7ae54c0b2a22c8dc03dd41692d48f2d7df73615c6a95dc0a",
+        "dest": "cargo/vendor/libappindicator-0.9.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"03589b9607c868cc7ae54c0b2a22c8dc03dd41692d48f2d7df73615c6a95dc0a\", \"files\": {}}",
+        "dest": "cargo/vendor/libappindicator-0.9.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/libappindicator-sys/libappindicator-sys-0.9.0.crate",
+        "sha256": "6e9ec52138abedcc58dc17a7c6c0c00a2bdb4f3427c7f63fa97fd0d859155caf",
+        "dest": "cargo/vendor/libappindicator-sys-0.9.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"6e9ec52138abedcc58dc17a7c6c0c00a2bdb4f3427c7f63fa97fd0d859155caf\", \"files\": {}}",
+        "dest": "cargo/vendor/libappindicator-sys-0.9.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/libc/libc-0.2.186.crate",
+        "sha256": "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66",
+        "dest": "cargo/vendor/libc-0.2.186"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66\", \"files\": {}}",
+        "dest": "cargo/vendor/libc-0.2.186",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/libfuzzer-sys/libfuzzer-sys-0.4.13.crate",
+        "sha256": "a9fd2f41a1cba099f79a0b6b6c35656cf7c03351a7bae8ff0f28f25270f929d2",
+        "dest": "cargo/vendor/libfuzzer-sys-0.4.13"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"a9fd2f41a1cba099f79a0b6b6c35656cf7c03351a7bae8ff0f28f25270f929d2\", \"files\": {}}",
+        "dest": "cargo/vendor/libfuzzer-sys-0.4.13",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/libloading/libloading-0.7.4.crate",
+        "sha256": "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f",
+        "dest": "cargo/vendor/libloading-0.7.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f\", \"files\": {}}",
+        "dest": "cargo/vendor/libloading-0.7.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/libm/libm-0.2.16.crate",
+        "sha256": "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981",
+        "dest": "cargo/vendor/libm-0.2.16"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981\", \"files\": {}}",
+        "dest": "cargo/vendor/libm-0.2.16",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/libredox/libredox-0.1.18.crate",
+        "sha256": "c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652",
+        "dest": "cargo/vendor/libredox-0.1.18"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652\", \"files\": {}}",
+        "dest": "cargo/vendor/libredox-0.1.18",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/linux-raw-sys/linux-raw-sys-0.12.1.crate",
+        "sha256": "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53",
+        "dest": "cargo/vendor/linux-raw-sys-0.12.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53\", \"files\": {}}",
+        "dest": "cargo/vendor/linux-raw-sys-0.12.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/litemap/litemap-0.8.2.crate",
+        "sha256": "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0",
+        "dest": "cargo/vendor/litemap-0.8.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0\", \"files\": {}}",
+        "dest": "cargo/vendor/litemap-0.8.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/litrs/litrs-1.0.0.crate",
+        "sha256": "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092",
+        "dest": "cargo/vendor/litrs-1.0.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092\", \"files\": {}}",
+        "dest": "cargo/vendor/litrs-1.0.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/lock_api/lock_api-0.4.14.crate",
+        "sha256": "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965",
+        "dest": "cargo/vendor/lock_api-0.4.14"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965\", \"files\": {}}",
+        "dest": "cargo/vendor/lock_api-0.4.14",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/log/log-0.4.33.crate",
+        "sha256": "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad",
+        "dest": "cargo/vendor/log-0.4.33"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad\", \"files\": {}}",
+        "dest": "cargo/vendor/log-0.4.33",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/loom/loom-0.7.2.crate",
+        "sha256": "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca",
+        "dest": "cargo/vendor/loom-0.7.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca\", \"files\": {}}",
+        "dest": "cargo/vendor/loom-0.7.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/loop9/loop9-0.1.5.crate",
+        "sha256": "0fae87c125b03c1d2c0150c90365d7d6bcc53fb73a9acaef207d2d065860f062",
+        "dest": "cargo/vendor/loop9-0.1.5"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"0fae87c125b03c1d2c0150c90365d7d6bcc53fb73a9acaef207d2d065860f062\", \"files\": {}}",
+        "dest": "cargo/vendor/loop9-0.1.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/lru/lru-0.18.0.crate",
+        "sha256": "8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9",
+        "dest": "cargo/vendor/lru-0.18.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9\", \"files\": {}}",
+        "dest": "cargo/vendor/lru-0.18.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/lru-slab/lru-slab-0.1.2.crate",
+        "sha256": "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154",
+        "dest": "cargo/vendor/lru-slab-0.1.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154\", \"files\": {}}",
+        "dest": "cargo/vendor/lru-slab-0.1.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/mac/mac-0.1.1.crate",
+        "sha256": "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4",
+        "dest": "cargo/vendor/mac-0.1.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4\", \"files\": {}}",
+        "dest": "cargo/vendor/mac-0.1.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/mac-addr/mac-addr-0.3.0.crate",
+        "sha256": "d3d25b0e0b648a86960ac23b7ad4abb9717601dec6f66c165f5b037f3f03065f",
+        "dest": "cargo/vendor/mac-addr-0.3.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"d3d25b0e0b648a86960ac23b7ad4abb9717601dec6f66c165f5b037f3f03065f\", \"files\": {}}",
+        "dest": "cargo/vendor/mac-addr-0.3.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/mac-notification-sys/mac-notification-sys-0.6.15.crate",
+        "sha256": "fd604973958ddcc11b561193c0fb96ba146506ef2f231ef2e7c35fd2cbc9beca",
+        "dest": "cargo/vendor/mac-notification-sys-0.6.15"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"fd604973958ddcc11b561193c0fb96ba146506ef2f231ef2e7c35fd2cbc9beca\", \"files\": {}}",
+        "dest": "cargo/vendor/mac-notification-sys-0.6.15",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/malloc_buf/malloc_buf-0.0.6.crate",
+        "sha256": "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb",
+        "dest": "cargo/vendor/malloc_buf-0.0.6"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb\", \"files\": {}}",
+        "dest": "cargo/vendor/malloc_buf-0.0.6",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/markup5ever/markup5ever-0.14.1.crate",
+        "sha256": "c7a7213d12e1864c0f002f52c2923d4556935a43dec5e71355c2760e0f6e7a18",
+        "dest": "cargo/vendor/markup5ever-0.14.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"c7a7213d12e1864c0f002f52c2923d4556935a43dec5e71355c2760e0f6e7a18\", \"files\": {}}",
+        "dest": "cargo/vendor/markup5ever-0.14.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/markup5ever/markup5ever-0.38.0.crate",
+        "sha256": "8983d30f2915feeaaab2d6babdd6bc7e9ed1a00b66b5e6d74df19aa9c0e91862",
+        "dest": "cargo/vendor/markup5ever-0.38.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"8983d30f2915feeaaab2d6babdd6bc7e9ed1a00b66b5e6d74df19aa9c0e91862\", \"files\": {}}",
+        "dest": "cargo/vendor/markup5ever-0.38.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/match_token/match_token-0.1.0.crate",
+        "sha256": "88a9689d8d44bf9964484516275f5cd4c9b59457a6940c1d5d0ecbb94510a36b",
+        "dest": "cargo/vendor/match_token-0.1.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"88a9689d8d44bf9964484516275f5cd4c9b59457a6940c1d5d0ecbb94510a36b\", \"files\": {}}",
+        "dest": "cargo/vendor/match_token-0.1.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/matchers/matchers-0.2.0.crate",
+        "sha256": "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9",
+        "dest": "cargo/vendor/matchers-0.2.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9\", \"files\": {}}",
+        "dest": "cargo/vendor/matchers-0.2.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/matches/matches-0.1.10.crate",
+        "sha256": "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5",
+        "dest": "cargo/vendor/matches-0.1.10"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5\", \"files\": {}}",
+        "dest": "cargo/vendor/matches-0.1.10",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/maybe-rayon/maybe-rayon-0.1.1.crate",
+        "sha256": "8ea1f30cedd69f0a2954655f7188c6a834246d2bcf1e315e2ac40c4b24dc9519",
+        "dest": "cargo/vendor/maybe-rayon-0.1.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"8ea1f30cedd69f0a2954655f7188c6a834246d2bcf1e315e2ac40c4b24dc9519\", \"files\": {}}",
+        "dest": "cargo/vendor/maybe-rayon-0.1.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/memchr/memchr-2.8.3.crate",
+        "sha256": "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98",
+        "dest": "cargo/vendor/memchr-2.8.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98\", \"files\": {}}",
+        "dest": "cargo/vendor/memchr-2.8.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/memoffset/memoffset-0.9.1.crate",
+        "sha256": "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a",
+        "dest": "cargo/vendor/memoffset-0.9.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a\", \"files\": {}}",
+        "dest": "cargo/vendor/memoffset-0.9.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/mime/mime-0.3.17.crate",
+        "sha256": "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a",
+        "dest": "cargo/vendor/mime-0.3.17"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a\", \"files\": {}}",
+        "dest": "cargo/vendor/mime-0.3.17",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/mime_guess/mime_guess-2.0.5.crate",
+        "sha256": "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e",
+        "dest": "cargo/vendor/mime_guess-2.0.5"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e\", \"files\": {}}",
+        "dest": "cargo/vendor/mime_guess-2.0.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/minimal-lexical/minimal-lexical-0.2.1.crate",
+        "sha256": "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a",
+        "dest": "cargo/vendor/minimal-lexical-0.2.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a\", \"files\": {}}",
+        "dest": "cargo/vendor/minimal-lexical-0.2.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/minisign-verify/minisign-verify-0.2.5.crate",
+        "sha256": "22f9645cb765ea72b8111f36c522475d2daa0d22c957a9826437e97534bc4e9e",
+        "dest": "cargo/vendor/minisign-verify-0.2.5"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"22f9645cb765ea72b8111f36c522475d2daa0d22c957a9826437e97534bc4e9e\", \"files\": {}}",
+        "dest": "cargo/vendor/minisign-verify-0.2.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/miniz_oxide/miniz_oxide-0.8.9.crate",
+        "sha256": "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316",
+        "dest": "cargo/vendor/miniz_oxide-0.8.9"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316\", \"files\": {}}",
+        "dest": "cargo/vendor/miniz_oxide-0.8.9",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/mio/mio-1.2.1.crate",
+        "sha256": "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda",
+        "dest": "cargo/vendor/mio-1.2.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda\", \"files\": {}}",
+        "dest": "cargo/vendor/mio-1.2.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/moka/moka-0.12.15.crate",
+        "sha256": "957228ad12042ee839f93c8f257b62b4c0ab5eaae1d4fa60de53b27c9d7c5046",
+        "dest": "cargo/vendor/moka-0.12.15"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"957228ad12042ee839f93c8f257b62b4c0ab5eaae1d4fa60de53b27c9d7c5046\", \"files\": {}}",
+        "dest": "cargo/vendor/moka-0.12.15",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/moxcms/moxcms-0.8.1.crate",
+        "sha256": "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b",
+        "dest": "cargo/vendor/moxcms-0.8.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b\", \"files\": {}}",
+        "dest": "cargo/vendor/moxcms-0.8.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/muda/muda-0.17.2.crate",
+        "sha256": "7c9fec5a4e89860383d778d10563a605838f8f0b2f9303868937e5ff32e86177",
+        "dest": "cargo/vendor/muda-0.17.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"7c9fec5a4e89860383d778d10563a605838f8f0b2f9303868937e5ff32e86177\", \"files\": {}}",
+        "dest": "cargo/vendor/muda-0.17.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/muldiv/muldiv-1.0.1.crate",
+        "sha256": "956787520e75e9bd233246045d19f42fb73242759cc57fba9611d940ae96d4b0",
+        "dest": "cargo/vendor/muldiv-1.0.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"956787520e75e9bd233246045d19f42fb73242759cc57fba9611d940ae96d4b0\", \"files\": {}}",
+        "dest": "cargo/vendor/muldiv-1.0.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/n0-error/n0-error-1.0.0.crate",
+        "sha256": "c37e81176a83a77d2514528b91bdafc70ef88aab428f0e1b91aebb8d99888895",
+        "dest": "cargo/vendor/n0-error-1.0.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"c37e81176a83a77d2514528b91bdafc70ef88aab428f0e1b91aebb8d99888895\", \"files\": {}}",
+        "dest": "cargo/vendor/n0-error-1.0.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/n0-error-macros/n0-error-macros-1.0.0.crate",
+        "sha256": "e2acd8b070213b0299282f884b4beba4e7b52d624fdcd504a3ad3665390c11e1",
+        "dest": "cargo/vendor/n0-error-macros-1.0.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"e2acd8b070213b0299282f884b4beba4e7b52d624fdcd504a3ad3665390c11e1\", \"files\": {}}",
+        "dest": "cargo/vendor/n0-error-macros-1.0.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/n0-future/n0-future-0.3.2.crate",
+        "sha256": "e2ab99dfb861450e68853d34ae665243a88b8c493d01ba957321a1e9b2312bbe",
+        "dest": "cargo/vendor/n0-future-0.3.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"e2ab99dfb861450e68853d34ae665243a88b8c493d01ba957321a1e9b2312bbe\", \"files\": {}}",
+        "dest": "cargo/vendor/n0-future-0.3.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/n0-watcher/n0-watcher-1.0.0.crate",
+        "sha256": "bbc618745ad0b7414b149d0517ad8b5573b2fb4d4e2717add3d2446ce1fdd826",
+        "dest": "cargo/vendor/n0-watcher-1.0.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"bbc618745ad0b7414b149d0517ad8b5573b2fb4d4e2717add3d2446ce1fdd826\", \"files\": {}}",
+        "dest": "cargo/vendor/n0-watcher-1.0.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/ndk/ndk-0.9.0.crate",
+        "sha256": "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4",
+        "dest": "cargo/vendor/ndk-0.9.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4\", \"files\": {}}",
+        "dest": "cargo/vendor/ndk-0.9.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/ndk-context/ndk-context-0.1.1.crate",
+        "sha256": "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b",
+        "dest": "cargo/vendor/ndk-context-0.1.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b\", \"files\": {}}",
+        "dest": "cargo/vendor/ndk-context-0.1.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/ndk-sys/ndk-sys-0.6.0+11769913.crate",
+        "sha256": "ee6cda3051665f1fb8d9e08fc35c96d5a244fb1be711a03b71118828afc9a873",
+        "dest": "cargo/vendor/ndk-sys-0.6.0+11769913"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"ee6cda3051665f1fb8d9e08fc35c96d5a244fb1be711a03b71118828afc9a873\", \"files\": {}}",
+        "dest": "cargo/vendor/ndk-sys-0.6.0+11769913",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/nested_enum_utils/nested_enum_utils-0.2.3.crate",
+        "sha256": "b1d5475271bdd36a4a2769eac1ef88df0f99428ea43e52dfd8b0ee5cb674695f",
+        "dest": "cargo/vendor/nested_enum_utils-0.2.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"b1d5475271bdd36a4a2769eac1ef88df0f99428ea43e52dfd8b0ee5cb674695f\", \"files\": {}}",
+        "dest": "cargo/vendor/nested_enum_utils-0.2.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/netdev/netdev-0.45.0.crate",
+        "sha256": "569dfbdd2efd771b24ec9bb57f956e04d4fbfc72f62b2f11961723f9b3f4b020",
+        "dest": "cargo/vendor/netdev-0.45.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"569dfbdd2efd771b24ec9bb57f956e04d4fbfc72f62b2f11961723f9b3f4b020\", \"files\": {}}",
+        "dest": "cargo/vendor/netdev-0.45.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/netlink-packet-core/netlink-packet-core-0.8.1.crate",
+        "sha256": "3463cbb78394cb0141e2c926b93fc2197e473394b761986eca3b9da2c63ae0f4",
+        "dest": "cargo/vendor/netlink-packet-core-0.8.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"3463cbb78394cb0141e2c926b93fc2197e473394b761986eca3b9da2c63ae0f4\", \"files\": {}}",
+        "dest": "cargo/vendor/netlink-packet-core-0.8.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/netlink-packet-route/netlink-packet-route-0.31.0.crate",
+        "sha256": "e2288fcb784eb3defd5fb16f4c4160d5f477de192eac730f43e1d11c24d9a007",
+        "dest": "cargo/vendor/netlink-packet-route-0.31.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"e2288fcb784eb3defd5fb16f4c4160d5f477de192eac730f43e1d11c24d9a007\", \"files\": {}}",
+        "dest": "cargo/vendor/netlink-packet-route-0.31.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/netlink-proto/netlink-proto-0.12.0.crate",
+        "sha256": "b65d130ee111430e47eed7896ea43ca693c387f097dd97376bffafbf25812128",
+        "dest": "cargo/vendor/netlink-proto-0.12.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"b65d130ee111430e47eed7896ea43ca693c387f097dd97376bffafbf25812128\", \"files\": {}}",
+        "dest": "cargo/vendor/netlink-proto-0.12.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/netlink-sys/netlink-sys-0.8.8.crate",
+        "sha256": "cd6c30ed10fa69cc491d491b85cc971f6bdeb8e7367b7cde2ee6cc878d583fae",
+        "dest": "cargo/vendor/netlink-sys-0.8.8"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"cd6c30ed10fa69cc491d491b85cc971f6bdeb8e7367b7cde2ee6cc878d583fae\", \"files\": {}}",
+        "dest": "cargo/vendor/netlink-sys-0.8.8",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/netwatch/netwatch-0.19.1.crate",
+        "sha256": "4d9cbe01741347ef750d743d6690603f5eed8341e679fb51c8e629337aa11976",
+        "dest": "cargo/vendor/netwatch-0.19.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"4d9cbe01741347ef750d743d6690603f5eed8341e679fb51c8e629337aa11976\", \"files\": {}}",
+        "dest": "cargo/vendor/netwatch-0.19.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/new_debug_unreachable/new_debug_unreachable-1.0.6.crate",
+        "sha256": "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086",
+        "dest": "cargo/vendor/new_debug_unreachable-1.0.6"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086\", \"files\": {}}",
+        "dest": "cargo/vendor/new_debug_unreachable-1.0.6",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/nix/nix-0.31.3.crate",
+        "sha256": "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d",
+        "dest": "cargo/vendor/nix-0.31.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d\", \"files\": {}}",
+        "dest": "cargo/vendor/nix-0.31.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/no_std_io2/no_std_io2-0.9.4.crate",
+        "sha256": "418abd1b6d34fbf6cae440dc874771b0525a604428704c76e48b29a5e67b8003",
+        "dest": "cargo/vendor/no_std_io2-0.9.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"418abd1b6d34fbf6cae440dc874771b0525a604428704c76e48b29a5e67b8003\", \"files\": {}}",
+        "dest": "cargo/vendor/no_std_io2-0.9.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/nodrop/nodrop-0.1.14.crate",
+        "sha256": "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb",
+        "dest": "cargo/vendor/nodrop-0.1.14"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb\", \"files\": {}}",
+        "dest": "cargo/vendor/nodrop-0.1.14",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/nom/nom-7.1.3.crate",
+        "sha256": "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a",
+        "dest": "cargo/vendor/nom-7.1.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a\", \"files\": {}}",
+        "dest": "cargo/vendor/nom-7.1.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/nom/nom-8.0.0.crate",
+        "sha256": "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405",
+        "dest": "cargo/vendor/nom-8.0.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405\", \"files\": {}}",
+        "dest": "cargo/vendor/nom-8.0.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/noop_proc_macro/noop_proc_macro-0.3.0.crate",
+        "sha256": "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8",
+        "dest": "cargo/vendor/noop_proc_macro-0.3.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8\", \"files\": {}}",
+        "dest": "cargo/vendor/noop_proc_macro-0.3.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/noq/noq-1.1.0.crate",
+        "sha256": "e11803df44ac03a30988d61585ea50885d5428e42da944fe1e498799da7886a2",
+        "dest": "cargo/vendor/noq-1.1.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"e11803df44ac03a30988d61585ea50885d5428e42da944fe1e498799da7886a2\", \"files\": {}}",
+        "dest": "cargo/vendor/noq-1.1.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/noq-proto/noq-proto-1.1.0.crate",
+        "sha256": "334c3c9833f7b2c573cceb9896ddc7aaeb58c8807cbb63211b24d1fe88bf866e",
+        "dest": "cargo/vendor/noq-proto-1.1.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"334c3c9833f7b2c573cceb9896ddc7aaeb58c8807cbb63211b24d1fe88bf866e\", \"files\": {}}",
+        "dest": "cargo/vendor/noq-proto-1.1.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/noq-udp/noq-udp-1.1.0.crate",
+        "sha256": "bde7a5d5102f1cff03d482240f0ed20551661f63663620f4b26112ed751165e9",
+        "dest": "cargo/vendor/noq-udp-1.1.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"bde7a5d5102f1cff03d482240f0ed20551661f63663620f4b26112ed751165e9\", \"files\": {}}",
+        "dest": "cargo/vendor/noq-udp-1.1.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/notify-rust/notify-rust-4.18.0.crate",
+        "sha256": "c5b4c1b4f2aa9f25f63a7a49d3dd0ed567b3670da15330a66b29434be899b891",
+        "dest": "cargo/vendor/notify-rust-4.18.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"c5b4c1b4f2aa9f25f63a7a49d3dd0ed567b3670da15330a66b29434be899b891\", \"files\": {}}",
+        "dest": "cargo/vendor/notify-rust-4.18.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/nu-ansi-term/nu-ansi-term-0.50.3.crate",
+        "sha256": "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5",
+        "dest": "cargo/vendor/nu-ansi-term-0.50.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5\", \"files\": {}}",
+        "dest": "cargo/vendor/nu-ansi-term-0.50.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/num-bigint/num-bigint-0.4.8.crate",
+        "sha256": "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367",
+        "dest": "cargo/vendor/num-bigint-0.4.8"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367\", \"files\": {}}",
+        "dest": "cargo/vendor/num-bigint-0.4.8",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/num-complex/num-complex-0.4.6.crate",
+        "sha256": "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495",
+        "dest": "cargo/vendor/num-complex-0.4.6"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495\", \"files\": {}}",
+        "dest": "cargo/vendor/num-complex-0.4.6",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/num-conv/num-conv-0.2.2.crate",
+        "sha256": "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441",
+        "dest": "cargo/vendor/num-conv-0.2.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441\", \"files\": {}}",
+        "dest": "cargo/vendor/num-conv-0.2.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/num-derive/num-derive-0.4.2.crate",
+        "sha256": "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202",
+        "dest": "cargo/vendor/num-derive-0.4.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202\", \"files\": {}}",
+        "dest": "cargo/vendor/num-derive-0.4.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/num-integer/num-integer-0.1.46.crate",
+        "sha256": "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f",
+        "dest": "cargo/vendor/num-integer-0.1.46"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f\", \"files\": {}}",
+        "dest": "cargo/vendor/num-integer-0.1.46",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/num-rational/num-rational-0.4.2.crate",
+        "sha256": "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824",
+        "dest": "cargo/vendor/num-rational-0.4.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824\", \"files\": {}}",
+        "dest": "cargo/vendor/num-rational-0.4.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/num-traits/num-traits-0.2.19.crate",
+        "sha256": "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841",
+        "dest": "cargo/vendor/num-traits-0.2.19"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841\", \"files\": {}}",
+        "dest": "cargo/vendor/num-traits-0.2.19",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/num_cpus/num_cpus-1.17.0.crate",
+        "sha256": "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b",
+        "dest": "cargo/vendor/num_cpus-1.17.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b\", \"files\": {}}",
+        "dest": "cargo/vendor/num_cpus-1.17.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/num_enum/num_enum-0.7.6.crate",
+        "sha256": "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26",
+        "dest": "cargo/vendor/num_enum-0.7.6"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26\", \"files\": {}}",
+        "dest": "cargo/vendor/num_enum-0.7.6",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/num_enum_derive/num_enum_derive-0.7.6.crate",
+        "sha256": "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8",
+        "dest": "cargo/vendor/num_enum_derive-0.7.6"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8\", \"files\": {}}",
+        "dest": "cargo/vendor/num_enum_derive-0.7.6",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/number_prefix/number_prefix-0.4.0.crate",
+        "sha256": "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3",
+        "dest": "cargo/vendor/number_prefix-0.4.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3\", \"files\": {}}",
+        "dest": "cargo/vendor/number_prefix-0.4.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/objc/objc-0.2.7.crate",
+        "sha256": "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1",
+        "dest": "cargo/vendor/objc-0.2.7"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1\", \"files\": {}}",
+        "dest": "cargo/vendor/objc-0.2.7",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/objc2/objc2-0.6.4.crate",
+        "sha256": "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f",
+        "dest": "cargo/vendor/objc2-0.6.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f\", \"files\": {}}",
+        "dest": "cargo/vendor/objc2-0.6.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/objc2-app-kit/objc2-app-kit-0.3.2.crate",
+        "sha256": "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c",
+        "dest": "cargo/vendor/objc2-app-kit-0.3.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c\", \"files\": {}}",
+        "dest": "cargo/vendor/objc2-app-kit-0.3.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/objc2-cloud-kit/objc2-cloud-kit-0.3.2.crate",
+        "sha256": "73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c",
+        "dest": "cargo/vendor/objc2-cloud-kit-0.3.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c\", \"files\": {}}",
+        "dest": "cargo/vendor/objc2-cloud-kit-0.3.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/objc2-core-data/objc2-core-data-0.3.2.crate",
+        "sha256": "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa",
+        "dest": "cargo/vendor/objc2-core-data-0.3.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa\", \"files\": {}}",
+        "dest": "cargo/vendor/objc2-core-data-0.3.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/objc2-core-foundation/objc2-core-foundation-0.3.2.crate",
+        "sha256": "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536",
+        "dest": "cargo/vendor/objc2-core-foundation-0.3.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536\", \"files\": {}}",
+        "dest": "cargo/vendor/objc2-core-foundation-0.3.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/objc2-core-graphics/objc2-core-graphics-0.3.2.crate",
+        "sha256": "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807",
+        "dest": "cargo/vendor/objc2-core-graphics-0.3.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807\", \"files\": {}}",
+        "dest": "cargo/vendor/objc2-core-graphics-0.3.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/objc2-core-image/objc2-core-image-0.3.2.crate",
+        "sha256": "e5d563b38d2b97209f8e861173de434bd0214cf020e3423a52624cd1d989f006",
+        "dest": "cargo/vendor/objc2-core-image-0.3.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"e5d563b38d2b97209f8e861173de434bd0214cf020e3423a52624cd1d989f006\", \"files\": {}}",
+        "dest": "cargo/vendor/objc2-core-image-0.3.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/objc2-core-location/objc2-core-location-0.3.2.crate",
+        "sha256": "ca347214e24bc973fc025fd0d36ebb179ff30536ed1f80252706db19ee452009",
+        "dest": "cargo/vendor/objc2-core-location-0.3.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"ca347214e24bc973fc025fd0d36ebb179ff30536ed1f80252706db19ee452009\", \"files\": {}}",
+        "dest": "cargo/vendor/objc2-core-location-0.3.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/objc2-core-text/objc2-core-text-0.3.2.crate",
+        "sha256": "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d",
+        "dest": "cargo/vendor/objc2-core-text-0.3.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d\", \"files\": {}}",
+        "dest": "cargo/vendor/objc2-core-text-0.3.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/objc2-core-wlan/objc2-core-wlan-0.3.2.crate",
+        "sha256": "c71e34919aba0d701380d911702455038a8a3587467fe0141d6a71501e7ffe48",
+        "dest": "cargo/vendor/objc2-core-wlan-0.3.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"c71e34919aba0d701380d911702455038a8a3587467fe0141d6a71501e7ffe48\", \"files\": {}}",
+        "dest": "cargo/vendor/objc2-core-wlan-0.3.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/objc2-encode/objc2-encode-4.1.0.crate",
+        "sha256": "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33",
+        "dest": "cargo/vendor/objc2-encode-4.1.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33\", \"files\": {}}",
+        "dest": "cargo/vendor/objc2-encode-4.1.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/objc2-exception-helper/objc2-exception-helper-0.1.1.crate",
+        "sha256": "c7a1c5fbb72d7735b076bb47b578523aedc40f3c439bea6dfd595c089d79d98a",
+        "dest": "cargo/vendor/objc2-exception-helper-0.1.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"c7a1c5fbb72d7735b076bb47b578523aedc40f3c439bea6dfd595c089d79d98a\", \"files\": {}}",
+        "dest": "cargo/vendor/objc2-exception-helper-0.1.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/objc2-foundation/objc2-foundation-0.3.2.crate",
+        "sha256": "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272",
+        "dest": "cargo/vendor/objc2-foundation-0.3.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272\", \"files\": {}}",
+        "dest": "cargo/vendor/objc2-foundation-0.3.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/objc2-io-surface/objc2-io-surface-0.3.2.crate",
+        "sha256": "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d",
+        "dest": "cargo/vendor/objc2-io-surface-0.3.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d\", \"files\": {}}",
+        "dest": "cargo/vendor/objc2-io-surface-0.3.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/objc2-javascript-core/objc2-javascript-core-0.3.2.crate",
+        "sha256": "2a1e6550c4caed348956ce3370c9ffeca70bb1dbed4fa96112e7c6170e074586",
+        "dest": "cargo/vendor/objc2-javascript-core-0.3.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"2a1e6550c4caed348956ce3370c9ffeca70bb1dbed4fa96112e7c6170e074586\", \"files\": {}}",
+        "dest": "cargo/vendor/objc2-javascript-core-0.3.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/objc2-osa-kit/objc2-osa-kit-0.3.2.crate",
+        "sha256": "f112d1746737b0da274ef79a23aac283376f335f4095a083a267a082f21db0c0",
+        "dest": "cargo/vendor/objc2-osa-kit-0.3.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"f112d1746737b0da274ef79a23aac283376f335f4095a083a267a082f21db0c0\", \"files\": {}}",
+        "dest": "cargo/vendor/objc2-osa-kit-0.3.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/objc2-quartz-core/objc2-quartz-core-0.3.2.crate",
+        "sha256": "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f",
+        "dest": "cargo/vendor/objc2-quartz-core-0.3.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f\", \"files\": {}}",
+        "dest": "cargo/vendor/objc2-quartz-core-0.3.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/objc2-security/objc2-security-0.3.2.crate",
+        "sha256": "709fe137109bd1e8b5a99390f77a7d8b2961dafc1a1c5db8f2e60329ad6d895a",
+        "dest": "cargo/vendor/objc2-security-0.3.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"709fe137109bd1e8b5a99390f77a7d8b2961dafc1a1c5db8f2e60329ad6d895a\", \"files\": {}}",
+        "dest": "cargo/vendor/objc2-security-0.3.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/objc2-security-foundation/objc2-security-foundation-0.3.2.crate",
+        "sha256": "ef76382e9cedd18123099f17638715cc3d81dba3637d4c0d39ab69df2ef345a5",
+        "dest": "cargo/vendor/objc2-security-foundation-0.3.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"ef76382e9cedd18123099f17638715cc3d81dba3637d4c0d39ab69df2ef345a5\", \"files\": {}}",
+        "dest": "cargo/vendor/objc2-security-foundation-0.3.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/objc2-system-configuration/objc2-system-configuration-0.3.2.crate",
+        "sha256": "7216bd11cbda54ccabcab84d523dc93b858ec75ecfb3a7d89513fa22464da396",
+        "dest": "cargo/vendor/objc2-system-configuration-0.3.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"7216bd11cbda54ccabcab84d523dc93b858ec75ecfb3a7d89513fa22464da396\", \"files\": {}}",
+        "dest": "cargo/vendor/objc2-system-configuration-0.3.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/objc2-ui-kit/objc2-ui-kit-0.3.2.crate",
+        "sha256": "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22",
+        "dest": "cargo/vendor/objc2-ui-kit-0.3.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22\", \"files\": {}}",
+        "dest": "cargo/vendor/objc2-ui-kit-0.3.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/objc2-user-notifications/objc2-user-notifications-0.3.2.crate",
+        "sha256": "9df9128cbbfef73cda168416ccf7f837b62737d748333bfe9ab71c245d76613e",
+        "dest": "cargo/vendor/objc2-user-notifications-0.3.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"9df9128cbbfef73cda168416ccf7f837b62737d748333bfe9ab71c245d76613e\", \"files\": {}}",
+        "dest": "cargo/vendor/objc2-user-notifications-0.3.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/objc2-web-kit/objc2-web-kit-0.3.2.crate",
+        "sha256": "b2e5aaab980c433cf470df9d7af96a7b46a9d892d521a2cbbb2f8a4c16751e7f",
+        "dest": "cargo/vendor/objc2-web-kit-0.3.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"b2e5aaab980c433cf470df9d7af96a7b46a9d892d521a2cbbb2f8a4c16751e7f\", \"files\": {}}",
+        "dest": "cargo/vendor/objc2-web-kit-0.3.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/oid-registry/oid-registry-0.8.1.crate",
+        "sha256": "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7",
+        "dest": "cargo/vendor/oid-registry-0.8.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7\", \"files\": {}}",
+        "dest": "cargo/vendor/oid-registry-0.8.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/once_cell/once_cell-1.21.4.crate",
+        "sha256": "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50",
+        "dest": "cargo/vendor/once_cell-1.21.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50\", \"files\": {}}",
+        "dest": "cargo/vendor/once_cell-1.21.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/once_cell_polyfill/once_cell_polyfill-1.70.2.crate",
+        "sha256": "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe",
+        "dest": "cargo/vendor/once_cell_polyfill-1.70.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe\", \"files\": {}}",
+        "dest": "cargo/vendor/once_cell_polyfill-1.70.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/opaque-debug/opaque-debug-0.3.1.crate",
+        "sha256": "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381",
+        "dest": "cargo/vendor/opaque-debug-0.3.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381\", \"files\": {}}",
+        "dest": "cargo/vendor/opaque-debug-0.3.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/open/open-5.3.6.crate",
+        "sha256": "cd8d3b65c44123a56e0133d2cd06ce4361bd3ca99d41198b2f25e3c3db9b8b4a",
+        "dest": "cargo/vendor/open-5.3.6"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"cd8d3b65c44123a56e0133d2cd06ce4361bd3ca99d41198b2f25e3c3db9b8b4a\", \"files\": {}}",
+        "dest": "cargo/vendor/open-5.3.6",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/openssl-probe/openssl-probe-0.2.1.crate",
+        "sha256": "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe",
+        "dest": "cargo/vendor/openssl-probe-0.2.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe\", \"files\": {}}",
+        "dest": "cargo/vendor/openssl-probe-0.2.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/option-ext/option-ext-0.2.0.crate",
+        "sha256": "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d",
+        "dest": "cargo/vendor/option-ext-0.2.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d\", \"files\": {}}",
+        "dest": "cargo/vendor/option-ext-0.2.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/option-operations/option-operations-0.5.0.crate",
+        "sha256": "7c26d27bb1aeab65138e4bf7666045169d1717febcc9ff870166be8348b223d0",
+        "dest": "cargo/vendor/option-operations-0.5.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"7c26d27bb1aeab65138e4bf7666045169d1717febcc9ff870166be8348b223d0\", \"files\": {}}",
+        "dest": "cargo/vendor/option-operations-0.5.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/ordered-multimap/ordered-multimap-0.7.3.crate",
+        "sha256": "49203cdcae0030493bad186b28da2fa25645fa276a51b6fec8010d281e02ef79",
+        "dest": "cargo/vendor/ordered-multimap-0.7.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"49203cdcae0030493bad186b28da2fa25645fa276a51b6fec8010d281e02ef79\", \"files\": {}}",
+        "dest": "cargo/vendor/ordered-multimap-0.7.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/ordered-stream/ordered-stream-0.2.0.crate",
+        "sha256": "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50",
+        "dest": "cargo/vendor/ordered-stream-0.2.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50\", \"files\": {}}",
+        "dest": "cargo/vendor/ordered-stream-0.2.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/os_info/os_info-3.15.0.crate",
+        "sha256": "9cf20a545b305cf1da722b236b5155c9bb35f1d5ceb28c048bd96ca842f41b5b",
+        "dest": "cargo/vendor/os_info-3.15.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"9cf20a545b305cf1da722b236b5155c9bb35f1d5ceb28c048bd96ca842f41b5b\", \"files\": {}}",
+        "dest": "cargo/vendor/os_info-3.15.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/osakit/osakit-0.3.1.crate",
+        "sha256": "732c71caeaa72c065bb69d7ea08717bd3f4863a4f451402fc9513e29dbd5261b",
+        "dest": "cargo/vendor/osakit-0.3.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"732c71caeaa72c065bb69d7ea08717bd3f4863a4f451402fc9513e29dbd5261b\", \"files\": {}}",
+        "dest": "cargo/vendor/osakit-0.3.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/pango/pango-0.18.3.crate",
+        "sha256": "7ca27ec1eb0457ab26f3036ea52229edbdb74dee1edd29063f5b9b010e7ebee4",
+        "dest": "cargo/vendor/pango-0.18.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"7ca27ec1eb0457ab26f3036ea52229edbdb74dee1edd29063f5b9b010e7ebee4\", \"files\": {}}",
+        "dest": "cargo/vendor/pango-0.18.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/pango-sys/pango-sys-0.18.0.crate",
+        "sha256": "436737e391a843e5933d6d9aa102cb126d501e815b83601365a948a518555dc5",
+        "dest": "cargo/vendor/pango-sys-0.18.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"436737e391a843e5933d6d9aa102cb126d501e815b83601365a948a518555dc5\", \"files\": {}}",
+        "dest": "cargo/vendor/pango-sys-0.18.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/papaya/papaya-0.2.4.crate",
+        "sha256": "997ee03cd38c01469a7046643714f0ad28880bcb9e6679ff0666e24817ca19b7",
+        "dest": "cargo/vendor/papaya-0.2.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"997ee03cd38c01469a7046643714f0ad28880bcb9e6679ff0666e24817ca19b7\", \"files\": {}}",
+        "dest": "cargo/vendor/papaya-0.2.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/parking/parking-2.2.1.crate",
+        "sha256": "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba",
+        "dest": "cargo/vendor/parking-2.2.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba\", \"files\": {}}",
+        "dest": "cargo/vendor/parking-2.2.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/parking_lot/parking_lot-0.12.5.crate",
+        "sha256": "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a",
+        "dest": "cargo/vendor/parking_lot-0.12.5"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a\", \"files\": {}}",
+        "dest": "cargo/vendor/parking_lot-0.12.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/parking_lot_core/parking_lot_core-0.9.12.crate",
+        "sha256": "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1",
+        "dest": "cargo/vendor/parking_lot_core-0.9.12"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1\", \"files\": {}}",
+        "dest": "cargo/vendor/parking_lot_core-0.9.12",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/paste/paste-1.0.15.crate",
+        "sha256": "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a",
+        "dest": "cargo/vendor/paste-1.0.15"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a\", \"files\": {}}",
+        "dest": "cargo/vendor/paste-1.0.15",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/pastey/pastey-0.1.1.crate",
+        "sha256": "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec",
+        "dest": "cargo/vendor/pastey-0.1.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec\", \"files\": {}}",
+        "dest": "cargo/vendor/pastey-0.1.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/pem/pem-3.0.6.crate",
+        "sha256": "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be",
+        "dest": "cargo/vendor/pem-3.0.6"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be\", \"files\": {}}",
+        "dest": "cargo/vendor/pem-3.0.6",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/pem-rfc7468/pem-rfc7468-1.0.0.crate",
+        "sha256": "a6305423e0e7738146434843d1694d621cce767262b2a86910beab705e4493d9",
+        "dest": "cargo/vendor/pem-rfc7468-1.0.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"a6305423e0e7738146434843d1694d621cce767262b2a86910beab705e4493d9\", \"files\": {}}",
+        "dest": "cargo/vendor/pem-rfc7468-1.0.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/percent-encoding/percent-encoding-2.3.2.crate",
+        "sha256": "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220",
+        "dest": "cargo/vendor/percent-encoding-2.3.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220\", \"files\": {}}",
+        "dest": "cargo/vendor/percent-encoding-2.3.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/pharos/pharos-0.5.3.crate",
+        "sha256": "e9567389417feee6ce15dd6527a8a1ecac205ef62c2932bcf3d9f6fc5b78b414",
+        "dest": "cargo/vendor/pharos-0.5.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"e9567389417feee6ce15dd6527a8a1ecac205ef62c2932bcf3d9f6fc5b78b414\", \"files\": {}}",
+        "dest": "cargo/vendor/pharos-0.5.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/phf/phf-0.8.0.crate",
+        "sha256": "3dfb61232e34fcb633f43d12c58f83c1df82962dcdfa565a4e866ffc17dafe12",
+        "dest": "cargo/vendor/phf-0.8.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"3dfb61232e34fcb633f43d12c58f83c1df82962dcdfa565a4e866ffc17dafe12\", \"files\": {}}",
+        "dest": "cargo/vendor/phf-0.8.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/phf/phf-0.10.1.crate",
+        "sha256": "fabbf1ead8a5bcbc20f5f8b939ee3f5b0f6f281b6ad3468b84656b658b455259",
+        "dest": "cargo/vendor/phf-0.10.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"fabbf1ead8a5bcbc20f5f8b939ee3f5b0f6f281b6ad3468b84656b658b455259\", \"files\": {}}",
+        "dest": "cargo/vendor/phf-0.10.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/phf/phf-0.11.3.crate",
+        "sha256": "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078",
+        "dest": "cargo/vendor/phf-0.11.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078\", \"files\": {}}",
+        "dest": "cargo/vendor/phf-0.11.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/phf/phf-0.13.1.crate",
+        "sha256": "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf",
+        "dest": "cargo/vendor/phf-0.13.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf\", \"files\": {}}",
+        "dest": "cargo/vendor/phf-0.13.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/phf_codegen/phf_codegen-0.8.0.crate",
+        "sha256": "cbffee61585b0411840d3ece935cce9cb6321f01c45477d30066498cd5e1a815",
+        "dest": "cargo/vendor/phf_codegen-0.8.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"cbffee61585b0411840d3ece935cce9cb6321f01c45477d30066498cd5e1a815\", \"files\": {}}",
+        "dest": "cargo/vendor/phf_codegen-0.8.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/phf_codegen/phf_codegen-0.11.3.crate",
+        "sha256": "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a",
+        "dest": "cargo/vendor/phf_codegen-0.11.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a\", \"files\": {}}",
+        "dest": "cargo/vendor/phf_codegen-0.11.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/phf_codegen/phf_codegen-0.13.1.crate",
+        "sha256": "49aa7f9d80421bca176ca8dbfebe668cc7a2684708594ec9f3c0db0805d5d6e1",
+        "dest": "cargo/vendor/phf_codegen-0.13.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"49aa7f9d80421bca176ca8dbfebe668cc7a2684708594ec9f3c0db0805d5d6e1\", \"files\": {}}",
+        "dest": "cargo/vendor/phf_codegen-0.13.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/phf_generator/phf_generator-0.8.0.crate",
+        "sha256": "17367f0cc86f2d25802b2c26ee58a7b23faeccf78a396094c13dced0d0182526",
+        "dest": "cargo/vendor/phf_generator-0.8.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"17367f0cc86f2d25802b2c26ee58a7b23faeccf78a396094c13dced0d0182526\", \"files\": {}}",
+        "dest": "cargo/vendor/phf_generator-0.8.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/phf_generator/phf_generator-0.10.0.crate",
+        "sha256": "5d5285893bb5eb82e6aaf5d59ee909a06a16737a8970984dd7746ba9283498d6",
+        "dest": "cargo/vendor/phf_generator-0.10.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"5d5285893bb5eb82e6aaf5d59ee909a06a16737a8970984dd7746ba9283498d6\", \"files\": {}}",
+        "dest": "cargo/vendor/phf_generator-0.10.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/phf_generator/phf_generator-0.11.3.crate",
+        "sha256": "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d",
+        "dest": "cargo/vendor/phf_generator-0.11.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d\", \"files\": {}}",
+        "dest": "cargo/vendor/phf_generator-0.11.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/phf_generator/phf_generator-0.13.1.crate",
+        "sha256": "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737",
+        "dest": "cargo/vendor/phf_generator-0.13.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737\", \"files\": {}}",
+        "dest": "cargo/vendor/phf_generator-0.13.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/phf_macros/phf_macros-0.10.0.crate",
+        "sha256": "58fdf3184dd560f160dd73922bea2d5cd6e8f064bf4b13110abd81b03697b4e0",
+        "dest": "cargo/vendor/phf_macros-0.10.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"58fdf3184dd560f160dd73922bea2d5cd6e8f064bf4b13110abd81b03697b4e0\", \"files\": {}}",
+        "dest": "cargo/vendor/phf_macros-0.10.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/phf_macros/phf_macros-0.13.1.crate",
+        "sha256": "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef",
+        "dest": "cargo/vendor/phf_macros-0.13.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef\", \"files\": {}}",
+        "dest": "cargo/vendor/phf_macros-0.13.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/phf_shared/phf_shared-0.8.0.crate",
+        "sha256": "c00cf8b9eafe68dde5e9eaa2cef8ee84a9336a47d566ec55ca16589633b65af7",
+        "dest": "cargo/vendor/phf_shared-0.8.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"c00cf8b9eafe68dde5e9eaa2cef8ee84a9336a47d566ec55ca16589633b65af7\", \"files\": {}}",
+        "dest": "cargo/vendor/phf_shared-0.8.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/phf_shared/phf_shared-0.10.0.crate",
+        "sha256": "b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096",
+        "dest": "cargo/vendor/phf_shared-0.10.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096\", \"files\": {}}",
+        "dest": "cargo/vendor/phf_shared-0.10.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/phf_shared/phf_shared-0.11.3.crate",
+        "sha256": "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5",
+        "dest": "cargo/vendor/phf_shared-0.11.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5\", \"files\": {}}",
+        "dest": "cargo/vendor/phf_shared-0.11.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/phf_shared/phf_shared-0.13.1.crate",
+        "sha256": "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266",
+        "dest": "cargo/vendor/phf_shared-0.13.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266\", \"files\": {}}",
+        "dest": "cargo/vendor/phf_shared-0.13.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/pin-project/pin-project-1.1.13.crate",
+        "sha256": "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924",
+        "dest": "cargo/vendor/pin-project-1.1.13"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924\", \"files\": {}}",
+        "dest": "cargo/vendor/pin-project-1.1.13",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/pin-project-internal/pin-project-internal-1.1.13.crate",
+        "sha256": "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b",
+        "dest": "cargo/vendor/pin-project-internal-1.1.13"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b\", \"files\": {}}",
+        "dest": "cargo/vendor/pin-project-internal-1.1.13",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/pin-project-lite/pin-project-lite-0.2.17.crate",
+        "sha256": "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd",
+        "dest": "cargo/vendor/pin-project-lite-0.2.17"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd\", \"files\": {}}",
+        "dest": "cargo/vendor/pin-project-lite-0.2.17",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/piper/piper-0.2.5.crate",
+        "sha256": "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1",
+        "dest": "cargo/vendor/piper-0.2.5"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1\", \"files\": {}}",
+        "dest": "cargo/vendor/piper-0.2.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/pkcs8/pkcs8-0.11.0.crate",
+        "sha256": "451913da69c775a56034ea8d9003d27ee8948e12443eae7c038ba100a4f21cb7",
+        "dest": "cargo/vendor/pkcs8-0.11.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"451913da69c775a56034ea8d9003d27ee8948e12443eae7c038ba100a4f21cb7\", \"files\": {}}",
+        "dest": "cargo/vendor/pkcs8-0.11.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/pkg-config/pkg-config-0.3.33.crate",
+        "sha256": "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e",
+        "dest": "cargo/vendor/pkg-config-0.3.33"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e\", \"files\": {}}",
+        "dest": "cargo/vendor/pkg-config-0.3.33",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/plist/plist-1.10.0.crate",
+        "sha256": "7da1d65da6dd5d1e44199ac0f58712d241c0f439f80adea8924d832384087f85",
+        "dest": "cargo/vendor/plist-1.10.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"7da1d65da6dd5d1e44199ac0f58712d241c0f439f80adea8924d832384087f85\", \"files\": {}}",
+        "dest": "cargo/vendor/plist-1.10.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/png/png-0.17.16.crate",
+        "sha256": "82151a2fc869e011c153adc57cf2789ccb8d9906ce52c0b39a6b5697749d7526",
+        "dest": "cargo/vendor/png-0.17.16"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"82151a2fc869e011c153adc57cf2789ccb8d9906ce52c0b39a6b5697749d7526\", \"files\": {}}",
+        "dest": "cargo/vendor/png-0.17.16",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/png/png-0.18.1.crate",
+        "sha256": "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61",
+        "dest": "cargo/vendor/png-0.18.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61\", \"files\": {}}",
+        "dest": "cargo/vendor/png-0.18.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/polling/polling-3.11.0.crate",
+        "sha256": "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218",
+        "dest": "cargo/vendor/polling-3.11.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218\", \"files\": {}}",
+        "dest": "cargo/vendor/polling-3.11.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/pollster/pollster-0.4.0.crate",
+        "sha256": "2f3a9f18d041e6d0e102a0a46750538147e5e8992d3b4873aaafee2520b00ce3",
+        "dest": "cargo/vendor/pollster-0.4.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"2f3a9f18d041e6d0e102a0a46750538147e5e8992d3b4873aaafee2520b00ce3\", \"files\": {}}",
+        "dest": "cargo/vendor/pollster-0.4.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/polyval/polyval-0.6.2.crate",
+        "sha256": "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25",
+        "dest": "cargo/vendor/polyval-0.6.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25\", \"files\": {}}",
+        "dest": "cargo/vendor/polyval-0.6.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/portable-atomic/portable-atomic-1.13.1.crate",
+        "sha256": "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49",
+        "dest": "cargo/vendor/portable-atomic-1.13.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49\", \"files\": {}}",
+        "dest": "cargo/vendor/portable-atomic-1.13.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/portmapper/portmapper-0.19.1.crate",
+        "sha256": "eb3713e4977408279158444a18c1a01ac9bf2e7eaf1fbfd1a19ac9cd18d90721",
+        "dest": "cargo/vendor/portmapper-0.19.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"eb3713e4977408279158444a18c1a01ac9bf2e7eaf1fbfd1a19ac9cd18d90721\", \"files\": {}}",
+        "dest": "cargo/vendor/portmapper-0.19.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/positioned-io/positioned-io-0.3.5.crate",
+        "sha256": "d4ec4b80060f033312b99b6874025d9503d2af87aef2dd4c516e253fbfcdada7",
+        "dest": "cargo/vendor/positioned-io-0.3.5"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"d4ec4b80060f033312b99b6874025d9503d2af87aef2dd4c516e253fbfcdada7\", \"files\": {}}",
+        "dest": "cargo/vendor/positioned-io-0.3.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/postcard/postcard-1.1.3.crate",
+        "sha256": "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24",
+        "dest": "cargo/vendor/postcard-1.1.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24\", \"files\": {}}",
+        "dest": "cargo/vendor/postcard-1.1.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/postcard-derive/postcard-derive-0.2.2.crate",
+        "sha256": "e0232bd009a197ceec9cc881ba46f727fcd8060a2d8d6a9dde7a69030a6fe2bb",
+        "dest": "cargo/vendor/postcard-derive-0.2.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"e0232bd009a197ceec9cc881ba46f727fcd8060a2d8d6a9dde7a69030a6fe2bb\", \"files\": {}}",
+        "dest": "cargo/vendor/postcard-derive-0.2.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/potential_utf/potential_utf-0.1.5.crate",
+        "sha256": "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564",
+        "dest": "cargo/vendor/potential_utf-0.1.5"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564\", \"files\": {}}",
+        "dest": "cargo/vendor/potential_utf-0.1.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/powerfmt/powerfmt-0.2.0.crate",
+        "sha256": "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391",
+        "dest": "cargo/vendor/powerfmt-0.2.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391\", \"files\": {}}",
+        "dest": "cargo/vendor/powerfmt-0.2.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/ppv-lite86/ppv-lite86-0.2.21.crate",
+        "sha256": "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9",
+        "dest": "cargo/vendor/ppv-lite86-0.2.21"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9\", \"files\": {}}",
+        "dest": "cargo/vendor/ppv-lite86-0.2.21",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/precomputed-hash/precomputed-hash-0.1.1.crate",
+        "sha256": "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c",
+        "dest": "cargo/vendor/precomputed-hash-0.1.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c\", \"files\": {}}",
+        "dest": "cargo/vendor/precomputed-hash-0.1.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/prefix-trie/prefix-trie-0.8.4.crate",
+        "sha256": "4cf6e3177f0684016a5c209b00882e15f8bdd3f3bb48f0491df10cd102d0c6e7",
+        "dest": "cargo/vendor/prefix-trie-0.8.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"4cf6e3177f0684016a5c209b00882e15f8bdd3f3bb48f0491df10cd102d0c6e7\", \"files\": {}}",
+        "dest": "cargo/vendor/prefix-trie-0.8.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/proc-macro-crate/proc-macro-crate-1.3.1.crate",
+        "sha256": "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919",
+        "dest": "cargo/vendor/proc-macro-crate-1.3.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919\", \"files\": {}}",
+        "dest": "cargo/vendor/proc-macro-crate-1.3.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/proc-macro-crate/proc-macro-crate-2.0.2.crate",
+        "sha256": "b00f26d3400549137f92511a46ac1cd8ce37cb5598a96d382381458b992a5d24",
+        "dest": "cargo/vendor/proc-macro-crate-2.0.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"b00f26d3400549137f92511a46ac1cd8ce37cb5598a96d382381458b992a5d24\", \"files\": {}}",
+        "dest": "cargo/vendor/proc-macro-crate-2.0.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/proc-macro-crate/proc-macro-crate-3.5.0.crate",
+        "sha256": "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f",
+        "dest": "cargo/vendor/proc-macro-crate-3.5.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f\", \"files\": {}}",
+        "dest": "cargo/vendor/proc-macro-crate-3.5.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/proc-macro-error/proc-macro-error-0.4.12.crate",
+        "sha256": "18f33027081eba0a6d8aba6d1b1c3a3be58cbb12106341c2d5759fcd9b5277e7",
+        "dest": "cargo/vendor/proc-macro-error-0.4.12"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"18f33027081eba0a6d8aba6d1b1c3a3be58cbb12106341c2d5759fcd9b5277e7\", \"files\": {}}",
+        "dest": "cargo/vendor/proc-macro-error-0.4.12",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/proc-macro-error/proc-macro-error-1.0.4.crate",
+        "sha256": "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c",
+        "dest": "cargo/vendor/proc-macro-error-1.0.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c\", \"files\": {}}",
+        "dest": "cargo/vendor/proc-macro-error-1.0.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/proc-macro-error-attr/proc-macro-error-attr-0.4.12.crate",
+        "sha256": "8a5b4b77fdb63c1eca72173d68d24501c54ab1269409f6b672c85deb18af69de",
+        "dest": "cargo/vendor/proc-macro-error-attr-0.4.12"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"8a5b4b77fdb63c1eca72173d68d24501c54ab1269409f6b672c85deb18af69de\", \"files\": {}}",
+        "dest": "cargo/vendor/proc-macro-error-attr-0.4.12",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/proc-macro-error-attr/proc-macro-error-attr-1.0.4.crate",
+        "sha256": "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869",
+        "dest": "cargo/vendor/proc-macro-error-attr-1.0.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869\", \"files\": {}}",
+        "dest": "cargo/vendor/proc-macro-error-attr-1.0.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/proc-macro-hack/proc-macro-hack-0.5.20+deprecated.crate",
+        "sha256": "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068",
+        "dest": "cargo/vendor/proc-macro-hack-0.5.20+deprecated"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068\", \"files\": {}}",
+        "dest": "cargo/vendor/proc-macro-hack-0.5.20+deprecated",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/proc-macro2/proc-macro2-1.0.106.crate",
+        "sha256": "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934",
+        "dest": "cargo/vendor/proc-macro2-1.0.106"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934\", \"files\": {}}",
+        "dest": "cargo/vendor/proc-macro2-1.0.106",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/profiling/profiling-1.0.18.crate",
+        "sha256": "3d595e54a326bc53c1c197b32d295e14b169e3cfeaa8dc82b529f947fba6bcf5",
+        "dest": "cargo/vendor/profiling-1.0.18"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"3d595e54a326bc53c1c197b32d295e14b169e3cfeaa8dc82b529f947fba6bcf5\", \"files\": {}}",
+        "dest": "cargo/vendor/profiling-1.0.18",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/profiling-procmacros/profiling-procmacros-1.0.18.crate",
+        "sha256": "4488a4a36b9a4ba6b9334a32a39971f77c1436ec82c38707bce707699cc3bbcb",
+        "dest": "cargo/vendor/profiling-procmacros-1.0.18"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"4488a4a36b9a4ba6b9334a32a39971f77c1436ec82c38707bce707699cc3bbcb\", \"files\": {}}",
+        "dest": "cargo/vendor/profiling-procmacros-1.0.18",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/pulp/pulp-0.22.3.crate",
+        "sha256": "046aa45b989642ec2e4717c8e72d677b13edd831a4d3b6cf37d9a3e54912496a",
+        "dest": "cargo/vendor/pulp-0.22.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"046aa45b989642ec2e4717c8e72d677b13edd831a4d3b6cf37d9a3e54912496a\", \"files\": {}}",
+        "dest": "cargo/vendor/pulp-0.22.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/pulp-wasm-simd-flag/pulp-wasm-simd-flag-0.1.1.crate",
+        "sha256": "1d8f70e07b9c3962945a74e59ca1c511bba65b6419468acc217c457d93f3c740",
+        "dest": "cargo/vendor/pulp-wasm-simd-flag-0.1.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"1d8f70e07b9c3962945a74e59ca1c511bba65b6419468acc217c457d93f3c740\", \"files\": {}}",
+        "dest": "cargo/vendor/pulp-wasm-simd-flag-0.1.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/pxfm/pxfm-0.1.30.crate",
+        "sha256": "d55d956fa96f5ec02be2e13af0e20391a5aa83d6a074e3ad368959d0fab299ea",
+        "dest": "cargo/vendor/pxfm-0.1.30"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"d55d956fa96f5ec02be2e13af0e20391a5aa83d6a074e3ad368959d0fab299ea\", \"files\": {}}",
+        "dest": "cargo/vendor/pxfm-0.1.30",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/qoi/qoi-0.4.1.crate",
+        "sha256": "7f6d64c71eb498fe9eae14ce4ec935c555749aef511cca85b5568910d6e48001",
+        "dest": "cargo/vendor/qoi-0.4.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"7f6d64c71eb498fe9eae14ce4ec935c555749aef511cca85b5568910d6e48001\", \"files\": {}}",
+        "dest": "cargo/vendor/qoi-0.4.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/quick-error/quick-error-2.0.1.crate",
+        "sha256": "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3",
+        "dest": "cargo/vendor/quick-error-2.0.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3\", \"files\": {}}",
+        "dest": "cargo/vendor/quick-error-2.0.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/quick-xml/quick-xml-0.41.0.crate",
+        "sha256": "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1",
+        "dest": "cargo/vendor/quick-xml-0.41.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1\", \"files\": {}}",
+        "dest": "cargo/vendor/quick-xml-0.41.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/quinn/quinn-0.11.11.crate",
+        "sha256": "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8",
+        "dest": "cargo/vendor/quinn-0.11.11"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8\", \"files\": {}}",
+        "dest": "cargo/vendor/quinn-0.11.11",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/quinn-proto/quinn-proto-0.11.16.crate",
+        "sha256": "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560",
+        "dest": "cargo/vendor/quinn-proto-0.11.16"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560\", \"files\": {}}",
+        "dest": "cargo/vendor/quinn-proto-0.11.16",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/quinn-udp/quinn-udp-0.5.15.crate",
+        "sha256": "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694",
+        "dest": "cargo/vendor/quinn-udp-0.5.15"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694\", \"files\": {}}",
+        "dest": "cargo/vendor/quinn-udp-0.5.15",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/quote/quote-1.0.46.crate",
+        "sha256": "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368",
+        "dest": "cargo/vendor/quote-1.0.46"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368\", \"files\": {}}",
+        "dest": "cargo/vendor/quote-1.0.46",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/r-efi/r-efi-5.3.0.crate",
+        "sha256": "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f",
+        "dest": "cargo/vendor/r-efi-5.3.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f\", \"files\": {}}",
+        "dest": "cargo/vendor/r-efi-5.3.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/r-efi/r-efi-6.0.0.crate",
+        "sha256": "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf",
+        "dest": "cargo/vendor/r-efi-6.0.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf\", \"files\": {}}",
+        "dest": "cargo/vendor/r-efi-6.0.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/rand/rand-0.7.3.crate",
+        "sha256": "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03",
+        "dest": "cargo/vendor/rand-0.7.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03\", \"files\": {}}",
+        "dest": "cargo/vendor/rand-0.7.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/rand/rand-0.8.6.crate",
+        "sha256": "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a",
+        "dest": "cargo/vendor/rand-0.8.6"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a\", \"files\": {}}",
+        "dest": "cargo/vendor/rand-0.8.6",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/rand/rand-0.9.4.crate",
+        "sha256": "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea",
+        "dest": "cargo/vendor/rand-0.9.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea\", \"files\": {}}",
+        "dest": "cargo/vendor/rand-0.9.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/rand/rand-0.10.2.crate",
+        "sha256": "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80",
+        "dest": "cargo/vendor/rand-0.10.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80\", \"files\": {}}",
+        "dest": "cargo/vendor/rand-0.10.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/rand_chacha/rand_chacha-0.2.2.crate",
+        "sha256": "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402",
+        "dest": "cargo/vendor/rand_chacha-0.2.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402\", \"files\": {}}",
+        "dest": "cargo/vendor/rand_chacha-0.2.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/rand_chacha/rand_chacha-0.3.1.crate",
+        "sha256": "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88",
+        "dest": "cargo/vendor/rand_chacha-0.3.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88\", \"files\": {}}",
+        "dest": "cargo/vendor/rand_chacha-0.3.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/rand_chacha/rand_chacha-0.9.0.crate",
+        "sha256": "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb",
+        "dest": "cargo/vendor/rand_chacha-0.9.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb\", \"files\": {}}",
+        "dest": "cargo/vendor/rand_chacha-0.9.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/rand_core/rand_core-0.5.1.crate",
+        "sha256": "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19",
+        "dest": "cargo/vendor/rand_core-0.5.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19\", \"files\": {}}",
+        "dest": "cargo/vendor/rand_core-0.5.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/rand_core/rand_core-0.6.4.crate",
+        "sha256": "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c",
+        "dest": "cargo/vendor/rand_core-0.6.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c\", \"files\": {}}",
+        "dest": "cargo/vendor/rand_core-0.6.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/rand_core/rand_core-0.9.5.crate",
+        "sha256": "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c",
+        "dest": "cargo/vendor/rand_core-0.9.5"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c\", \"files\": {}}",
+        "dest": "cargo/vendor/rand_core-0.9.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/rand_core/rand_core-0.10.1.crate",
+        "sha256": "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69",
+        "dest": "cargo/vendor/rand_core-0.10.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69\", \"files\": {}}",
+        "dest": "cargo/vendor/rand_core-0.10.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/rand_hc/rand_hc-0.2.0.crate",
+        "sha256": "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c",
+        "dest": "cargo/vendor/rand_hc-0.2.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c\", \"files\": {}}",
+        "dest": "cargo/vendor/rand_hc-0.2.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/rand_pcg/rand_pcg-0.2.1.crate",
+        "sha256": "16abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429",
+        "dest": "cargo/vendor/rand_pcg-0.2.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"16abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429\", \"files\": {}}",
+        "dest": "cargo/vendor/rand_pcg-0.2.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/rand_pcg/rand_pcg-0.10.2.crate",
+        "sha256": "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a",
+        "dest": "cargo/vendor/rand_pcg-0.10.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a\", \"files\": {}}",
+        "dest": "cargo/vendor/rand_pcg-0.10.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/range-collections/range-collections-0.4.6.crate",
+        "sha256": "861706ea9c4aded7584c5cd1d241cec2ea7f5f50999f236c22b65409a1f1a0d0",
+        "dest": "cargo/vendor/range-collections-0.4.6"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"861706ea9c4aded7584c5cd1d241cec2ea7f5f50999f236c22b65409a1f1a0d0\", \"files\": {}}",
+        "dest": "cargo/vendor/range-collections-0.4.6",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/rav1e/rav1e-0.8.1.crate",
+        "sha256": "43b6dd56e85d9483277cde964fd1bdb0428de4fec5ebba7540995639a21cb32b",
+        "dest": "cargo/vendor/rav1e-0.8.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"43b6dd56e85d9483277cde964fd1bdb0428de4fec5ebba7540995639a21cb32b\", \"files\": {}}",
+        "dest": "cargo/vendor/rav1e-0.8.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/ravif/ravif-0.13.0.crate",
+        "sha256": "e52310197d971b0f5be7fe6b57530dcd27beb35c1b013f29d66c1ad73fbbcc45",
+        "dest": "cargo/vendor/ravif-0.13.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"e52310197d971b0f5be7fe6b57530dcd27beb35c1b013f29d66c1ad73fbbcc45\", \"files\": {}}",
+        "dest": "cargo/vendor/ravif-0.13.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/raw-cpuid/raw-cpuid-11.6.0.crate",
+        "sha256": "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186",
+        "dest": "cargo/vendor/raw-cpuid-11.6.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186\", \"files\": {}}",
+        "dest": "cargo/vendor/raw-cpuid-11.6.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/raw-window-handle/raw-window-handle-0.6.2.crate",
+        "sha256": "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539",
+        "dest": "cargo/vendor/raw-window-handle-0.6.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539\", \"files\": {}}",
+        "dest": "cargo/vendor/raw-window-handle-0.6.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/rayon/rayon-1.12.0.crate",
+        "sha256": "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d",
+        "dest": "cargo/vendor/rayon-1.12.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d\", \"files\": {}}",
+        "dest": "cargo/vendor/rayon-1.12.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/rayon-core/rayon-core-1.13.0.crate",
+        "sha256": "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91",
+        "dest": "cargo/vendor/rayon-core-1.13.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91\", \"files\": {}}",
+        "dest": "cargo/vendor/rayon-core-1.13.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/rcgen/rcgen-0.14.8.crate",
+        "sha256": "57f6d249aad744e274e682777a50283a225a32705394ee6d5fcc01efa25e4055",
+        "dest": "cargo/vendor/rcgen-0.14.8"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"57f6d249aad744e274e682777a50283a225a32705394ee6d5fcc01efa25e4055\", \"files\": {}}",
+        "dest": "cargo/vendor/rcgen-0.14.8",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/reborrow/reborrow-0.5.5.crate",
+        "sha256": "03251193000f4bd3b042892be858ee50e8b3719f2b08e5833ac4353724632430",
+        "dest": "cargo/vendor/reborrow-0.5.5"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"03251193000f4bd3b042892be858ee50e8b3719f2b08e5833ac4353724632430\", \"files\": {}}",
+        "dest": "cargo/vendor/reborrow-0.5.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/redb/redb-4.1.0.crate",
+        "sha256": "8e925444704b5f17d32bf42f5b6e2df050bceebc3dcd6e71cc73dafe8092e839",
+        "dest": "cargo/vendor/redb-4.1.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"8e925444704b5f17d32bf42f5b6e2df050bceebc3dcd6e71cc73dafe8092e839\", \"files\": {}}",
+        "dest": "cargo/vendor/redb-4.1.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/redox_syscall/redox_syscall-0.5.18.crate",
+        "sha256": "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d",
+        "dest": "cargo/vendor/redox_syscall-0.5.18"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d\", \"files\": {}}",
+        "dest": "cargo/vendor/redox_syscall-0.5.18",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/redox_users/redox_users-0.5.2.crate",
+        "sha256": "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac",
+        "dest": "cargo/vendor/redox_users-0.5.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac\", \"files\": {}}",
+        "dest": "cargo/vendor/redox_users-0.5.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/ref-cast/ref-cast-1.0.25.crate",
+        "sha256": "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d",
+        "dest": "cargo/vendor/ref-cast-1.0.25"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d\", \"files\": {}}",
+        "dest": "cargo/vendor/ref-cast-1.0.25",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/ref-cast-impl/ref-cast-impl-1.0.25.crate",
+        "sha256": "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da",
+        "dest": "cargo/vendor/ref-cast-impl-1.0.25"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da\", \"files\": {}}",
+        "dest": "cargo/vendor/ref-cast-impl-1.0.25",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/reflink-copy/reflink-copy-0.1.30.crate",
+        "sha256": "d9dd7ab4af0363d5ccfd2838d782a28196cf32a5cc2e4fe3c5dc83f2be588b8b",
+        "dest": "cargo/vendor/reflink-copy-0.1.30"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"d9dd7ab4af0363d5ccfd2838d782a28196cf32a5cc2e4fe3c5dc83f2be588b8b\", \"files\": {}}",
+        "dest": "cargo/vendor/reflink-copy-0.1.30",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/regex/regex-1.12.4.crate",
+        "sha256": "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba",
+        "dest": "cargo/vendor/regex-1.12.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba\", \"files\": {}}",
+        "dest": "cargo/vendor/regex-1.12.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/regex-automata/regex-automata-0.4.14.crate",
+        "sha256": "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f",
+        "dest": "cargo/vendor/regex-automata-0.4.14"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f\", \"files\": {}}",
+        "dest": "cargo/vendor/regex-automata-0.4.14",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/regex-syntax/regex-syntax-0.8.11.crate",
+        "sha256": "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4",
+        "dest": "cargo/vendor/regex-syntax-0.8.11"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4\", \"files\": {}}",
+        "dest": "cargo/vendor/regex-syntax-0.8.11",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/reqwest/reqwest-0.13.4.crate",
+        "sha256": "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3",
+        "dest": "cargo/vendor/reqwest-0.13.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3\", \"files\": {}}",
+        "dest": "cargo/vendor/reqwest-0.13.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/resolv-conf/resolv-conf-0.7.6.crate",
+        "sha256": "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7",
+        "dest": "cargo/vendor/resolv-conf-0.7.6"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7\", \"files\": {}}",
+        "dest": "cargo/vendor/resolv-conf-0.7.6",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/rfd/rfd-0.16.0.crate",
+        "sha256": "a15ad77d9e70a92437d8f74c35d99b4e4691128df018833e99f90bcd36152672",
+        "dest": "cargo/vendor/rfd-0.16.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"a15ad77d9e70a92437d8f74c35d99b4e4691128df018833e99f90bcd36152672\", \"files\": {}}",
+        "dest": "cargo/vendor/rfd-0.16.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/rgb/rgb-0.8.53.crate",
+        "sha256": "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4",
+        "dest": "cargo/vendor/rgb-0.8.53"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4\", \"files\": {}}",
+        "dest": "cargo/vendor/rgb-0.8.53",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/ring/ring-0.17.14.crate",
+        "sha256": "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7",
+        "dest": "cargo/vendor/ring-0.17.14"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7\", \"files\": {}}",
+        "dest": "cargo/vendor/ring-0.17.14",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/rust-ini/rust-ini-0.21.3.crate",
+        "sha256": "796e8d2b6696392a43bea58116b667fb4c29727dc5abd27d6acf338bb4f688c7",
+        "dest": "cargo/vendor/rust-ini-0.21.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"796e8d2b6696392a43bea58116b667fb4c29727dc5abd27d6acf338bb4f688c7\", \"files\": {}}",
+        "dest": "cargo/vendor/rust-ini-0.21.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/rustc-hash/rustc-hash-2.1.3.crate",
+        "sha256": "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d",
+        "dest": "cargo/vendor/rustc-hash-2.1.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d\", \"files\": {}}",
+        "dest": "cargo/vendor/rustc-hash-2.1.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/rustc_version/rustc_version-0.4.1.crate",
+        "sha256": "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92",
+        "dest": "cargo/vendor/rustc_version-0.4.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92\", \"files\": {}}",
+        "dest": "cargo/vendor/rustc_version-0.4.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/rusticata-macros/rusticata-macros-4.1.0.crate",
+        "sha256": "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632",
+        "dest": "cargo/vendor/rusticata-macros-4.1.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632\", \"files\": {}}",
+        "dest": "cargo/vendor/rusticata-macros-4.1.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/rustix/rustix-1.1.4.crate",
+        "sha256": "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190",
+        "dest": "cargo/vendor/rustix-1.1.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190\", \"files\": {}}",
+        "dest": "cargo/vendor/rustix-1.1.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/rustls/rustls-0.23.36.crate",
+        "sha256": "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b",
+        "dest": "cargo/vendor/rustls-0.23.36"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b\", \"files\": {}}",
+        "dest": "cargo/vendor/rustls-0.23.36",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/rustls-native-certs/rustls-native-certs-0.8.4.crate",
+        "sha256": "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d",
+        "dest": "cargo/vendor/rustls-native-certs-0.8.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d\", \"files\": {}}",
+        "dest": "cargo/vendor/rustls-native-certs-0.8.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/rustls-pki-types/rustls-pki-types-1.15.0.crate",
+        "sha256": "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046",
+        "dest": "cargo/vendor/rustls-pki-types-1.15.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046\", \"files\": {}}",
+        "dest": "cargo/vendor/rustls-pki-types-1.15.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/rustls-platform-verifier/rustls-platform-verifier-0.7.0.crate",
+        "sha256": "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0",
+        "dest": "cargo/vendor/rustls-platform-verifier-0.7.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0\", \"files\": {}}",
+        "dest": "cargo/vendor/rustls-platform-verifier-0.7.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/rustls-platform-verifier-android/rustls-platform-verifier-android-0.1.1.crate",
+        "sha256": "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f",
+        "dest": "cargo/vendor/rustls-platform-verifier-android-0.1.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f\", \"files\": {}}",
+        "dest": "cargo/vendor/rustls-platform-verifier-android-0.1.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/rustls-webpki/rustls-webpki-0.103.13.crate",
+        "sha256": "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e",
+        "dest": "cargo/vendor/rustls-webpki-0.103.13"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e\", \"files\": {}}",
+        "dest": "cargo/vendor/rustls-webpki-0.103.13",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/rustversion/rustversion-1.0.23.crate",
+        "sha256": "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f",
+        "dest": "cargo/vendor/rustversion-1.0.23"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f\", \"files\": {}}",
+        "dest": "cargo/vendor/rustversion-1.0.23",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/ryu/ryu-1.0.23.crate",
+        "sha256": "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f",
+        "dest": "cargo/vendor/ryu-1.0.23"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f\", \"files\": {}}",
+        "dest": "cargo/vendor/ryu-1.0.23",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/same-file/same-file-1.0.6.crate",
+        "sha256": "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502",
+        "dest": "cargo/vendor/same-file-1.0.6"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502\", \"files\": {}}",
+        "dest": "cargo/vendor/same-file-1.0.6",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/schannel/schannel-0.1.29.crate",
+        "sha256": "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939",
+        "dest": "cargo/vendor/schannel-0.1.29"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939\", \"files\": {}}",
+        "dest": "cargo/vendor/schannel-0.1.29",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/schemars/schemars-0.8.22.crate",
+        "sha256": "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615",
+        "dest": "cargo/vendor/schemars-0.8.22"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615\", \"files\": {}}",
+        "dest": "cargo/vendor/schemars-0.8.22",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/schemars/schemars-0.9.0.crate",
+        "sha256": "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f",
+        "dest": "cargo/vendor/schemars-0.9.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f\", \"files\": {}}",
+        "dest": "cargo/vendor/schemars-0.9.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/schemars/schemars-1.2.1.crate",
+        "sha256": "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc",
+        "dest": "cargo/vendor/schemars-1.2.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc\", \"files\": {}}",
+        "dest": "cargo/vendor/schemars-1.2.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/schemars_derive/schemars_derive-0.8.22.crate",
+        "sha256": "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d",
+        "dest": "cargo/vendor/schemars_derive-0.8.22"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d\", \"files\": {}}",
+        "dest": "cargo/vendor/schemars_derive-0.8.22",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/scoped-tls/scoped-tls-1.0.1.crate",
+        "sha256": "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294",
+        "dest": "cargo/vendor/scoped-tls-1.0.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294\", \"files\": {}}",
+        "dest": "cargo/vendor/scoped-tls-1.0.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/scopeguard/scopeguard-1.2.0.crate",
+        "sha256": "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49",
+        "dest": "cargo/vendor/scopeguard-1.2.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49\", \"files\": {}}",
+        "dest": "cargo/vendor/scopeguard-1.2.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/security-framework/security-framework-3.7.0.crate",
+        "sha256": "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d",
+        "dest": "cargo/vendor/security-framework-3.7.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d\", \"files\": {}}",
+        "dest": "cargo/vendor/security-framework-3.7.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/security-framework-sys/security-framework-sys-2.17.0.crate",
+        "sha256": "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3",
+        "dest": "cargo/vendor/security-framework-sys-2.17.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3\", \"files\": {}}",
+        "dest": "cargo/vendor/security-framework-sys-2.17.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/seize/seize-0.5.1.crate",
+        "sha256": "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521",
+        "dest": "cargo/vendor/seize-0.5.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521\", \"files\": {}}",
+        "dest": "cargo/vendor/seize-0.5.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/selectors/selectors-0.24.0.crate",
+        "sha256": "0c37578180969d00692904465fb7f6b3d50b9a2b952b87c23d0e2e5cb5013416",
+        "dest": "cargo/vendor/selectors-0.24.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"0c37578180969d00692904465fb7f6b3d50b9a2b952b87c23d0e2e5cb5013416\", \"files\": {}}",
+        "dest": "cargo/vendor/selectors-0.24.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/selectors/selectors-0.36.1.crate",
+        "sha256": "c5d9c0c92a92d33f08817311cf3f2c29a3538a8240e94a6a3c622ce652d7e00c",
+        "dest": "cargo/vendor/selectors-0.36.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"c5d9c0c92a92d33f08817311cf3f2c29a3538a8240e94a6a3c622ce652d7e00c\", \"files\": {}}",
+        "dest": "cargo/vendor/selectors-0.36.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/self_cell/self_cell-1.2.2.crate",
+        "sha256": "b12e76d157a900eb52e81bc6e9f3069344290341720e9178cde2407113ac8d89",
+        "dest": "cargo/vendor/self_cell-1.2.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"b12e76d157a900eb52e81bc6e9f3069344290341720e9178cde2407113ac8d89\", \"files\": {}}",
+        "dest": "cargo/vendor/self_cell-1.2.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/semver/semver-1.0.28.crate",
+        "sha256": "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd",
+        "dest": "cargo/vendor/semver-1.0.28"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd\", \"files\": {}}",
+        "dest": "cargo/vendor/semver-1.0.28",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/send_wrapper/send_wrapper-0.6.0.crate",
+        "sha256": "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73",
+        "dest": "cargo/vendor/send_wrapper-0.6.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73\", \"files\": {}}",
+        "dest": "cargo/vendor/send_wrapper-0.6.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/serde/serde-1.0.228.crate",
+        "sha256": "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e",
+        "dest": "cargo/vendor/serde-1.0.228"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e\", \"files\": {}}",
+        "dest": "cargo/vendor/serde-1.0.228",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/serde-untagged/serde-untagged-0.1.9.crate",
+        "sha256": "f9faf48a4a2d2693be24c6289dbe26552776eb7737074e6722891fadbe6c5058",
+        "dest": "cargo/vendor/serde-untagged-0.1.9"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"f9faf48a4a2d2693be24c6289dbe26552776eb7737074e6722891fadbe6c5058\", \"files\": {}}",
+        "dest": "cargo/vendor/serde-untagged-0.1.9",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/serde_bytes/serde_bytes-0.11.19.crate",
+        "sha256": "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8",
+        "dest": "cargo/vendor/serde_bytes-0.11.19"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8\", \"files\": {}}",
+        "dest": "cargo/vendor/serde_bytes-0.11.19",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/serde_core/serde_core-1.0.228.crate",
+        "sha256": "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad",
+        "dest": "cargo/vendor/serde_core-1.0.228"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad\", \"files\": {}}",
+        "dest": "cargo/vendor/serde_core-1.0.228",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/serde_derive/serde_derive-1.0.228.crate",
+        "sha256": "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79",
+        "dest": "cargo/vendor/serde_derive-1.0.228"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79\", \"files\": {}}",
+        "dest": "cargo/vendor/serde_derive-1.0.228",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/serde_derive_internals/serde_derive_internals-0.29.1.crate",
+        "sha256": "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711",
+        "dest": "cargo/vendor/serde_derive_internals-0.29.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711\", \"files\": {}}",
+        "dest": "cargo/vendor/serde_derive_internals-0.29.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/serde_json/serde_json-1.0.150.crate",
+        "sha256": "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9",
+        "dest": "cargo/vendor/serde_json-1.0.150"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9\", \"files\": {}}",
+        "dest": "cargo/vendor/serde_json-1.0.150",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/serde_repr/serde_repr-0.1.20.crate",
+        "sha256": "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c",
+        "dest": "cargo/vendor/serde_repr-0.1.20"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c\", \"files\": {}}",
+        "dest": "cargo/vendor/serde_repr-0.1.20",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/serde_spanned/serde_spanned-0.6.9.crate",
+        "sha256": "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3",
+        "dest": "cargo/vendor/serde_spanned-0.6.9"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3\", \"files\": {}}",
+        "dest": "cargo/vendor/serde_spanned-0.6.9",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/serde_spanned/serde_spanned-1.1.1.crate",
+        "sha256": "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26",
+        "dest": "cargo/vendor/serde_spanned-1.1.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26\", \"files\": {}}",
+        "dest": "cargo/vendor/serde_spanned-1.1.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/serde_with/serde_with-3.21.0.crate",
+        "sha256": "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c",
+        "dest": "cargo/vendor/serde_with-3.21.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c\", \"files\": {}}",
+        "dest": "cargo/vendor/serde_with-3.21.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/serde_with_macros/serde_with_macros-3.21.0.crate",
+        "sha256": "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660",
+        "dest": "cargo/vendor/serde_with_macros-3.21.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660\", \"files\": {}}",
+        "dest": "cargo/vendor/serde_with_macros-3.21.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/serdect/serdect-0.4.3.crate",
+        "sha256": "66cf8fedced2fcf12406bcb34223dffb92eaf34908ede12fed414c82b7f00b3e",
+        "dest": "cargo/vendor/serdect-0.4.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"66cf8fedced2fcf12406bcb34223dffb92eaf34908ede12fed414c82b7f00b3e\", \"files\": {}}",
+        "dest": "cargo/vendor/serdect-0.4.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/serialize-to-javascript/serialize-to-javascript-0.1.2.crate",
+        "sha256": "04f3666a07a197cdb77cdf306c32be9b7f598d7060d50cfd4d5aa04bfd92f6c5",
+        "dest": "cargo/vendor/serialize-to-javascript-0.1.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"04f3666a07a197cdb77cdf306c32be9b7f598d7060d50cfd4d5aa04bfd92f6c5\", \"files\": {}}",
+        "dest": "cargo/vendor/serialize-to-javascript-0.1.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/serialize-to-javascript-impl/serialize-to-javascript-impl-0.1.2.crate",
+        "sha256": "772ee033c0916d670af7860b6e1ef7d658a4629a6d0b4c8c3e67f09b3765b75d",
+        "dest": "cargo/vendor/serialize-to-javascript-impl-0.1.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"772ee033c0916d670af7860b6e1ef7d658a4629a6d0b4c8c3e67f09b3765b75d\", \"files\": {}}",
+        "dest": "cargo/vendor/serialize-to-javascript-impl-0.1.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/servo_arc/servo_arc-0.2.0.crate",
+        "sha256": "d52aa42f8fdf0fed91e5ce7f23d8138441002fa31dca008acf47e6fd4721f741",
+        "dest": "cargo/vendor/servo_arc-0.2.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"d52aa42f8fdf0fed91e5ce7f23d8138441002fa31dca008acf47e6fd4721f741\", \"files\": {}}",
+        "dest": "cargo/vendor/servo_arc-0.2.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/servo_arc/servo_arc-0.4.3.crate",
+        "sha256": "170fb83ab34de17dc69aa7c67482b22218ddb85da56546f9bd6b929e32a05930",
+        "dest": "cargo/vendor/servo_arc-0.4.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"170fb83ab34de17dc69aa7c67482b22218ddb85da56546f9bd6b929e32a05930\", \"files\": {}}",
+        "dest": "cargo/vendor/servo_arc-0.4.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/sha1_smol/sha1_smol-1.0.1.crate",
+        "sha256": "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d",
+        "dest": "cargo/vendor/sha1_smol-1.0.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d\", \"files\": {}}",
+        "dest": "cargo/vendor/sha1_smol-1.0.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/sha2/sha2-0.10.9.crate",
+        "sha256": "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283",
+        "dest": "cargo/vendor/sha2-0.10.9"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283\", \"files\": {}}",
+        "dest": "cargo/vendor/sha2-0.10.9",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/sha2/sha2-0.11.0.crate",
+        "sha256": "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4",
+        "dest": "cargo/vendor/sha2-0.11.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4\", \"files\": {}}",
+        "dest": "cargo/vendor/sha2-0.11.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/sharded-slab/sharded-slab-0.1.7.crate",
+        "sha256": "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6",
+        "dest": "cargo/vendor/sharded-slab-0.1.7"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6\", \"files\": {}}",
+        "dest": "cargo/vendor/sharded-slab-0.1.7",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/shlex/shlex-2.0.1.crate",
+        "sha256": "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba",
+        "dest": "cargo/vendor/shlex-2.0.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba\", \"files\": {}}",
+        "dest": "cargo/vendor/shlex-2.0.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/signal-hook/signal-hook-0.3.18.crate",
+        "sha256": "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2",
+        "dest": "cargo/vendor/signal-hook-0.3.18"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2\", \"files\": {}}",
+        "dest": "cargo/vendor/signal-hook-0.3.18",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/signal-hook-mio/signal-hook-mio-0.2.5.crate",
+        "sha256": "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc",
+        "dest": "cargo/vendor/signal-hook-mio-0.2.5"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc\", \"files\": {}}",
+        "dest": "cargo/vendor/signal-hook-mio-0.2.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/signal-hook-registry/signal-hook-registry-1.4.8.crate",
+        "sha256": "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b",
+        "dest": "cargo/vendor/signal-hook-registry-1.4.8"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b\", \"files\": {}}",
+        "dest": "cargo/vendor/signal-hook-registry-1.4.8",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/signature/signature-3.0.0.crate",
+        "sha256": "28d567dcbaf0049cb8ac2608a76cd95ff9e4412e1899d389ee400918ca7537f5",
+        "dest": "cargo/vendor/signature-3.0.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"28d567dcbaf0049cb8ac2608a76cd95ff9e4412e1899d389ee400918ca7537f5\", \"files\": {}}",
+        "dest": "cargo/vendor/signature-3.0.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/simd-adler32/simd-adler32-0.3.9.crate",
+        "sha256": "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214",
+        "dest": "cargo/vendor/simd-adler32-0.3.9"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214\", \"files\": {}}",
+        "dest": "cargo/vendor/simd-adler32-0.3.9",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/simd_cesu8/simd_cesu8-1.1.1.crate",
+        "sha256": "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33",
+        "dest": "cargo/vendor/simd_cesu8-1.1.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33\", \"files\": {}}",
+        "dest": "cargo/vendor/simd_cesu8-1.1.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/simd_helpers/simd_helpers-0.1.0.crate",
+        "sha256": "95890f873bec569a0362c235787f3aca6e1e887302ba4840839bcc6459c42da6",
+        "dest": "cargo/vendor/simd_helpers-0.1.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"95890f873bec569a0362c235787f3aca6e1e887302ba4840839bcc6459c42da6\", \"files\": {}}",
+        "dest": "cargo/vendor/simd_helpers-0.1.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/simdutf8/simdutf8-0.1.5.crate",
+        "sha256": "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e",
+        "dest": "cargo/vendor/simdutf8-0.1.5"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e\", \"files\": {}}",
+        "dest": "cargo/vendor/simdutf8-0.1.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/simple-dns/simple-dns-0.11.3.crate",
+        "sha256": "7a75cbde1bf934313596a004973e462f9a82caa814dcf1a5f507bdf51597eeb4",
+        "dest": "cargo/vendor/simple-dns-0.11.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"7a75cbde1bf934313596a004973e462f9a82caa814dcf1a5f507bdf51597eeb4\", \"files\": {}}",
+        "dest": "cargo/vendor/simple-dns-0.11.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/siphasher/siphasher-0.3.11.crate",
+        "sha256": "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d",
+        "dest": "cargo/vendor/siphasher-0.3.11"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d\", \"files\": {}}",
+        "dest": "cargo/vendor/siphasher-0.3.11",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/siphasher/siphasher-1.0.3.crate",
+        "sha256": "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649",
+        "dest": "cargo/vendor/siphasher-1.0.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649\", \"files\": {}}",
+        "dest": "cargo/vendor/siphasher-1.0.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/slab/slab-0.4.12.crate",
+        "sha256": "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5",
+        "dest": "cargo/vendor/slab-0.4.12"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5\", \"files\": {}}",
+        "dest": "cargo/vendor/slab-0.4.12",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/smallvec/smallvec-1.15.2.crate",
+        "sha256": "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90",
+        "dest": "cargo/vendor/smallvec-1.15.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90\", \"files\": {}}",
+        "dest": "cargo/vendor/smallvec-1.15.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/socket2/socket2-0.6.4.crate",
+        "sha256": "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51",
+        "dest": "cargo/vendor/socket2-0.6.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51\", \"files\": {}}",
+        "dest": "cargo/vendor/socket2-0.6.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/softbuffer/softbuffer-0.4.8.crate",
+        "sha256": "aac18da81ebbf05109ab275b157c22a653bb3c12cf884450179942f81bcbf6c3",
+        "dest": "cargo/vendor/softbuffer-0.4.8"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"aac18da81ebbf05109ab275b157c22a653bb3c12cf884450179942f81bcbf6c3\", \"files\": {}}",
+        "dest": "cargo/vendor/softbuffer-0.4.8",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/sorted-index-buffer/sorted-index-buffer-0.2.1.crate",
+        "sha256": "ea06cc588e43c632923a55450401b8f25e628131571d4e1baea1bdfdb2b5ed06",
+        "dest": "cargo/vendor/sorted-index-buffer-0.2.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"ea06cc588e43c632923a55450401b8f25e628131571d4e1baea1bdfdb2b5ed06\", \"files\": {}}",
+        "dest": "cargo/vendor/sorted-index-buffer-0.2.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/soup3/soup3-0.5.0.crate",
+        "sha256": "471f924a40f31251afc77450e781cb26d55c0b650842efafc9c6cbd2f7cc4f9f",
+        "dest": "cargo/vendor/soup3-0.5.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"471f924a40f31251afc77450e781cb26d55c0b650842efafc9c6cbd2f7cc4f9f\", \"files\": {}}",
+        "dest": "cargo/vendor/soup3-0.5.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/soup3-sys/soup3-sys-0.5.0.crate",
+        "sha256": "7ebe8950a680a12f24f15ebe1bf70db7af98ad242d9db43596ad3108aab86c27",
+        "dest": "cargo/vendor/soup3-sys-0.5.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"7ebe8950a680a12f24f15ebe1bf70db7af98ad242d9db43596ad3108aab86c27\", \"files\": {}}",
+        "dest": "cargo/vendor/soup3-sys-0.5.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/spez/spez-0.1.2.crate",
+        "sha256": "c87e960f4dca2788eeb86bbdde8dd246be8948790b7618d656e68f9b720a86e8",
+        "dest": "cargo/vendor/spez-0.1.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"c87e960f4dca2788eeb86bbdde8dd246be8948790b7618d656e68f9b720a86e8\", \"files\": {}}",
+        "dest": "cargo/vendor/spez-0.1.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/spin/spin-0.9.8.crate",
+        "sha256": "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67",
+        "dest": "cargo/vendor/spin-0.9.8"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67\", \"files\": {}}",
+        "dest": "cargo/vendor/spin-0.9.8",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/spin/spin-0.10.0.crate",
+        "sha256": "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591",
+        "dest": "cargo/vendor/spin-0.10.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591\", \"files\": {}}",
+        "dest": "cargo/vendor/spin-0.10.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/spki/spki-0.8.0.crate",
+        "sha256": "1d9efca8738c78ee9484207732f728b1ef517bbb1833d6fc0879ca898a522f6f",
+        "dest": "cargo/vendor/spki-0.8.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"1d9efca8738c78ee9484207732f728b1ef517bbb1833d6fc0879ca898a522f6f\", \"files\": {}}",
+        "dest": "cargo/vendor/spki-0.8.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/stable_deref_trait/stable_deref_trait-1.2.1.crate",
+        "sha256": "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596",
+        "dest": "cargo/vendor/stable_deref_trait-1.2.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596\", \"files\": {}}",
+        "dest": "cargo/vendor/stable_deref_trait-1.2.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/string_cache/string_cache-0.8.9.crate",
+        "sha256": "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f",
+        "dest": "cargo/vendor/string_cache-0.8.9"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f\", \"files\": {}}",
+        "dest": "cargo/vendor/string_cache-0.8.9",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/string_cache/string_cache-0.9.0.crate",
+        "sha256": "a18596f8c785a729f2819c0f6a7eae6ebeebdfffbfe4214ae6b087f690e31901",
+        "dest": "cargo/vendor/string_cache-0.9.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"a18596f8c785a729f2819c0f6a7eae6ebeebdfffbfe4214ae6b087f690e31901\", \"files\": {}}",
+        "dest": "cargo/vendor/string_cache-0.9.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/string_cache_codegen/string_cache_codegen-0.5.4.crate",
+        "sha256": "c711928715f1fe0fe509c53b43e993a9a557babc2d0a3567d0a3006f1ac931a0",
+        "dest": "cargo/vendor/string_cache_codegen-0.5.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"c711928715f1fe0fe509c53b43e993a9a557babc2d0a3567d0a3006f1ac931a0\", \"files\": {}}",
+        "dest": "cargo/vendor/string_cache_codegen-0.5.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/string_cache_codegen/string_cache_codegen-0.6.1.crate",
+        "sha256": "585635e46db231059f76c5849798146164652513eb9e8ab2685939dd90f29b69",
+        "dest": "cargo/vendor/string_cache_codegen-0.6.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"585635e46db231059f76c5849798146164652513eb9e8ab2685939dd90f29b69\", \"files\": {}}",
+        "dest": "cargo/vendor/string_cache_codegen-0.6.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/strsim/strsim-0.11.1.crate",
+        "sha256": "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f",
+        "dest": "cargo/vendor/strsim-0.11.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f\", \"files\": {}}",
+        "dest": "cargo/vendor/strsim-0.11.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/strum/strum-0.28.0.crate",
+        "sha256": "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd",
+        "dest": "cargo/vendor/strum-0.28.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd\", \"files\": {}}",
+        "dest": "cargo/vendor/strum-0.28.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/strum_macros/strum_macros-0.28.0.crate",
+        "sha256": "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664",
+        "dest": "cargo/vendor/strum_macros-0.28.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664\", \"files\": {}}",
+        "dest": "cargo/vendor/strum_macros-0.28.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/subtle/subtle-2.6.1.crate",
+        "sha256": "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292",
+        "dest": "cargo/vendor/subtle-2.6.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292\", \"files\": {}}",
+        "dest": "cargo/vendor/subtle-2.6.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/swift-rs/swift-rs-1.0.7.crate",
+        "sha256": "4057c98e2e852d51fdcfca832aac7b571f6b351ad159f9eda5db1655f8d0c4d7",
+        "dest": "cargo/vendor/swift-rs-1.0.7"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"4057c98e2e852d51fdcfca832aac7b571f6b351ad159f9eda5db1655f8d0c4d7\", \"files\": {}}",
+        "dest": "cargo/vendor/swift-rs-1.0.7",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/symlink/symlink-0.1.0.crate",
+        "sha256": "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a",
+        "dest": "cargo/vendor/symlink-0.1.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a\", \"files\": {}}",
+        "dest": "cargo/vendor/symlink-0.1.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/syn/syn-1.0.109.crate",
+        "sha256": "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237",
+        "dest": "cargo/vendor/syn-1.0.109"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237\", \"files\": {}}",
+        "dest": "cargo/vendor/syn-1.0.109",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/syn/syn-2.0.118.crate",
+        "sha256": "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422",
+        "dest": "cargo/vendor/syn-2.0.118"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422\", \"files\": {}}",
+        "dest": "cargo/vendor/syn-2.0.118",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/syn-mid/syn-mid-0.5.4.crate",
+        "sha256": "fea305d57546cc8cd04feb14b62ec84bf17f50e3f7b12560d7bfa9265f39d9ed",
+        "dest": "cargo/vendor/syn-mid-0.5.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"fea305d57546cc8cd04feb14b62ec84bf17f50e3f7b12560d7bfa9265f39d9ed\", \"files\": {}}",
+        "dest": "cargo/vendor/syn-mid-0.5.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/sync_wrapper/sync_wrapper-1.0.2.crate",
+        "sha256": "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263",
+        "dest": "cargo/vendor/sync_wrapper-1.0.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263\", \"files\": {}}",
+        "dest": "cargo/vendor/sync_wrapper-1.0.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/synstructure/synstructure-0.13.2.crate",
+        "sha256": "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2",
+        "dest": "cargo/vendor/synstructure-0.13.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2\", \"files\": {}}",
+        "dest": "cargo/vendor/synstructure-0.13.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/sys-locale/sys-locale-0.3.2.crate",
+        "sha256": "8eab9a99a024a169fe8a903cf9d4a3b3601109bcc13bd9e3c6fff259138626c4",
+        "dest": "cargo/vendor/sys-locale-0.3.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"8eab9a99a024a169fe8a903cf9d4a3b3601109bcc13bd9e3c6fff259138626c4\", \"files\": {}}",
+        "dest": "cargo/vendor/sys-locale-0.3.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/system-configuration/system-configuration-0.7.0.crate",
+        "sha256": "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b",
+        "dest": "cargo/vendor/system-configuration-0.7.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b\", \"files\": {}}",
+        "dest": "cargo/vendor/system-configuration-0.7.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/system-configuration-sys/system-configuration-sys-0.6.0.crate",
+        "sha256": "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4",
+        "dest": "cargo/vendor/system-configuration-sys-0.6.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4\", \"files\": {}}",
+        "dest": "cargo/vendor/system-configuration-sys-0.6.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/system-deps/system-deps-6.2.2.crate",
+        "sha256": "a3e535eb8dded36d55ec13eddacd30dec501792ff23a0b1682c38601b8cf2349",
+        "dest": "cargo/vendor/system-deps-6.2.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"a3e535eb8dded36d55ec13eddacd30dec501792ff23a0b1682c38601b8cf2349\", \"files\": {}}",
+        "dest": "cargo/vendor/system-deps-6.2.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/system-deps/system-deps-7.0.8.crate",
+        "sha256": "396a35feb67335377e0251fcbc1092fc85c484bd4e3a7a54319399da127796e7",
+        "dest": "cargo/vendor/system-deps-7.0.8"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"396a35feb67335377e0251fcbc1092fc85c484bd4e3a7a54319399da127796e7\", \"files\": {}}",
+        "dest": "cargo/vendor/system-deps-7.0.8",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/tagptr/tagptr-0.2.0.crate",
+        "sha256": "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417",
+        "dest": "cargo/vendor/tagptr-0.2.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417\", \"files\": {}}",
+        "dest": "cargo/vendor/tagptr-0.2.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/tao/tao-0.34.8.crate",
+        "sha256": "9103edf55f2da3c82aea4c7fab7c4241032bfeea0e71fa557d98e00e7ce7cc20",
+        "dest": "cargo/vendor/tao-0.34.8"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"9103edf55f2da3c82aea4c7fab7c4241032bfeea0e71fa557d98e00e7ce7cc20\", \"files\": {}}",
+        "dest": "cargo/vendor/tao-0.34.8",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/tao-macros/tao-macros-0.1.3.crate",
+        "sha256": "f4e16beb8b2ac17db28eab8bca40e62dbfbb34c0fcdc6d9826b11b7b5d047dfd",
+        "dest": "cargo/vendor/tao-macros-0.1.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"f4e16beb8b2ac17db28eab8bca40e62dbfbb34c0fcdc6d9826b11b7b5d047dfd\", \"files\": {}}",
+        "dest": "cargo/vendor/tao-macros-0.1.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/tar/tar-0.4.46.crate",
+        "sha256": "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840",
+        "dest": "cargo/vendor/tar-0.4.46"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840\", \"files\": {}}",
+        "dest": "cargo/vendor/tar-0.4.46",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/target-lexicon/target-lexicon-0.12.16.crate",
+        "sha256": "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1",
+        "dest": "cargo/vendor/target-lexicon-0.12.16"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1\", \"files\": {}}",
+        "dest": "cargo/vendor/target-lexicon-0.12.16",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/target-lexicon/target-lexicon-0.13.5.crate",
+        "sha256": "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca",
+        "dest": "cargo/vendor/target-lexicon-0.13.5"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca\", \"files\": {}}",
+        "dest": "cargo/vendor/target-lexicon-0.13.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/tauri/tauri-2.10.1.crate",
+        "sha256": "1025aa560c1eaa14ef96de5540cbe13ed6be1933ebe4398338c96bc370b807c6",
+        "dest": "cargo/vendor/tauri-2.10.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"1025aa560c1eaa14ef96de5540cbe13ed6be1933ebe4398338c96bc370b807c6\", \"files\": {}}",
+        "dest": "cargo/vendor/tauri-2.10.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/tauri-build/tauri-build-2.6.3.crate",
+        "sha256": "bc9ce40b16101cb6ea63d3e221567affd1c3a9205f95d7bc574941a10636b632",
+        "dest": "cargo/vendor/tauri-build-2.6.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"bc9ce40b16101cb6ea63d3e221567affd1c3a9205f95d7bc574941a10636b632\", \"files\": {}}",
+        "dest": "cargo/vendor/tauri-build-2.6.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/tauri-codegen/tauri-codegen-2.6.3.crate",
+        "sha256": "08279169ff42f8fc45a1dbc9dcae888893ba95288142e5880c59b93a26d2cfc5",
+        "dest": "cargo/vendor/tauri-codegen-2.6.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"08279169ff42f8fc45a1dbc9dcae888893ba95288142e5880c59b93a26d2cfc5\", \"files\": {}}",
+        "dest": "cargo/vendor/tauri-codegen-2.6.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/tauri-macros/tauri-macros-2.6.3.crate",
+        "sha256": "e8b394794f399a421811d06966343e7933fcae92d59f5180b9388d1174497a45",
+        "dest": "cargo/vendor/tauri-macros-2.6.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"e8b394794f399a421811d06966343e7933fcae92d59f5180b9388d1174497a45\", \"files\": {}}",
+        "dest": "cargo/vendor/tauri-macros-2.6.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/tauri-plugin/tauri-plugin-2.6.3.crate",
+        "sha256": "74be5dd4bed9afbd145e5716b5fa2ec28cbc29c34ffa61c258c9273d896c8020",
+        "dest": "cargo/vendor/tauri-plugin-2.6.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"74be5dd4bed9afbd145e5716b5fa2ec28cbc29c34ffa61c258c9273d896c8020\", \"files\": {}}",
+        "dest": "cargo/vendor/tauri-plugin-2.6.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/tauri-plugin-deep-link/tauri-plugin-deep-link-2.4.9.crate",
+        "sha256": "70ee75bc5627f77bfdf40c913255ebc258117b10ebe2b2239a1a1cf40b0b58aa",
+        "dest": "cargo/vendor/tauri-plugin-deep-link-2.4.9"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"70ee75bc5627f77bfdf40c913255ebc258117b10ebe2b2239a1a1cf40b0b58aa\", \"files\": {}}",
+        "dest": "cargo/vendor/tauri-plugin-deep-link-2.4.9",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/tauri-plugin-dialog/tauri-plugin-dialog-2.7.1.crate",
+        "sha256": "65981abb771e74e571a38196c3baa11c459379164791eba0e67abc1a5fac9884",
+        "dest": "cargo/vendor/tauri-plugin-dialog-2.7.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"65981abb771e74e571a38196c3baa11c459379164791eba0e67abc1a5fac9884\", \"files\": {}}",
+        "dest": "cargo/vendor/tauri-plugin-dialog-2.7.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/tauri-plugin-fs/tauri-plugin-fs-2.5.1.crate",
+        "sha256": "b7ecc274121aca0c036a2b42d1cbe83d368d348f54e0bb8a735c2b1548e8f371",
+        "dest": "cargo/vendor/tauri-plugin-fs-2.5.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"b7ecc274121aca0c036a2b42d1cbe83d368d348f54e0bb8a735c2b1548e8f371\", \"files\": {}}",
+        "dest": "cargo/vendor/tauri-plugin-fs-2.5.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/tauri-plugin-notification/tauri-plugin-notification-2.3.3.crate",
+        "sha256": "01fc2c5ff41105bd1f7242d8201fdf3efd70749b82fa013a17f2126357d194cc",
+        "dest": "cargo/vendor/tauri-plugin-notification-2.3.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"01fc2c5ff41105bd1f7242d8201fdf3efd70749b82fa013a17f2126357d194cc\", \"files\": {}}",
+        "dest": "cargo/vendor/tauri-plugin-notification-2.3.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/tauri-plugin-opener/tauri-plugin-opener-2.5.4.crate",
+        "sha256": "17e1bea14edce6b793a04e2417e3fd924b9bc4faae83cdee7d714156cceeed29",
+        "dest": "cargo/vendor/tauri-plugin-opener-2.5.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"17e1bea14edce6b793a04e2417e3fd924b9bc4faae83cdee7d714156cceeed29\", \"files\": {}}",
+        "dest": "cargo/vendor/tauri-plugin-opener-2.5.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/tauri-plugin-os/tauri-plugin-os-2.3.2.crate",
+        "sha256": "d8f08346c8deb39e96f86973da0e2d76cbb933d7ac9b750f6dc4daf955a6f997",
+        "dest": "cargo/vendor/tauri-plugin-os-2.3.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"d8f08346c8deb39e96f86973da0e2d76cbb933d7ac9b750f6dc4daf955a6f997\", \"files\": {}}",
+        "dest": "cargo/vendor/tauri-plugin-os-2.3.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/tauri-plugin-single-instance/tauri-plugin-single-instance-2.4.2.crate",
+        "sha256": "5c8f29386f5e9fdc699182388a33ee80a56de436d91b67459e86afef426282af",
+        "dest": "cargo/vendor/tauri-plugin-single-instance-2.4.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"5c8f29386f5e9fdc699182388a33ee80a56de436d91b67459e86afef426282af\", \"files\": {}}",
+        "dest": "cargo/vendor/tauri-plugin-single-instance-2.4.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/tauri-plugin-store/tauri-plugin-store-2.4.3.crate",
+        "sha256": "6c72dda16786eb4a3f903e43a17b64d8d78dc0f00fe2aa4b757c28f617a8630b",
+        "dest": "cargo/vendor/tauri-plugin-store-2.4.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"6c72dda16786eb4a3f903e43a17b64d8d78dc0f00fe2aa4b757c28f617a8630b\", \"files\": {}}",
+        "dest": "cargo/vendor/tauri-plugin-store-2.4.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/tauri-plugin-updater/tauri-plugin-updater-2.10.1.crate",
+        "sha256": "806d9dac662c2e4594ff03c647a552f2c9bd544e7d0f683ec58f872f952ce4af",
+        "dest": "cargo/vendor/tauri-plugin-updater-2.10.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"806d9dac662c2e4594ff03c647a552f2c9bd544e7d0f683ec58f872f952ce4af\", \"files\": {}}",
+        "dest": "cargo/vendor/tauri-plugin-updater-2.10.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/tauri-runtime/tauri-runtime-2.10.1.crate",
+        "sha256": "2826d79a3297ed08cd6ea7f412644ef58e32969504bc4fbd8d7dbeabc4445ea2",
+        "dest": "cargo/vendor/tauri-runtime-2.10.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"2826d79a3297ed08cd6ea7f412644ef58e32969504bc4fbd8d7dbeabc4445ea2\", \"files\": {}}",
+        "dest": "cargo/vendor/tauri-runtime-2.10.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/tauri-runtime-wry/tauri-runtime-wry-2.10.1.crate",
+        "sha256": "e11ea2e6f801d275fdd890d6c9603736012742a1c33b96d0db788c9cdebf7f9e",
+        "dest": "cargo/vendor/tauri-runtime-wry-2.10.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"e11ea2e6f801d275fdd890d6c9603736012742a1c33b96d0db788c9cdebf7f9e\", \"files\": {}}",
+        "dest": "cargo/vendor/tauri-runtime-wry-2.10.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/tauri-utils/tauri-utils-2.9.3.crate",
+        "sha256": "3e176a18e67764923c4f1ce66f25ae4abe5f688384d5eb1a0fa6c77f3d90f887",
+        "dest": "cargo/vendor/tauri-utils-2.9.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"3e176a18e67764923c4f1ce66f25ae4abe5f688384d5eb1a0fa6c77f3d90f887\", \"files\": {}}",
+        "dest": "cargo/vendor/tauri-utils-2.9.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/tauri-winres/tauri-winres-0.3.6.crate",
+        "sha256": "cc65d45c68858bfe420dd29e834b5d15dbecf8a07a8a16cf4d532c7b1f69d4b6",
+        "dest": "cargo/vendor/tauri-winres-0.3.6"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"cc65d45c68858bfe420dd29e834b5d15dbecf8a07a8a16cf4d532c7b1f69d4b6\", \"files\": {}}",
+        "dest": "cargo/vendor/tauri-winres-0.3.6",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/tauri-winrt-notification/tauri-winrt-notification-0.7.3.crate",
+        "sha256": "9ed071c670382e85fc2f48ae706492d8c338f4f89bf72520d32f8abfe880aade",
+        "dest": "cargo/vendor/tauri-winrt-notification-0.7.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"9ed071c670382e85fc2f48ae706492d8c338f4f89bf72520d32f8abfe880aade\", \"files\": {}}",
+        "dest": "cargo/vendor/tauri-winrt-notification-0.7.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/tempfile/tempfile-3.27.0.crate",
+        "sha256": "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd",
+        "dest": "cargo/vendor/tempfile-3.27.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd\", \"files\": {}}",
+        "dest": "cargo/vendor/tempfile-3.27.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/tendril/tendril-0.4.3.crate",
+        "sha256": "d24a120c5fc464a3458240ee02c299ebcb9d67b5249c8848b09d639dca8d7bb0",
+        "dest": "cargo/vendor/tendril-0.4.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"d24a120c5fc464a3458240ee02c299ebcb9d67b5249c8848b09d639dca8d7bb0\", \"files\": {}}",
+        "dest": "cargo/vendor/tendril-0.4.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/tendril/tendril-0.5.1.crate",
+        "sha256": "5fed54709c5b3a53d09bb1c113ea4f5ceafd1e772ddcb0030a82e1d56c087b08",
+        "dest": "cargo/vendor/tendril-0.5.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"5fed54709c5b3a53d09bb1c113ea4f5ceafd1e772ddcb0030a82e1d56c087b08\", \"files\": {}}",
+        "dest": "cargo/vendor/tendril-0.5.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/thiserror/thiserror-1.0.69.crate",
+        "sha256": "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52",
+        "dest": "cargo/vendor/thiserror-1.0.69"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52\", \"files\": {}}",
+        "dest": "cargo/vendor/thiserror-1.0.69",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/thiserror/thiserror-2.0.18.crate",
+        "sha256": "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4",
+        "dest": "cargo/vendor/thiserror-2.0.18"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4\", \"files\": {}}",
+        "dest": "cargo/vendor/thiserror-2.0.18",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/thiserror-impl/thiserror-impl-1.0.69.crate",
+        "sha256": "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1",
+        "dest": "cargo/vendor/thiserror-impl-1.0.69"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1\", \"files\": {}}",
+        "dest": "cargo/vendor/thiserror-impl-1.0.69",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/thiserror-impl/thiserror-impl-2.0.18.crate",
+        "sha256": "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5",
+        "dest": "cargo/vendor/thiserror-impl-2.0.18"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5\", \"files\": {}}",
+        "dest": "cargo/vendor/thiserror-impl-2.0.18",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/thread_local/thread_local-1.1.9.crate",
+        "sha256": "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185",
+        "dest": "cargo/vendor/thread_local-1.1.9"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185\", \"files\": {}}",
+        "dest": "cargo/vendor/thread_local-1.1.9",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/tiff/tiff-0.11.3.crate",
+        "sha256": "b63feaf3343d35b6ca4d50483f94843803b0f51634937cc2ec519fc32232bc52",
+        "dest": "cargo/vendor/tiff-0.11.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"b63feaf3343d35b6ca4d50483f94843803b0f51634937cc2ec519fc32232bc52\", \"files\": {}}",
+        "dest": "cargo/vendor/tiff-0.11.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/time/time-0.3.53.crate",
+        "sha256": "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50",
+        "dest": "cargo/vendor/time-0.3.53"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50\", \"files\": {}}",
+        "dest": "cargo/vendor/time-0.3.53",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/time-core/time-core-0.1.9.crate",
+        "sha256": "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109",
+        "dest": "cargo/vendor/time-core-0.1.9"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109\", \"files\": {}}",
+        "dest": "cargo/vendor/time-core-0.1.9",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/time-macros/time-macros-0.2.31.crate",
+        "sha256": "c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f",
+        "dest": "cargo/vendor/time-macros-0.2.31"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f\", \"files\": {}}",
+        "dest": "cargo/vendor/time-macros-0.2.31",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/tiny-keccak/tiny-keccak-2.0.2.crate",
+        "sha256": "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237",
+        "dest": "cargo/vendor/tiny-keccak-2.0.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237\", \"files\": {}}",
+        "dest": "cargo/vendor/tiny-keccak-2.0.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/tinystr/tinystr-0.8.3.crate",
+        "sha256": "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d",
+        "dest": "cargo/vendor/tinystr-0.8.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d\", \"files\": {}}",
+        "dest": "cargo/vendor/tinystr-0.8.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/tinyvec/tinyvec-1.11.0.crate",
+        "sha256": "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3",
+        "dest": "cargo/vendor/tinyvec-1.11.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3\", \"files\": {}}",
+        "dest": "cargo/vendor/tinyvec-1.11.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/tinyvec_macros/tinyvec_macros-0.1.1.crate",
+        "sha256": "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20",
+        "dest": "cargo/vendor/tinyvec_macros-0.1.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20\", \"files\": {}}",
+        "dest": "cargo/vendor/tinyvec_macros-0.1.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/tokio/tokio-1.52.3.crate",
+        "sha256": "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe",
+        "dest": "cargo/vendor/tokio-1.52.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe\", \"files\": {}}",
+        "dest": "cargo/vendor/tokio-1.52.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/tokio-macros/tokio-macros-2.7.0.crate",
+        "sha256": "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496",
+        "dest": "cargo/vendor/tokio-macros-2.7.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496\", \"files\": {}}",
+        "dest": "cargo/vendor/tokio-macros-2.7.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/tokio-rustls/tokio-rustls-0.26.4.crate",
+        "sha256": "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61",
+        "dest": "cargo/vendor/tokio-rustls-0.26.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61\", \"files\": {}}",
+        "dest": "cargo/vendor/tokio-rustls-0.26.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/tokio-stream/tokio-stream-0.1.18.crate",
+        "sha256": "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70",
+        "dest": "cargo/vendor/tokio-stream-0.1.18"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70\", \"files\": {}}",
+        "dest": "cargo/vendor/tokio-stream-0.1.18",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/tokio-util/tokio-util-0.7.18.crate",
+        "sha256": "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098",
+        "dest": "cargo/vendor/tokio-util-0.7.18"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098\", \"files\": {}}",
+        "dest": "cargo/vendor/tokio-util-0.7.18",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/tokio-websockets/tokio-websockets-0.13.3.crate",
+        "sha256": "d52efb639344a7c6adb8e62c6f3d2c19c001ff1b79a5041ba1c6ed42e19c6aa5",
+        "dest": "cargo/vendor/tokio-websockets-0.13.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"d52efb639344a7c6adb8e62c6f3d2c19c001ff1b79a5041ba1c6ed42e19c6aa5\", \"files\": {}}",
+        "dest": "cargo/vendor/tokio-websockets-0.13.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/toml/toml-0.8.2.crate",
+        "sha256": "185d8ab0dfbb35cf1399a6344d8484209c088f75f8f68230da55d48d95d43e3d",
+        "dest": "cargo/vendor/toml-0.8.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"185d8ab0dfbb35cf1399a6344d8484209c088f75f8f68230da55d48d95d43e3d\", \"files\": {}}",
+        "dest": "cargo/vendor/toml-0.8.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/toml/toml-0.9.12+spec-1.1.0.crate",
+        "sha256": "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863",
+        "dest": "cargo/vendor/toml-0.9.12+spec-1.1.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863\", \"files\": {}}",
+        "dest": "cargo/vendor/toml-0.9.12+spec-1.1.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/toml/toml-1.1.2+spec-1.1.0.crate",
+        "sha256": "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee",
+        "dest": "cargo/vendor/toml-1.1.2+spec-1.1.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee\", \"files\": {}}",
+        "dest": "cargo/vendor/toml-1.1.2+spec-1.1.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/toml_datetime/toml_datetime-0.6.3.crate",
+        "sha256": "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b",
+        "dest": "cargo/vendor/toml_datetime-0.6.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b\", \"files\": {}}",
+        "dest": "cargo/vendor/toml_datetime-0.6.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/toml_datetime/toml_datetime-0.7.5+spec-1.1.0.crate",
+        "sha256": "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347",
+        "dest": "cargo/vendor/toml_datetime-0.7.5+spec-1.1.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347\", \"files\": {}}",
+        "dest": "cargo/vendor/toml_datetime-0.7.5+spec-1.1.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/toml_datetime/toml_datetime-1.1.1+spec-1.1.0.crate",
+        "sha256": "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7",
+        "dest": "cargo/vendor/toml_datetime-1.1.1+spec-1.1.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7\", \"files\": {}}",
+        "dest": "cargo/vendor/toml_datetime-1.1.1+spec-1.1.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/toml_edit/toml_edit-0.19.15.crate",
+        "sha256": "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421",
+        "dest": "cargo/vendor/toml_edit-0.19.15"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421\", \"files\": {}}",
+        "dest": "cargo/vendor/toml_edit-0.19.15",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/toml_edit/toml_edit-0.20.2.crate",
+        "sha256": "396e4d48bbb2b7554c944bde63101b5ae446cff6ec4a24227428f15eb72ef338",
+        "dest": "cargo/vendor/toml_edit-0.20.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"396e4d48bbb2b7554c944bde63101b5ae446cff6ec4a24227428f15eb72ef338\", \"files\": {}}",
+        "dest": "cargo/vendor/toml_edit-0.20.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/toml_edit/toml_edit-0.25.12+spec-1.1.0.crate",
+        "sha256": "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7",
+        "dest": "cargo/vendor/toml_edit-0.25.12+spec-1.1.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7\", \"files\": {}}",
+        "dest": "cargo/vendor/toml_edit-0.25.12+spec-1.1.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/toml_parser/toml_parser-1.1.2+spec-1.1.0.crate",
+        "sha256": "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526",
+        "dest": "cargo/vendor/toml_parser-1.1.2+spec-1.1.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526\", \"files\": {}}",
+        "dest": "cargo/vendor/toml_parser-1.1.2+spec-1.1.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/toml_writer/toml_writer-1.1.1+spec-1.1.0.crate",
+        "sha256": "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db",
+        "dest": "cargo/vendor/toml_writer-1.1.1+spec-1.1.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db\", \"files\": {}}",
+        "dest": "cargo/vendor/toml_writer-1.1.1+spec-1.1.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/tower/tower-0.5.3.crate",
+        "sha256": "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4",
+        "dest": "cargo/vendor/tower-0.5.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4\", \"files\": {}}",
+        "dest": "cargo/vendor/tower-0.5.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/tower-http/tower-http-0.6.11.crate",
+        "sha256": "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840",
+        "dest": "cargo/vendor/tower-http-0.6.11"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840\", \"files\": {}}",
+        "dest": "cargo/vendor/tower-http-0.6.11",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/tower-layer/tower-layer-0.3.3.crate",
+        "sha256": "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e",
+        "dest": "cargo/vendor/tower-layer-0.3.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e\", \"files\": {}}",
+        "dest": "cargo/vendor/tower-layer-0.3.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/tower-service/tower-service-0.3.3.crate",
+        "sha256": "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3",
+        "dest": "cargo/vendor/tower-service-0.3.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3\", \"files\": {}}",
+        "dest": "cargo/vendor/tower-service-0.3.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/tracing/tracing-0.1.44.crate",
+        "sha256": "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100",
+        "dest": "cargo/vendor/tracing-0.1.44"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100\", \"files\": {}}",
+        "dest": "cargo/vendor/tracing-0.1.44",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/tracing-appender/tracing-appender-0.2.5.crate",
+        "sha256": "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c",
+        "dest": "cargo/vendor/tracing-appender-0.2.5"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c\", \"files\": {}}",
+        "dest": "cargo/vendor/tracing-appender-0.2.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/tracing-attributes/tracing-attributes-0.1.31.crate",
+        "sha256": "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da",
+        "dest": "cargo/vendor/tracing-attributes-0.1.31"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da\", \"files\": {}}",
+        "dest": "cargo/vendor/tracing-attributes-0.1.31",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/tracing-core/tracing-core-0.1.36.crate",
+        "sha256": "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a",
+        "dest": "cargo/vendor/tracing-core-0.1.36"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a\", \"files\": {}}",
+        "dest": "cargo/vendor/tracing-core-0.1.36",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/tracing-log/tracing-log-0.2.0.crate",
+        "sha256": "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3",
+        "dest": "cargo/vendor/tracing-log-0.2.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3\", \"files\": {}}",
+        "dest": "cargo/vendor/tracing-log-0.2.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/tracing-subscriber/tracing-subscriber-0.3.23.crate",
+        "sha256": "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319",
+        "dest": "cargo/vendor/tracing-subscriber-0.3.23"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319\", \"files\": {}}",
+        "dest": "cargo/vendor/tracing-subscriber-0.3.23",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/tray-icon/tray-icon-0.21.3.crate",
+        "sha256": "a5e85aa143ceb072062fc4d6356c1b520a51d636e7bc8e77ec94be3608e5e80c",
+        "dest": "cargo/vendor/tray-icon-0.21.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"a5e85aa143ceb072062fc4d6356c1b520a51d636e7bc8e77ec94be3608e5e80c\", \"files\": {}}",
+        "dest": "cargo/vendor/tray-icon-0.21.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/try-lock/try-lock-0.2.5.crate",
+        "sha256": "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b",
+        "dest": "cargo/vendor/try-lock-0.2.5"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b\", \"files\": {}}",
+        "dest": "cargo/vendor/try-lock-0.2.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/typeid/typeid-1.0.3.crate",
+        "sha256": "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c",
+        "dest": "cargo/vendor/typeid-1.0.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c\", \"files\": {}}",
+        "dest": "cargo/vendor/typeid-1.0.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/typenum/typenum-1.20.1.crate",
+        "sha256": "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20",
+        "dest": "cargo/vendor/typenum-1.20.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20\", \"files\": {}}",
+        "dest": "cargo/vendor/typenum-1.20.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/uds_windows/uds_windows-1.2.1.crate",
+        "sha256": "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e",
+        "dest": "cargo/vendor/uds_windows-1.2.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e\", \"files\": {}}",
+        "dest": "cargo/vendor/uds_windows-1.2.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/unic-char-property/unic-char-property-0.9.0.crate",
+        "sha256": "a8c57a407d9b6fa02b4795eb81c5b6652060a15a7903ea981f3d723e6c0be221",
+        "dest": "cargo/vendor/unic-char-property-0.9.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"a8c57a407d9b6fa02b4795eb81c5b6652060a15a7903ea981f3d723e6c0be221\", \"files\": {}}",
+        "dest": "cargo/vendor/unic-char-property-0.9.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/unic-char-range/unic-char-range-0.9.0.crate",
+        "sha256": "0398022d5f700414f6b899e10b8348231abf9173fa93144cbc1a43b9793c1fbc",
+        "dest": "cargo/vendor/unic-char-range-0.9.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"0398022d5f700414f6b899e10b8348231abf9173fa93144cbc1a43b9793c1fbc\", \"files\": {}}",
+        "dest": "cargo/vendor/unic-char-range-0.9.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/unic-common/unic-common-0.9.0.crate",
+        "sha256": "80d7ff825a6a654ee85a63e80f92f054f904f21e7d12da4e22f9834a4aaa35bc",
+        "dest": "cargo/vendor/unic-common-0.9.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"80d7ff825a6a654ee85a63e80f92f054f904f21e7d12da4e22f9834a4aaa35bc\", \"files\": {}}",
+        "dest": "cargo/vendor/unic-common-0.9.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/unic-ucd-ident/unic-ucd-ident-0.9.0.crate",
+        "sha256": "e230a37c0381caa9219d67cf063aa3a375ffed5bf541a452db16e744bdab6987",
+        "dest": "cargo/vendor/unic-ucd-ident-0.9.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"e230a37c0381caa9219d67cf063aa3a375ffed5bf541a452db16e744bdab6987\", \"files\": {}}",
+        "dest": "cargo/vendor/unic-ucd-ident-0.9.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/unic-ucd-version/unic-ucd-version-0.9.0.crate",
+        "sha256": "96bd2f2237fe450fcd0a1d2f5f4e91711124f7857ba2e964247776ebeeb7b0c4",
+        "dest": "cargo/vendor/unic-ucd-version-0.9.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"96bd2f2237fe450fcd0a1d2f5f4e91711124f7857ba2e964247776ebeeb7b0c4\", \"files\": {}}",
+        "dest": "cargo/vendor/unic-ucd-version-0.9.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/unicase/unicase-2.9.0.crate",
+        "sha256": "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142",
+        "dest": "cargo/vendor/unicase-2.9.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142\", \"files\": {}}",
+        "dest": "cargo/vendor/unicase-2.9.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/unicode-ident/unicode-ident-1.0.24.crate",
+        "sha256": "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75",
+        "dest": "cargo/vendor/unicode-ident-1.0.24"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75\", \"files\": {}}",
+        "dest": "cargo/vendor/unicode-ident-1.0.24",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/unicode-segmentation/unicode-segmentation-1.13.3.crate",
+        "sha256": "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8",
+        "dest": "cargo/vendor/unicode-segmentation-1.13.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8\", \"files\": {}}",
+        "dest": "cargo/vendor/unicode-segmentation-1.13.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/unicode-width/unicode-width-0.2.2.crate",
+        "sha256": "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254",
+        "dest": "cargo/vendor/unicode-width-0.2.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254\", \"files\": {}}",
+        "dest": "cargo/vendor/unicode-width-0.2.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/unicode-xid/unicode-xid-0.2.6.crate",
+        "sha256": "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853",
+        "dest": "cargo/vendor/unicode-xid-0.2.6"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853\", \"files\": {}}",
+        "dest": "cargo/vendor/unicode-xid-0.2.6",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/universal-hash/universal-hash-0.5.1.crate",
+        "sha256": "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea",
+        "dest": "cargo/vendor/universal-hash-0.5.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea\", \"files\": {}}",
+        "dest": "cargo/vendor/universal-hash-0.5.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/untrusted/untrusted-0.9.0.crate",
+        "sha256": "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1",
+        "dest": "cargo/vendor/untrusted-0.9.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1\", \"files\": {}}",
+        "dest": "cargo/vendor/untrusted-0.9.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/url/url-2.5.8.crate",
+        "sha256": "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed",
+        "dest": "cargo/vendor/url-2.5.8"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed\", \"files\": {}}",
+        "dest": "cargo/vendor/url-2.5.8",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/urlencoding/urlencoding-2.1.3.crate",
+        "sha256": "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da",
+        "dest": "cargo/vendor/urlencoding-2.1.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da\", \"files\": {}}",
+        "dest": "cargo/vendor/urlencoding-2.1.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/urlpattern/urlpattern-0.3.0.crate",
+        "sha256": "70acd30e3aa1450bc2eece896ce2ad0d178e9c079493819301573dae3c37ba6d",
+        "dest": "cargo/vendor/urlpattern-0.3.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"70acd30e3aa1450bc2eece896ce2ad0d178e9c079493819301573dae3c37ba6d\", \"files\": {}}",
+        "dest": "cargo/vendor/urlpattern-0.3.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/utf-8/utf-8-0.7.6.crate",
+        "sha256": "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9",
+        "dest": "cargo/vendor/utf-8-0.7.6"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9\", \"files\": {}}",
+        "dest": "cargo/vendor/utf-8-0.7.6",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/utf8_iter/utf8_iter-1.0.4.crate",
+        "sha256": "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be",
+        "dest": "cargo/vendor/utf8_iter-1.0.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be\", \"files\": {}}",
+        "dest": "cargo/vendor/utf8_iter-1.0.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/utf8parse/utf8parse-0.2.2.crate",
+        "sha256": "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821",
+        "dest": "cargo/vendor/utf8parse-0.2.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821\", \"files\": {}}",
+        "dest": "cargo/vendor/utf8parse-0.2.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/uuid/uuid-1.23.4.crate",
+        "sha256": "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53",
+        "dest": "cargo/vendor/uuid-1.23.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53\", \"files\": {}}",
+        "dest": "cargo/vendor/uuid-1.23.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/v_frame/v_frame-0.3.9.crate",
+        "sha256": "666b7727c8875d6ab5db9533418d7c764233ac9c0cff1d469aec8fa127597be2",
+        "dest": "cargo/vendor/v_frame-0.3.9"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"666b7727c8875d6ab5db9533418d7c764233ac9c0cff1d469aec8fa127597be2\", \"files\": {}}",
+        "dest": "cargo/vendor/v_frame-0.3.9",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/valuable/valuable-0.1.1.crate",
+        "sha256": "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65",
+        "dest": "cargo/vendor/valuable-0.1.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65\", \"files\": {}}",
+        "dest": "cargo/vendor/valuable-0.1.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/version-compare/version-compare-0.2.1.crate",
+        "sha256": "03c2856837ef78f57382f06b2b8563a2f512f7185d732608fd9176cb3b8edf0e",
+        "dest": "cargo/vendor/version-compare-0.2.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"03c2856837ef78f57382f06b2b8563a2f512f7185d732608fd9176cb3b8edf0e\", \"files\": {}}",
+        "dest": "cargo/vendor/version-compare-0.2.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/version_check/version_check-0.9.5.crate",
+        "sha256": "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a",
+        "dest": "cargo/vendor/version_check-0.9.5"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a\", \"files\": {}}",
+        "dest": "cargo/vendor/version_check-0.9.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/vswhom/vswhom-0.1.0.crate",
+        "sha256": "be979b7f07507105799e854203b470ff7c78a1639e330a58f183b5fea574608b",
+        "dest": "cargo/vendor/vswhom-0.1.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"be979b7f07507105799e854203b470ff7c78a1639e330a58f183b5fea574608b\", \"files\": {}}",
+        "dest": "cargo/vendor/vswhom-0.1.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/vswhom-sys/vswhom-sys-0.1.3.crate",
+        "sha256": "fb067e4cbd1ff067d1df46c9194b5de0e98efd2810bbc95c5d5e5f25a3231150",
+        "dest": "cargo/vendor/vswhom-sys-0.1.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"fb067e4cbd1ff067d1df46c9194b5de0e98efd2810bbc95c5d5e5f25a3231150\", \"files\": {}}",
+        "dest": "cargo/vendor/vswhom-sys-0.1.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/walkdir/walkdir-2.5.0.crate",
+        "sha256": "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b",
+        "dest": "cargo/vendor/walkdir-2.5.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b\", \"files\": {}}",
+        "dest": "cargo/vendor/walkdir-2.5.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/want/want-0.3.1.crate",
+        "sha256": "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e",
+        "dest": "cargo/vendor/want-0.3.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e\", \"files\": {}}",
+        "dest": "cargo/vendor/want-0.3.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/wasi/wasi-0.9.0+wasi-snapshot-preview1.crate",
+        "sha256": "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519",
+        "dest": "cargo/vendor/wasi-0.9.0+wasi-snapshot-preview1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519\", \"files\": {}}",
+        "dest": "cargo/vendor/wasi-0.9.0+wasi-snapshot-preview1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/wasi/wasi-0.11.1+wasi-snapshot-preview1.crate",
+        "sha256": "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b",
+        "dest": "cargo/vendor/wasi-0.11.1+wasi-snapshot-preview1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b\", \"files\": {}}",
+        "dest": "cargo/vendor/wasi-0.11.1+wasi-snapshot-preview1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/wasip2/wasip2-1.0.4+wasi-0.2.12.crate",
+        "sha256": "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487",
+        "dest": "cargo/vendor/wasip2-1.0.4+wasi-0.2.12"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487\", \"files\": {}}",
+        "dest": "cargo/vendor/wasip2-1.0.4+wasi-0.2.12",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/wasm-bindgen/wasm-bindgen-0.2.126.crate",
+        "sha256": "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4",
+        "dest": "cargo/vendor/wasm-bindgen-0.2.126"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4\", \"files\": {}}",
+        "dest": "cargo/vendor/wasm-bindgen-0.2.126",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/wasm-bindgen-futures/wasm-bindgen-futures-0.4.76.crate",
+        "sha256": "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d",
+        "dest": "cargo/vendor/wasm-bindgen-futures-0.4.76"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d\", \"files\": {}}",
+        "dest": "cargo/vendor/wasm-bindgen-futures-0.4.76",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/wasm-bindgen-macro/wasm-bindgen-macro-0.2.126.crate",
+        "sha256": "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1",
+        "dest": "cargo/vendor/wasm-bindgen-macro-0.2.126"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1\", \"files\": {}}",
+        "dest": "cargo/vendor/wasm-bindgen-macro-0.2.126",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/wasm-bindgen-macro-support/wasm-bindgen-macro-support-0.2.126.crate",
+        "sha256": "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e",
+        "dest": "cargo/vendor/wasm-bindgen-macro-support-0.2.126"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e\", \"files\": {}}",
+        "dest": "cargo/vendor/wasm-bindgen-macro-support-0.2.126",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/wasm-bindgen-shared/wasm-bindgen-shared-0.2.126.crate",
+        "sha256": "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24",
+        "dest": "cargo/vendor/wasm-bindgen-shared-0.2.126"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24\", \"files\": {}}",
+        "dest": "cargo/vendor/wasm-bindgen-shared-0.2.126",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/wasm-streams/wasm-streams-0.5.0.crate",
+        "sha256": "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb",
+        "dest": "cargo/vendor/wasm-streams-0.5.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb\", \"files\": {}}",
+        "dest": "cargo/vendor/wasm-streams-0.5.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/wayland-backend/wayland-backend-0.3.16.crate",
+        "sha256": "016ccf01d1c58b6f8999612813e17c9b2390f7d70671428869913310f83f54b8",
+        "dest": "cargo/vendor/wayland-backend-0.3.16"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"016ccf01d1c58b6f8999612813e17c9b2390f7d70671428869913310f83f54b8\", \"files\": {}}",
+        "dest": "cargo/vendor/wayland-backend-0.3.16",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/wayland-client/wayland-client-0.31.15.crate",
+        "sha256": "e3c36a0f861ad76d0901f2800b46321410d9f73f2ea88aac0650d86c32688073",
+        "dest": "cargo/vendor/wayland-client-0.31.15"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"e3c36a0f861ad76d0901f2800b46321410d9f73f2ea88aac0650d86c32688073\", \"files\": {}}",
+        "dest": "cargo/vendor/wayland-client-0.31.15",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/wayland-protocols/wayland-protocols-0.32.13.crate",
+        "sha256": "23d0c813de3daa2ed6520af85a3bd49b0e722a3078506899aa9686fea58dc4b6",
+        "dest": "cargo/vendor/wayland-protocols-0.32.13"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"23d0c813de3daa2ed6520af85a3bd49b0e722a3078506899aa9686fea58dc4b6\", \"files\": {}}",
+        "dest": "cargo/vendor/wayland-protocols-0.32.13",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/wayland-scanner/wayland-scanner-0.31.11.crate",
+        "sha256": "338e30461b3a2b67d70eb30a6d89f8e0c93a833e07d2ae89085cd070c4a00ac0",
+        "dest": "cargo/vendor/wayland-scanner-0.31.11"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"338e30461b3a2b67d70eb30a6d89f8e0c93a833e07d2ae89085cd070c4a00ac0\", \"files\": {}}",
+        "dest": "cargo/vendor/wayland-scanner-0.31.11",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/wayland-sys/wayland-sys-0.31.11.crate",
+        "sha256": "d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be",
+        "dest": "cargo/vendor/wayland-sys-0.31.11"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be\", \"files\": {}}",
+        "dest": "cargo/vendor/wayland-sys-0.31.11",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/web-sys/web-sys-0.3.103.crate",
+        "sha256": "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141",
+        "dest": "cargo/vendor/web-sys-0.3.103"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141\", \"files\": {}}",
+        "dest": "cargo/vendor/web-sys-0.3.103",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/web-time/web-time-1.1.0.crate",
+        "sha256": "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb",
+        "dest": "cargo/vendor/web-time-1.1.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb\", \"files\": {}}",
+        "dest": "cargo/vendor/web-time-1.1.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/web_atoms/web_atoms-0.2.5.crate",
+        "sha256": "075474b12bcb3d2e3d4546580e9de478eeeead668a1761e2a8860c836b7ef297",
+        "dest": "cargo/vendor/web_atoms-0.2.5"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"075474b12bcb3d2e3d4546580e9de478eeeead668a1761e2a8860c836b7ef297\", \"files\": {}}",
+        "dest": "cargo/vendor/web_atoms-0.2.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/webkit2gtk/webkit2gtk-2.0.2.crate",
+        "sha256": "a1027150013530fb2eaf806408df88461ae4815a45c541c8975e61d6f2fc4793",
+        "dest": "cargo/vendor/webkit2gtk-2.0.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"a1027150013530fb2eaf806408df88461ae4815a45c541c8975e61d6f2fc4793\", \"files\": {}}",
+        "dest": "cargo/vendor/webkit2gtk-2.0.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/webkit2gtk-sys/webkit2gtk-sys-2.0.2.crate",
+        "sha256": "916a5f65c2ef0dfe12fff695960a2ec3d4565359fdbb2e9943c974e06c734ea5",
+        "dest": "cargo/vendor/webkit2gtk-sys-2.0.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"916a5f65c2ef0dfe12fff695960a2ec3d4565359fdbb2e9943c974e06c734ea5\", \"files\": {}}",
+        "dest": "cargo/vendor/webkit2gtk-sys-2.0.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/webpki-root-certs/webpki-root-certs-1.0.8.crate",
+        "sha256": "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267",
+        "dest": "cargo/vendor/webpki-root-certs-1.0.8"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267\", \"files\": {}}",
+        "dest": "cargo/vendor/webpki-root-certs-1.0.8",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/webpki-roots/webpki-roots-1.0.8.crate",
+        "sha256": "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf",
+        "dest": "cargo/vendor/webpki-roots-1.0.8"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf\", \"files\": {}}",
+        "dest": "cargo/vendor/webpki-roots-1.0.8",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/webview2-com/webview2-com-0.38.2.crate",
+        "sha256": "7130243a7a5b33c54a444e54842e6a9e133de08b5ad7b5861cd8ed9a6a5bc96a",
+        "dest": "cargo/vendor/webview2-com-0.38.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"7130243a7a5b33c54a444e54842e6a9e133de08b5ad7b5861cd8ed9a6a5bc96a\", \"files\": {}}",
+        "dest": "cargo/vendor/webview2-com-0.38.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/webview2-com-macros/webview2-com-macros-0.8.1.crate",
+        "sha256": "67a921c1b6914c367b2b823cd4cde6f96beec77d30a939c8199bb377cf9b9b54",
+        "dest": "cargo/vendor/webview2-com-macros-0.8.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"67a921c1b6914c367b2b823cd4cde6f96beec77d30a939c8199bb377cf9b9b54\", \"files\": {}}",
+        "dest": "cargo/vendor/webview2-com-macros-0.8.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/webview2-com-sys/webview2-com-sys-0.38.2.crate",
+        "sha256": "381336cfffd772377d291702245447a5251a2ffa5bad679c99e61bc48bacbf9c",
+        "dest": "cargo/vendor/webview2-com-sys-0.38.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"381336cfffd772377d291702245447a5251a2ffa5bad679c99e61bc48bacbf9c\", \"files\": {}}",
+        "dest": "cargo/vendor/webview2-com-sys-0.38.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/weezl/weezl-0.1.12.crate",
+        "sha256": "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88",
+        "dest": "cargo/vendor/weezl-0.1.12"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88\", \"files\": {}}",
+        "dest": "cargo/vendor/weezl-0.1.12",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/widestring/widestring-1.2.1.crate",
+        "sha256": "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471",
+        "dest": "cargo/vendor/widestring-1.2.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471\", \"files\": {}}",
+        "dest": "cargo/vendor/widestring-1.2.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/winapi/winapi-0.3.9.crate",
+        "sha256": "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419",
+        "dest": "cargo/vendor/winapi-0.3.9"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419\", \"files\": {}}",
+        "dest": "cargo/vendor/winapi-0.3.9",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/winapi-i686-pc-windows-gnu/winapi-i686-pc-windows-gnu-0.4.0.crate",
+        "sha256": "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6",
+        "dest": "cargo/vendor/winapi-i686-pc-windows-gnu-0.4.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6\", \"files\": {}}",
+        "dest": "cargo/vendor/winapi-i686-pc-windows-gnu-0.4.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/winapi-util/winapi-util-0.1.11.crate",
+        "sha256": "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22",
+        "dest": "cargo/vendor/winapi-util-0.1.11"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22\", \"files\": {}}",
+        "dest": "cargo/vendor/winapi-util-0.1.11",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/winapi-x86_64-pc-windows-gnu/winapi-x86_64-pc-windows-gnu-0.4.0.crate",
+        "sha256": "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f",
+        "dest": "cargo/vendor/winapi-x86_64-pc-windows-gnu-0.4.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f\", \"files\": {}}",
+        "dest": "cargo/vendor/winapi-x86_64-pc-windows-gnu-0.4.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/window-vibrancy/window-vibrancy-0.6.0.crate",
+        "sha256": "d9bec5a31f3f9362f2258fd0e9c9dd61a9ca432e7306cc78c444258f0dce9a9c",
+        "dest": "cargo/vendor/window-vibrancy-0.6.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"d9bec5a31f3f9362f2258fd0e9c9dd61a9ca432e7306cc78c444258f0dce9a9c\", \"files\": {}}",
+        "dest": "cargo/vendor/window-vibrancy-0.6.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows/windows-0.58.0.crate",
+        "sha256": "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6",
+        "dest": "cargo/vendor/windows-0.58.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6\", \"files\": {}}",
+        "dest": "cargo/vendor/windows-0.58.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows/windows-0.61.3.crate",
+        "sha256": "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893",
+        "dest": "cargo/vendor/windows-0.61.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893\", \"files\": {}}",
+        "dest": "cargo/vendor/windows-0.61.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows/windows-0.62.2.crate",
+        "sha256": "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580",
+        "dest": "cargo/vendor/windows-0.62.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580\", \"files\": {}}",
+        "dest": "cargo/vendor/windows-0.62.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows-collections/windows-collections-0.2.0.crate",
+        "sha256": "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8",
+        "dest": "cargo/vendor/windows-collections-0.2.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8\", \"files\": {}}",
+        "dest": "cargo/vendor/windows-collections-0.2.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows-collections/windows-collections-0.3.2.crate",
+        "sha256": "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610",
+        "dest": "cargo/vendor/windows-collections-0.3.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610\", \"files\": {}}",
+        "dest": "cargo/vendor/windows-collections-0.3.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows-core/windows-core-0.58.0.crate",
+        "sha256": "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99",
+        "dest": "cargo/vendor/windows-core-0.58.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99\", \"files\": {}}",
+        "dest": "cargo/vendor/windows-core-0.58.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows-core/windows-core-0.61.2.crate",
+        "sha256": "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3",
+        "dest": "cargo/vendor/windows-core-0.61.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3\", \"files\": {}}",
+        "dest": "cargo/vendor/windows-core-0.61.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows-core/windows-core-0.62.2.crate",
+        "sha256": "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb",
+        "dest": "cargo/vendor/windows-core-0.62.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb\", \"files\": {}}",
+        "dest": "cargo/vendor/windows-core-0.62.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows-future/windows-future-0.2.1.crate",
+        "sha256": "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e",
+        "dest": "cargo/vendor/windows-future-0.2.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e\", \"files\": {}}",
+        "dest": "cargo/vendor/windows-future-0.2.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows-future/windows-future-0.3.2.crate",
+        "sha256": "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb",
+        "dest": "cargo/vendor/windows-future-0.3.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb\", \"files\": {}}",
+        "dest": "cargo/vendor/windows-future-0.3.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows-implement/windows-implement-0.58.0.crate",
+        "sha256": "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b",
+        "dest": "cargo/vendor/windows-implement-0.58.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b\", \"files\": {}}",
+        "dest": "cargo/vendor/windows-implement-0.58.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows-implement/windows-implement-0.60.2.crate",
+        "sha256": "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf",
+        "dest": "cargo/vendor/windows-implement-0.60.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf\", \"files\": {}}",
+        "dest": "cargo/vendor/windows-implement-0.60.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows-interface/windows-interface-0.58.0.crate",
+        "sha256": "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515",
+        "dest": "cargo/vendor/windows-interface-0.58.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515\", \"files\": {}}",
+        "dest": "cargo/vendor/windows-interface-0.58.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows-interface/windows-interface-0.59.3.crate",
+        "sha256": "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358",
+        "dest": "cargo/vendor/windows-interface-0.59.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358\", \"files\": {}}",
+        "dest": "cargo/vendor/windows-interface-0.59.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows-link/windows-link-0.1.3.crate",
+        "sha256": "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a",
+        "dest": "cargo/vendor/windows-link-0.1.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a\", \"files\": {}}",
+        "dest": "cargo/vendor/windows-link-0.1.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows-link/windows-link-0.2.1.crate",
+        "sha256": "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5",
+        "dest": "cargo/vendor/windows-link-0.2.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5\", \"files\": {}}",
+        "dest": "cargo/vendor/windows-link-0.2.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows-numerics/windows-numerics-0.2.0.crate",
+        "sha256": "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1",
+        "dest": "cargo/vendor/windows-numerics-0.2.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1\", \"files\": {}}",
+        "dest": "cargo/vendor/windows-numerics-0.2.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows-numerics/windows-numerics-0.3.1.crate",
+        "sha256": "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26",
+        "dest": "cargo/vendor/windows-numerics-0.3.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26\", \"files\": {}}",
+        "dest": "cargo/vendor/windows-numerics-0.3.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows-registry/windows-registry-0.5.3.crate",
+        "sha256": "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e",
+        "dest": "cargo/vendor/windows-registry-0.5.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e\", \"files\": {}}",
+        "dest": "cargo/vendor/windows-registry-0.5.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows-registry/windows-registry-0.6.1.crate",
+        "sha256": "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720",
+        "dest": "cargo/vendor/windows-registry-0.6.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720\", \"files\": {}}",
+        "dest": "cargo/vendor/windows-registry-0.6.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows-result/windows-result-0.2.0.crate",
+        "sha256": "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e",
+        "dest": "cargo/vendor/windows-result-0.2.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e\", \"files\": {}}",
+        "dest": "cargo/vendor/windows-result-0.2.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows-result/windows-result-0.3.4.crate",
+        "sha256": "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6",
+        "dest": "cargo/vendor/windows-result-0.3.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6\", \"files\": {}}",
+        "dest": "cargo/vendor/windows-result-0.3.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows-result/windows-result-0.4.1.crate",
+        "sha256": "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5",
+        "dest": "cargo/vendor/windows-result-0.4.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5\", \"files\": {}}",
+        "dest": "cargo/vendor/windows-result-0.4.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows-strings/windows-strings-0.1.0.crate",
+        "sha256": "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10",
+        "dest": "cargo/vendor/windows-strings-0.1.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10\", \"files\": {}}",
+        "dest": "cargo/vendor/windows-strings-0.1.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows-strings/windows-strings-0.4.2.crate",
+        "sha256": "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57",
+        "dest": "cargo/vendor/windows-strings-0.4.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57\", \"files\": {}}",
+        "dest": "cargo/vendor/windows-strings-0.4.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows-strings/windows-strings-0.5.1.crate",
+        "sha256": "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091",
+        "dest": "cargo/vendor/windows-strings-0.5.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091\", \"files\": {}}",
+        "dest": "cargo/vendor/windows-strings-0.5.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows-sys/windows-sys-0.45.0.crate",
+        "sha256": "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0",
+        "dest": "cargo/vendor/windows-sys-0.45.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0\", \"files\": {}}",
+        "dest": "cargo/vendor/windows-sys-0.45.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows-sys/windows-sys-0.48.0.crate",
+        "sha256": "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9",
+        "dest": "cargo/vendor/windows-sys-0.48.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9\", \"files\": {}}",
+        "dest": "cargo/vendor/windows-sys-0.48.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows-sys/windows-sys-0.52.0.crate",
+        "sha256": "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d",
+        "dest": "cargo/vendor/windows-sys-0.52.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d\", \"files\": {}}",
+        "dest": "cargo/vendor/windows-sys-0.52.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows-sys/windows-sys-0.59.0.crate",
+        "sha256": "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b",
+        "dest": "cargo/vendor/windows-sys-0.59.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b\", \"files\": {}}",
+        "dest": "cargo/vendor/windows-sys-0.59.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows-sys/windows-sys-0.60.2.crate",
+        "sha256": "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb",
+        "dest": "cargo/vendor/windows-sys-0.60.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb\", \"files\": {}}",
+        "dest": "cargo/vendor/windows-sys-0.60.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows-sys/windows-sys-0.61.2.crate",
+        "sha256": "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc",
+        "dest": "cargo/vendor/windows-sys-0.61.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc\", \"files\": {}}",
+        "dest": "cargo/vendor/windows-sys-0.61.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows-targets/windows-targets-0.42.2.crate",
+        "sha256": "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071",
+        "dest": "cargo/vendor/windows-targets-0.42.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071\", \"files\": {}}",
+        "dest": "cargo/vendor/windows-targets-0.42.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows-targets/windows-targets-0.48.5.crate",
+        "sha256": "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c",
+        "dest": "cargo/vendor/windows-targets-0.48.5"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c\", \"files\": {}}",
+        "dest": "cargo/vendor/windows-targets-0.48.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows-targets/windows-targets-0.52.6.crate",
+        "sha256": "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973",
+        "dest": "cargo/vendor/windows-targets-0.52.6"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973\", \"files\": {}}",
+        "dest": "cargo/vendor/windows-targets-0.52.6",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows-targets/windows-targets-0.53.5.crate",
+        "sha256": "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3",
+        "dest": "cargo/vendor/windows-targets-0.53.5"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3\", \"files\": {}}",
+        "dest": "cargo/vendor/windows-targets-0.53.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows-threading/windows-threading-0.1.0.crate",
+        "sha256": "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6",
+        "dest": "cargo/vendor/windows-threading-0.1.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6\", \"files\": {}}",
+        "dest": "cargo/vendor/windows-threading-0.1.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows-threading/windows-threading-0.2.1.crate",
+        "sha256": "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37",
+        "dest": "cargo/vendor/windows-threading-0.2.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37\", \"files\": {}}",
+        "dest": "cargo/vendor/windows-threading-0.2.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows-version/windows-version-0.1.7.crate",
+        "sha256": "e4060a1da109b9d0326b7262c8e12c84df67cc0dbc9e33cf49e01ccc2eb63631",
+        "dest": "cargo/vendor/windows-version-0.1.7"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"e4060a1da109b9d0326b7262c8e12c84df67cc0dbc9e33cf49e01ccc2eb63631\", \"files\": {}}",
+        "dest": "cargo/vendor/windows-version-0.1.7",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows_aarch64_gnullvm/windows_aarch64_gnullvm-0.42.2.crate",
+        "sha256": "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8",
+        "dest": "cargo/vendor/windows_aarch64_gnullvm-0.42.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8\", \"files\": {}}",
+        "dest": "cargo/vendor/windows_aarch64_gnullvm-0.42.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows_aarch64_gnullvm/windows_aarch64_gnullvm-0.48.5.crate",
+        "sha256": "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8",
+        "dest": "cargo/vendor/windows_aarch64_gnullvm-0.48.5"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8\", \"files\": {}}",
+        "dest": "cargo/vendor/windows_aarch64_gnullvm-0.48.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows_aarch64_gnullvm/windows_aarch64_gnullvm-0.52.6.crate",
+        "sha256": "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3",
+        "dest": "cargo/vendor/windows_aarch64_gnullvm-0.52.6"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3\", \"files\": {}}",
+        "dest": "cargo/vendor/windows_aarch64_gnullvm-0.52.6",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows_aarch64_gnullvm/windows_aarch64_gnullvm-0.53.1.crate",
+        "sha256": "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53",
+        "dest": "cargo/vendor/windows_aarch64_gnullvm-0.53.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53\", \"files\": {}}",
+        "dest": "cargo/vendor/windows_aarch64_gnullvm-0.53.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows_aarch64_msvc/windows_aarch64_msvc-0.42.2.crate",
+        "sha256": "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43",
+        "dest": "cargo/vendor/windows_aarch64_msvc-0.42.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43\", \"files\": {}}",
+        "dest": "cargo/vendor/windows_aarch64_msvc-0.42.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows_aarch64_msvc/windows_aarch64_msvc-0.48.5.crate",
+        "sha256": "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc",
+        "dest": "cargo/vendor/windows_aarch64_msvc-0.48.5"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc\", \"files\": {}}",
+        "dest": "cargo/vendor/windows_aarch64_msvc-0.48.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows_aarch64_msvc/windows_aarch64_msvc-0.52.6.crate",
+        "sha256": "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469",
+        "dest": "cargo/vendor/windows_aarch64_msvc-0.52.6"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469\", \"files\": {}}",
+        "dest": "cargo/vendor/windows_aarch64_msvc-0.52.6",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows_aarch64_msvc/windows_aarch64_msvc-0.53.1.crate",
+        "sha256": "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006",
+        "dest": "cargo/vendor/windows_aarch64_msvc-0.53.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006\", \"files\": {}}",
+        "dest": "cargo/vendor/windows_aarch64_msvc-0.53.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows_i686_gnu/windows_i686_gnu-0.42.2.crate",
+        "sha256": "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f",
+        "dest": "cargo/vendor/windows_i686_gnu-0.42.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f\", \"files\": {}}",
+        "dest": "cargo/vendor/windows_i686_gnu-0.42.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows_i686_gnu/windows_i686_gnu-0.48.5.crate",
+        "sha256": "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e",
+        "dest": "cargo/vendor/windows_i686_gnu-0.48.5"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e\", \"files\": {}}",
+        "dest": "cargo/vendor/windows_i686_gnu-0.48.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows_i686_gnu/windows_i686_gnu-0.52.6.crate",
+        "sha256": "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b",
+        "dest": "cargo/vendor/windows_i686_gnu-0.52.6"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b\", \"files\": {}}",
+        "dest": "cargo/vendor/windows_i686_gnu-0.52.6",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows_i686_gnu/windows_i686_gnu-0.53.1.crate",
+        "sha256": "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3",
+        "dest": "cargo/vendor/windows_i686_gnu-0.53.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3\", \"files\": {}}",
+        "dest": "cargo/vendor/windows_i686_gnu-0.53.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows_i686_gnullvm/windows_i686_gnullvm-0.52.6.crate",
+        "sha256": "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66",
+        "dest": "cargo/vendor/windows_i686_gnullvm-0.52.6"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66\", \"files\": {}}",
+        "dest": "cargo/vendor/windows_i686_gnullvm-0.52.6",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows_i686_gnullvm/windows_i686_gnullvm-0.53.1.crate",
+        "sha256": "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c",
+        "dest": "cargo/vendor/windows_i686_gnullvm-0.53.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c\", \"files\": {}}",
+        "dest": "cargo/vendor/windows_i686_gnullvm-0.53.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows_i686_msvc/windows_i686_msvc-0.42.2.crate",
+        "sha256": "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060",
+        "dest": "cargo/vendor/windows_i686_msvc-0.42.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060\", \"files\": {}}",
+        "dest": "cargo/vendor/windows_i686_msvc-0.42.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows_i686_msvc/windows_i686_msvc-0.48.5.crate",
+        "sha256": "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406",
+        "dest": "cargo/vendor/windows_i686_msvc-0.48.5"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406\", \"files\": {}}",
+        "dest": "cargo/vendor/windows_i686_msvc-0.48.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows_i686_msvc/windows_i686_msvc-0.52.6.crate",
+        "sha256": "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66",
+        "dest": "cargo/vendor/windows_i686_msvc-0.52.6"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66\", \"files\": {}}",
+        "dest": "cargo/vendor/windows_i686_msvc-0.52.6",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows_i686_msvc/windows_i686_msvc-0.53.1.crate",
+        "sha256": "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2",
+        "dest": "cargo/vendor/windows_i686_msvc-0.53.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2\", \"files\": {}}",
+        "dest": "cargo/vendor/windows_i686_msvc-0.53.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows_x86_64_gnu/windows_x86_64_gnu-0.42.2.crate",
+        "sha256": "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36",
+        "dest": "cargo/vendor/windows_x86_64_gnu-0.42.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36\", \"files\": {}}",
+        "dest": "cargo/vendor/windows_x86_64_gnu-0.42.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows_x86_64_gnu/windows_x86_64_gnu-0.48.5.crate",
+        "sha256": "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e",
+        "dest": "cargo/vendor/windows_x86_64_gnu-0.48.5"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e\", \"files\": {}}",
+        "dest": "cargo/vendor/windows_x86_64_gnu-0.48.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows_x86_64_gnu/windows_x86_64_gnu-0.52.6.crate",
+        "sha256": "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78",
+        "dest": "cargo/vendor/windows_x86_64_gnu-0.52.6"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78\", \"files\": {}}",
+        "dest": "cargo/vendor/windows_x86_64_gnu-0.52.6",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows_x86_64_gnu/windows_x86_64_gnu-0.53.1.crate",
+        "sha256": "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499",
+        "dest": "cargo/vendor/windows_x86_64_gnu-0.53.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499\", \"files\": {}}",
+        "dest": "cargo/vendor/windows_x86_64_gnu-0.53.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows_x86_64_gnullvm/windows_x86_64_gnullvm-0.42.2.crate",
+        "sha256": "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3",
+        "dest": "cargo/vendor/windows_x86_64_gnullvm-0.42.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3\", \"files\": {}}",
+        "dest": "cargo/vendor/windows_x86_64_gnullvm-0.42.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows_x86_64_gnullvm/windows_x86_64_gnullvm-0.48.5.crate",
+        "sha256": "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc",
+        "dest": "cargo/vendor/windows_x86_64_gnullvm-0.48.5"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc\", \"files\": {}}",
+        "dest": "cargo/vendor/windows_x86_64_gnullvm-0.48.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows_x86_64_gnullvm/windows_x86_64_gnullvm-0.52.6.crate",
+        "sha256": "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d",
+        "dest": "cargo/vendor/windows_x86_64_gnullvm-0.52.6"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d\", \"files\": {}}",
+        "dest": "cargo/vendor/windows_x86_64_gnullvm-0.52.6",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows_x86_64_gnullvm/windows_x86_64_gnullvm-0.53.1.crate",
+        "sha256": "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1",
+        "dest": "cargo/vendor/windows_x86_64_gnullvm-0.53.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1\", \"files\": {}}",
+        "dest": "cargo/vendor/windows_x86_64_gnullvm-0.53.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows_x86_64_msvc/windows_x86_64_msvc-0.42.2.crate",
+        "sha256": "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0",
+        "dest": "cargo/vendor/windows_x86_64_msvc-0.42.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0\", \"files\": {}}",
+        "dest": "cargo/vendor/windows_x86_64_msvc-0.42.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows_x86_64_msvc/windows_x86_64_msvc-0.48.5.crate",
+        "sha256": "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538",
+        "dest": "cargo/vendor/windows_x86_64_msvc-0.48.5"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538\", \"files\": {}}",
+        "dest": "cargo/vendor/windows_x86_64_msvc-0.48.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows_x86_64_msvc/windows_x86_64_msvc-0.52.6.crate",
+        "sha256": "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec",
+        "dest": "cargo/vendor/windows_x86_64_msvc-0.52.6"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec\", \"files\": {}}",
+        "dest": "cargo/vendor/windows_x86_64_msvc-0.52.6",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows_x86_64_msvc/windows_x86_64_msvc-0.53.1.crate",
+        "sha256": "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650",
+        "dest": "cargo/vendor/windows_x86_64_msvc-0.53.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650\", \"files\": {}}",
+        "dest": "cargo/vendor/windows_x86_64_msvc-0.53.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/winnow/winnow-0.5.40.crate",
+        "sha256": "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876",
+        "dest": "cargo/vendor/winnow-0.5.40"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876\", \"files\": {}}",
+        "dest": "cargo/vendor/winnow-0.5.40",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/winnow/winnow-0.7.15.crate",
+        "sha256": "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945",
+        "dest": "cargo/vendor/winnow-0.7.15"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945\", \"files\": {}}",
+        "dest": "cargo/vendor/winnow-0.7.15",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/winnow/winnow-1.0.3.crate",
+        "sha256": "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1",
+        "dest": "cargo/vendor/winnow-1.0.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1\", \"files\": {}}",
+        "dest": "cargo/vendor/winnow-1.0.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/winreg/winreg-0.52.0.crate",
+        "sha256": "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5",
+        "dest": "cargo/vendor/winreg-0.52.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5\", \"files\": {}}",
+        "dest": "cargo/vendor/winreg-0.52.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/winreg/winreg-0.55.0.crate",
+        "sha256": "cb5a765337c50e9ec252c2069be9bf91c7df47afb103b642ba3a53bf8101be97",
+        "dest": "cargo/vendor/winreg-0.55.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"cb5a765337c50e9ec252c2069be9bf91c7df47afb103b642ba3a53bf8101be97\", \"files\": {}}",
+        "dest": "cargo/vendor/winreg-0.55.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/wit-bindgen/wit-bindgen-0.57.1.crate",
+        "sha256": "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e",
+        "dest": "cargo/vendor/wit-bindgen-0.57.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e\", \"files\": {}}",
+        "dest": "cargo/vendor/wit-bindgen-0.57.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/wmi/wmi-0.18.4.crate",
+        "sha256": "7c81b85c57a57500e56669586496bf2abd5cf082b9d32995251185d105208b64",
+        "dest": "cargo/vendor/wmi-0.18.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"7c81b85c57a57500e56669586496bf2abd5cf082b9d32995251185d105208b64\", \"files\": {}}",
+        "dest": "cargo/vendor/wmi-0.18.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/writeable/writeable-0.6.3.crate",
+        "sha256": "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4",
+        "dest": "cargo/vendor/writeable-0.6.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4\", \"files\": {}}",
+        "dest": "cargo/vendor/writeable-0.6.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/wry/wry-0.54.4.crate",
+        "sha256": "e5a8135d8676225e5744de000d4dff5a082501bf7db6a1c1495034f8c314edbc",
+        "dest": "cargo/vendor/wry-0.54.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"e5a8135d8676225e5744de000d4dff5a082501bf7db6a1c1495034f8c314edbc\", \"files\": {}}",
+        "dest": "cargo/vendor/wry-0.54.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/ws_stream_wasm/ws_stream_wasm-0.7.5.crate",
+        "sha256": "6c173014acad22e83f16403ee360115b38846fe754e735c5d9d3803fe70c6abc",
+        "dest": "cargo/vendor/ws_stream_wasm-0.7.5"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"6c173014acad22e83f16403ee360115b38846fe754e735c5d9d3803fe70c6abc\", \"files\": {}}",
+        "dest": "cargo/vendor/ws_stream_wasm-0.7.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/x11/x11-2.21.0.crate",
+        "sha256": "502da5464ccd04011667b11c435cb992822c2c0dbde1770c988480d312a0db2e",
+        "dest": "cargo/vendor/x11-2.21.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"502da5464ccd04011667b11c435cb992822c2c0dbde1770c988480d312a0db2e\", \"files\": {}}",
+        "dest": "cargo/vendor/x11-2.21.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/x11-dl/x11-dl-2.21.0.crate",
+        "sha256": "38735924fedd5314a6e548792904ed8c6de6636285cb9fec04d5b1db85c1516f",
+        "dest": "cargo/vendor/x11-dl-2.21.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"38735924fedd5314a6e548792904ed8c6de6636285cb9fec04d5b1db85c1516f\", \"files\": {}}",
+        "dest": "cargo/vendor/x11-dl-2.21.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/x509-parser/x509-parser-0.18.1.crate",
+        "sha256": "d43b0f71ce057da06bc0851b23ee24f3f86190b07203dd8f567d0b706a185202",
+        "dest": "cargo/vendor/x509-parser-0.18.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"d43b0f71ce057da06bc0851b23ee24f3f86190b07203dd8f567d0b706a185202\", \"files\": {}}",
+        "dest": "cargo/vendor/x509-parser-0.18.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/xattr/xattr-1.6.1.crate",
+        "sha256": "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156",
+        "dest": "cargo/vendor/xattr-1.6.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156\", \"files\": {}}",
+        "dest": "cargo/vendor/xattr-1.6.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/xml-rs/xml-rs-0.8.28.crate",
+        "sha256": "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f",
+        "dest": "cargo/vendor/xml-rs-0.8.28"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f\", \"files\": {}}",
+        "dest": "cargo/vendor/xml-rs-0.8.28",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/xmltree/xmltree-0.10.3.crate",
+        "sha256": "d7d8a75eaf6557bb84a65ace8609883db44a29951042ada9b393151532e41fcb",
+        "dest": "cargo/vendor/xmltree-0.10.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"d7d8a75eaf6557bb84a65ace8609883db44a29951042ada9b393151532e41fcb\", \"files\": {}}",
+        "dest": "cargo/vendor/xmltree-0.10.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/y4m/y4m-0.8.0.crate",
+        "sha256": "7a5a4b21e1a62b67a2970e6831bc091d7b87e119e7f9791aef9702e3bef04448",
+        "dest": "cargo/vendor/y4m-0.8.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"7a5a4b21e1a62b67a2970e6831bc091d7b87e119e7f9791aef9702e3bef04448\", \"files\": {}}",
+        "dest": "cargo/vendor/y4m-0.8.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/yasna/yasna-0.6.0.crate",
+        "sha256": "b5f6765e852b9b4dc8e2a76843e4d64d1cea8e79bcde0b6901aea8e7c7f08282",
+        "dest": "cargo/vendor/yasna-0.6.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"b5f6765e852b9b4dc8e2a76843e4d64d1cea8e79bcde0b6901aea8e7c7f08282\", \"files\": {}}",
+        "dest": "cargo/vendor/yasna-0.6.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/yoke/yoke-0.8.3.crate",
+        "sha256": "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5",
+        "dest": "cargo/vendor/yoke-0.8.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5\", \"files\": {}}",
+        "dest": "cargo/vendor/yoke-0.8.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/yoke-derive/yoke-derive-0.8.2.crate",
+        "sha256": "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e",
+        "dest": "cargo/vendor/yoke-derive-0.8.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e\", \"files\": {}}",
+        "dest": "cargo/vendor/yoke-derive-0.8.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/zbus/zbus-5.17.0.crate",
+        "sha256": "a28b97f866896a4be7aefd2b5a8e01bb6773d19a775d54ab28b4d094b9a4480e",
+        "dest": "cargo/vendor/zbus-5.17.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"a28b97f866896a4be7aefd2b5a8e01bb6773d19a775d54ab28b4d094b9a4480e\", \"files\": {}}",
+        "dest": "cargo/vendor/zbus-5.17.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/zbus_macros/zbus_macros-5.17.0.crate",
+        "sha256": "5e05ad887425eecf5e8384dc2406a4a9313eb73468712fc1cdea362eb4fe0469",
+        "dest": "cargo/vendor/zbus_macros-5.17.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"5e05ad887425eecf5e8384dc2406a4a9313eb73468712fc1cdea362eb4fe0469\", \"files\": {}}",
+        "dest": "cargo/vendor/zbus_macros-5.17.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/zbus_names/zbus_names-4.3.3.crate",
+        "sha256": "1039ca249fee9559680f3a9f05b55e0761fee51af4f6c1e7d8c1f31e549721d2",
+        "dest": "cargo/vendor/zbus_names-4.3.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"1039ca249fee9559680f3a9f05b55e0761fee51af4f6c1e7d8c1f31e549721d2\", \"files\": {}}",
+        "dest": "cargo/vendor/zbus_names-4.3.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/zerocopy/zerocopy-0.8.53.crate",
+        "sha256": "75726053136156d419e285b9b7eddaaea9e3fea6ce32eed44a89901f0bd98de1",
+        "dest": "cargo/vendor/zerocopy-0.8.53"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"75726053136156d419e285b9b7eddaaea9e3fea6ce32eed44a89901f0bd98de1\", \"files\": {}}",
+        "dest": "cargo/vendor/zerocopy-0.8.53",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/zerocopy-derive/zerocopy-derive-0.8.53.crate",
+        "sha256": "4714fd92cf900833d49538023a9b3915155210801d1c1169eba513b2addefd71",
+        "dest": "cargo/vendor/zerocopy-derive-0.8.53"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"4714fd92cf900833d49538023a9b3915155210801d1c1169eba513b2addefd71\", \"files\": {}}",
+        "dest": "cargo/vendor/zerocopy-derive-0.8.53",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/zerofrom/zerofrom-0.1.8.crate",
+        "sha256": "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272",
+        "dest": "cargo/vendor/zerofrom-0.1.8"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272\", \"files\": {}}",
+        "dest": "cargo/vendor/zerofrom-0.1.8",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/zerofrom-derive/zerofrom-derive-0.1.7.crate",
+        "sha256": "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1",
+        "dest": "cargo/vendor/zerofrom-derive-0.1.7"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1\", \"files\": {}}",
+        "dest": "cargo/vendor/zerofrom-derive-0.1.7",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/zeroize/zeroize-1.9.0.crate",
+        "sha256": "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e",
+        "dest": "cargo/vendor/zeroize-1.9.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e\", \"files\": {}}",
+        "dest": "cargo/vendor/zeroize-1.9.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/zeroize_derive/zeroize_derive-1.5.0.crate",
+        "sha256": "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328",
+        "dest": "cargo/vendor/zeroize_derive-1.5.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328\", \"files\": {}}",
+        "dest": "cargo/vendor/zeroize_derive-1.5.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/zerotrie/zerotrie-0.2.4.crate",
+        "sha256": "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf",
+        "dest": "cargo/vendor/zerotrie-0.2.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf\", \"files\": {}}",
+        "dest": "cargo/vendor/zerotrie-0.2.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/zerovec/zerovec-0.11.6.crate",
+        "sha256": "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239",
+        "dest": "cargo/vendor/zerovec-0.11.6"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239\", \"files\": {}}",
+        "dest": "cargo/vendor/zerovec-0.11.6",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/zerovec-derive/zerovec-derive-0.11.3.crate",
+        "sha256": "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555",
+        "dest": "cargo/vendor/zerovec-derive-0.11.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555\", \"files\": {}}",
+        "dest": "cargo/vendor/zerovec-derive-0.11.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/zip/zip-4.6.1.crate",
+        "sha256": "caa8cd6af31c3b31c6631b8f483848b91589021b28fffe50adada48d4f4d2ed1",
+        "dest": "cargo/vendor/zip-4.6.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"caa8cd6af31c3b31c6631b8f483848b91589021b28fffe50adada48d4f4d2ed1\", \"files\": {}}",
+        "dest": "cargo/vendor/zip-4.6.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/zmij/zmij-1.0.21.crate",
+        "sha256": "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa",
+        "dest": "cargo/vendor/zmij-1.0.21"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa\", \"files\": {}}",
+        "dest": "cargo/vendor/zmij-1.0.21",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/zune-core/zune-core-0.5.1.crate",
+        "sha256": "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9",
+        "dest": "cargo/vendor/zune-core-0.5.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9\", \"files\": {}}",
+        "dest": "cargo/vendor/zune-core-0.5.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/zune-inflate/zune-inflate-0.2.54.crate",
+        "sha256": "73ab332fe2f6680068f3582b16a24f90ad7096d5d39b974d1c0aff0125116f02",
+        "dest": "cargo/vendor/zune-inflate-0.2.54"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"73ab332fe2f6680068f3582b16a24f90ad7096d5d39b974d1c0aff0125116f02\", \"files\": {}}",
+        "dest": "cargo/vendor/zune-inflate-0.2.54",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/zune-jpeg/zune-jpeg-0.5.15.crate",
+        "sha256": "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296",
+        "dest": "cargo/vendor/zune-jpeg-0.5.15"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296\", \"files\": {}}",
+        "dest": "cargo/vendor/zune-jpeg-0.5.15",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/zvariant/zvariant-5.13.0.crate",
+        "sha256": "7cf057bb00bf5c9ad77abb6147b0ca4818236a1858416e9d988e40d6322fefa7",
+        "dest": "cargo/vendor/zvariant-5.13.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"7cf057bb00bf5c9ad77abb6147b0ca4818236a1858416e9d988e40d6322fefa7\", \"files\": {}}",
+        "dest": "cargo/vendor/zvariant-5.13.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/zvariant_derive/zvariant_derive-5.13.0.crate",
+        "sha256": "8118ca6bda77bfc0ab51d660db0c955f2505eef854c9a449435bccb616933b31",
+        "dest": "cargo/vendor/zvariant_derive-5.13.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"8118ca6bda77bfc0ab51d660db0c955f2505eef854c9a449435bccb616933b31\", \"files\": {}}",
+        "dest": "cargo/vendor/zvariant_derive-5.13.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/zvariant_utils/zvariant_utils-3.5.0.crate",
+        "sha256": "90cb9383f9b45290407a1258b202d3f8f01db719eb60b4e4055c6375af4fc7c7",
+        "dest": "cargo/vendor/zvariant_utils-3.5.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"90cb9383f9b45290407a1258b202d3f8f01db719eb60b4e4055c6375af4fc7c7\", \"files\": {}}",
+        "dest": "cargo/vendor/zvariant_utils-3.5.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "inline",
+        "contents": "[source.vendored-sources]\ndirectory = \"cargo/vendor\"\n\n[source.crates-io]\nreplace-with = \"vendored-sources\"\n",
+        "dest": "cargo",
+        "dest-filename": "config"
+    }
 ]

--- a/flatpak/net.dashbeam.DashBeam.yml
+++ b/flatpak/net.dashbeam.DashBeam.yml
@@ -29,9 +29,9 @@ modules:
       - type: git
         url: https://github.com/tonyantony300/dashbeam.git
         # Must point at a release tag whose tree contains this flatpak/ dir.
-        # Set `commit` to the exact commit that tag v0.6.2 resolves to.
+        # commit must be the exact SHA that tag v0.6.2 resolves to.
         tag: v0.6.2
-        commit: 84595357aeb5ff3fab9667cec47fcd82537817bd
+        commit: c24a704d6f7efd20beadd8707fac3e44e9a9cc5d
       - cargo-sources.json
       - node-sources.json
       - type: archive

--- a/flatpak/node-sources.json
+++ b/flatpak/node-sources.json
@@ -1,1574 +1,2071 @@
 [
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
-		"sha512": "52b700041fb86d4ac5001c1b96e4c8044ad7c2f6ec53f57b4d959f99b8097db930881bb3892f60c5d383532ba279c7dd190f398e094c5ba8ee4b7fb3e53b0a2f",
-		"dest-filename": "@alloc__quick-lru-5.2.0.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
-		"sha512": "36af0e8465a264864657a84b1e8c8028b2dc26284fff115e04c189a14af14d7da9b08f1d0a27f32e16484856fe5564b7c053110e6086c3947e74ec920aa3cb87",
-		"dest-filename": "@babel__runtime-7.29.7.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@base-ui/react/-/react-1.6.0.tgz",
-		"sha512": "fe3ce34d62585e14453b8e417aff657377076e68f308ca54a9b319d8080acbfcf6e6663d07ab2119235c5dc8d06abf67e5da0cd0a616d56f1f705bf68d906e33",
-		"dest-filename": "@base-ui__react-1.6.0.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@base-ui/utils/-/utils-0.3.1.tgz",
-		"sha512": "80516296d3915665bf37a2082d31b18b33f73c1a55a72b2a30bd402d8e55934987fbb7da5640a49ce537d60a181cde40a1e9367648f1bdad57383d827bd5ae22",
-		"dest-filename": "@base-ui__utils-0.3.1.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.5.1.tgz",
-		"sha512": "21758b0b12a669efab23b2ce1d2d41dc46d58ac43a1910166e137d9ac6ba2a3342c855abbca656478a147629da36cb2b57ce763ab487b923daf7987518f25ced",
-		"dest-filename": "@biomejs__biome-2.5.1.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.5.1.tgz",
-		"sha512": "9e9a83cefaafeef15a59188d3754deef5b224603daa92f4ca6a81809d3ff0ab51b909ec0a5ecda79a2a3b9e28744dfc91ffea54632500078bc69c403080cf6db",
-		"dest-filename": "@biomejs__cli-darwin-arm64-2.5.1.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.5.1.tgz",
-		"sha512": "460c13a8f00cf20dad9f58fe6f9a118c5fc36d2057f1ae20c288edb86f57ba17caec68289af67df93fadaa35e255b8cb11e1893a82fa54493c9af45355e4b26f",
-		"dest-filename": "@biomejs__cli-darwin-x64-2.5.1.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.5.1.tgz",
-		"sha512": "58c72f30b801cb24ea5711a5abdd7c341058962abd15147d1804151131dbf958c656a5c26457c79591c2d455f889bb9863f1e0e93244deb1d4d3156b7495cd47",
-		"dest-filename": "@biomejs__cli-linux-arm64-musl-2.5.1.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.5.1.tgz",
-		"sha512": "ca1577e42cd9877f15c8cbd31178b72538f1641b3efa808a2bd286f2f07a548e7ebaf42f64d47704558428acee3a6c7d0c9263eec4296782d025c99b193b37f9",
-		"dest-filename": "@biomejs__cli-linux-arm64-2.5.1.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.5.1.tgz",
-		"sha512": "00d4e8c2d94b98f626e7278c724598f17cdbf48c7e2493f7b601d1fe7eb1463d555b2233cd6b5f45f8a1f61bfd5660a5c1a76906f65db8849921b06c225606dc",
-		"dest-filename": "@biomejs__cli-linux-x64-musl-2.5.1.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.5.1.tgz",
-		"sha512": "27feee1d25fb35fa180c8ec78a302477c9674083ab45bd96ee3dd7fadc3847e379131bd71acc9716219d41c7dcc5f3a635099955240e08393be7b7f0a73a9072",
-		"dest-filename": "@biomejs__cli-linux-x64-2.5.1.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.5.1.tgz",
-		"sha512": "ce05e728d8163c2e223c5ed8d6547749351e094b994690fa2223ab0bb4d94e58742f1e85895513d399b2b8c40743d0fed5c73bbb2325762e1fa2b13a969d22bd",
-		"dest-filename": "@biomejs__cli-win32-arm64-2.5.1.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.5.1.tgz",
-		"sha512": "eaec6947d86f6a094036465e99e4a237f1616209066acac41a7dbaede5c85af8eb8c9d8b843964db9d48863549aba317ce4576fdb717c0bc12ae82f23eda9166",
-		"dest-filename": "@biomejs__cli-win32-x64-2.5.1.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
-		"sha512": "452bdb4261f374accdb0b61aff01eb6dcdca378b182ca01d3d9c6a88cd87013aaffd2064dbf10d487a6f5c668b38c72c032cf4a68106aa49a62981b739688911",
-		"dest-filename": "@emnapi__core-1.11.1.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
-		"sha512": "be08fb477cb75a0c76e0841a18f03f47a6055cb1d530e674b951322103da5acfab7750337c43179400b6d856303b55e4291e8d3ecabb9946a7747f2821175917",
-		"dest-filename": "@emnapi__runtime-1.11.1.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
-		"sha512": "73de6a39790777274d2a1b1c05379ba840b5095019a72a8e7d57c1cd0d6a833ca5de07de95d5232208036c86600cab072e09ec33e8a01fb4c9fde01ab1a56e30",
-		"dest-filename": "@emnapi__wasi-threads-1.2.2.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
-		"sha512": "d488785935b2c34fa52b214c7011c66dbe54e45b6e1c9bae8e8cb2af9cd36964b911831e4fa25bd80b8379fb6c0ac12e7213be98cda28f9faaf5cae1c9dccb85",
-		"dest-filename": "@floating-ui__core-1.7.5.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
-		"sha512": "f60652008e57337ebcf343cf326ffff5d7e2127818a02e809b68b3112d45178d3a605b23bf204c99e2768384808eedf15b0b6eca735114bdacf61831a4b23949",
-		"dest-filename": "@floating-ui__dom-1.7.6.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.8.tgz",
-		"sha512": "702e766c7c0cfe7fc2c52f3b147d3259d9e0119ae376d2d6fea56bba8ebcaa0fa9acaed943860676eb761b20d5a6819e0187bf87cf7dad578e566e8e8b8d24d8",
-		"dest-filename": "@floating-ui__react-dom-2.1.8.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
-		"sha512": "46207fc8887bf29708c65ea52cc1b40a0057019d98d1e547a8c3d8ba0bbef54d00793e9805e889a5fee56dd24d22e8053f94888f0351828e03851d50c62dba1a",
-		"dest-filename": "@floating-ui__utils-0.2.11.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
-		"sha512": "da492dffb9e227a32010fc45d1b61d43a7ad65a03e7d0bc370b29c921cb5c8840ecdaa0a8c10634a3eb7fda2d58d8137aa146de5dbccfae5327c283a50a0816c",
-		"dest-filename": "@jridgewell__gen-mapping-0.3.13.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
-		"sha512": "2c8f6effe95a606e03b354c3292256d983eb22571560ec22d9f502eb1078de5b9e0a383157895f7ce0990ad605887e9334e5feb50297c7ded3e082876e1c8711",
-		"dest-filename": "@jridgewell__remapping-2.3.5.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
-		"sha512": "6d12128022233f6d3fb5b5923d63048b9e1054f45913192e0fd9492fe508c542adc15240f305b54eb6f58ccb354455e8d42053359ff98690bd42f98a59da292b",
-		"dest-filename": "@jridgewell__resolve-uri-3.1.2.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
-		"sha512": "71843ddf5d20aeac6e7966e5f96b885086a251a0dc8fb58eab97d58449633558117ce52163d7f2db34ef7e8a96b2779b87c4a5ef45527056c80af2672ca0743a",
-		"dest-filename": "@jridgewell__sourcemap-codec-1.5.5.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
-		"sha512": "cf3351f9275048327373c8e869e3fc410a0242bf0db98c76748232b65d507811191c9f6e5ba85e6ecad881bcfc849c1441aa374d608cb667d5f0dbb5b7038b03",
-		"dest-filename": "@jridgewell__trace-mapping-0.3.31.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
-		"sha512": "64bbff25d51f92f3b2f5e0a79c16867e23be5e299b8de6c078ef8c450a83fc1f85475b6744dd2da4a4891d16c4f2c15f4ba6aab1767aed34237f07ecc542d56e",
-		"dest-filename": "@napi-rs__wasm-runtime-1.1.6.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@oxc-project/types/-/types-0.137.0.tgz",
-		"sha512": "593f866f6e22f219afa3ce4022fda8118a2e11791194a0254fd59a09add37cb80d08df8686b24e199b8894ca2e021dfc41ee103b1dba794395b2aef4a97af2c0",
-		"dest-filename": "@oxc-project__types-0.137.0.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@phosphor-icons/react/-/react-2.1.10.tgz",
-		"sha512": "bedf13beaf062e385e0196586be606fe95bb1c36e8bfc125fcc00d5bca4e033e1e1b1af08676dfad066ad02a78abccc112ef0d2211dd9ebfabf2d8677d148d60",
-		"dest-filename": "@phosphor-icons__react-2.1.10.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@radix-ui/number/-/number-1.1.2.tgz",
-		"sha512": "71e4f06b173823920e8bdec3802a2d977a6a8b2446bdf7dc734a0eb04d9d418689385203b03b785561bac446e0d5078fbfd4166aeb02108a69b9dfed275c0d8a",
-		"dest-filename": "@radix-ui__number-1.1.2.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.4.tgz",
-		"sha512": "ec07422bd3d0ca29632a80436cdf0eb9cb426ddfdeb1dc193d0f11b4e1374acc90b54a623dbf8d0fbe6ad231210b59b579c048d0c14d78b26fc0887d88a1d171",
-		"dest-filename": "@radix-ui__primitive-1.1.4.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@radix-ui/react-accessible-icon/-/react-accessible-icon-1.1.10.tgz",
-		"sha512": "4eb692c1952a4dc55b883576fd15f30170bb69e5555dc86ad1d68f15913bcc0c5815a3338ce52080b39f407f4a14b8118b3bb054a64efdcaef795d5e78edff65",
-		"dest-filename": "@radix-ui__react-accessible-icon-1.1.10.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@radix-ui/react-accordion/-/react-accordion-1.2.14.tgz",
-		"sha512": "884f1807d9e64c11fccddef7a1f048499f090b380ca0c9004c9afba83c1aeaee45d7eee64ccf3557a7daef58e067ae6ba6356979c0dfd6f4a7c0814ff4bcb5cf",
-		"dest-filename": "@radix-ui__react-accordion-1.2.14.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@radix-ui/react-alert-dialog/-/react-alert-dialog-1.1.17.tgz",
-		"sha512": "e7adf28067b258faf1c9508da7b395e2b1366885e114f927a45ca8e306c395cc8c30f67ac9287ecc2e564ef6346452e03d383f401ead03c3f20d0c89d9be1c3e",
-		"dest-filename": "@radix-ui__react-alert-dialog-1.1.17.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.10.tgz",
-		"sha512": "8f65530f3d6f802b26b86d24e6505f39c33c9f924f16a64170caf26ac1631d8321c3160be5245457994c494a5174db70dc3fd2bfca7326dae502092cb184ac41",
-		"dest-filename": "@radix-ui__react-arrow-1.1.10.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@radix-ui/react-aspect-ratio/-/react-aspect-ratio-1.1.10.tgz",
-		"sha512": "91b23b36baa10debb2b58aeaec98c0b285dccef2fcc208f6b5cd4cc9a6169bee746cc28708742d5560abcac971e1c0a99824d390173041c904e029a6195da169",
-		"dest-filename": "@radix-ui__react-aspect-ratio-1.1.10.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@radix-ui/react-avatar/-/react-avatar-1.2.0.tgz",
-		"sha512": "6a6fc2c25b57b66b5db4ffb915b61b9580e731aff3b8a70c24fd62dff4893035d77e3da61be053a8b1f6c2e72a7b2ca240cbabb14b60ff970af8d876a4269238",
-		"dest-filename": "@radix-ui__react-avatar-1.2.0.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@radix-ui/react-checkbox/-/react-checkbox-1.3.5.tgz",
-		"sha512": "a51133ae63675701af61a06833ae21b9344aec1de5ad346ec23f00f67c213e212d31bfb2b9d89687acd602a12d3f40f3779fa205ad4a8bb575a42c55f04c4c74",
-		"dest-filename": "@radix-ui__react-checkbox-1.3.5.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@radix-ui/react-collapsible/-/react-collapsible-1.1.14.tgz",
-		"sha512": "f5b4fe16f89f5f514ad8c8fa504b13772bb470ddc9680dca75f85a05aa3e38dad8172fe9c8ecb74d4d53370ee23a4d68fb484e12aebb4688e55149a8146c31c8",
-		"dest-filename": "@radix-ui__react-collapsible-1.1.14.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.10.tgz",
-		"sha512": "215573e04bc170a8ebcca8287fbd78a839f3fd2cd00242c0d849a1e5e7651db81c13a7cd777527e8224b95a61c9e6f0de09980b73420b1ee1d38ac5c0f6c9cf6",
-		"dest-filename": "@radix-ui__react-collection-1.1.10.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.3.tgz",
-		"sha512": "ad838ff0e327bae3cc405d6e84f56518d7020e592890aa86144dc97311558889005cfec4bc5594962240b2dadaa72a5a04b24d1db64bea31a16d50c64f099584",
-		"dest-filename": "@radix-ui__react-compose-refs-1.1.3.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@radix-ui/react-context-menu/-/react-context-menu-2.3.1.tgz",
-		"sha512": "5dbaf14baf16e5dca21387c06fdeb2bc9c12554e71eba076d00f7db03e4c937c5258afcba9e3a7c7a4d99e29b52a278c8d74bf09316af2b78e0235b16acd86f1",
-		"dest-filename": "@radix-ui__react-context-menu-2.3.1.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.4.tgz",
-		"sha512": "4301f83cee6eaeb6cef85686779020960f98260593cb2b99de0ffa98abecaab68b92094375c930f4969f80be4c70be55109e843cd76e3da4f7644f41b6d0c0aa",
-		"dest-filename": "@radix-ui__react-context-1.1.4.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.17.tgz",
-		"sha512": "4c34d89a976af1d236f9782f823f4027c1a1aaaf84a61fd345511d68540f0c8b4863ee904a453b30931e7afc35e7af18c3fd888f3f014e984f48fd977a32a987",
-		"dest-filename": "@radix-ui__react-dialog-1.1.17.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.2.tgz",
-		"sha512": "0b7bc585bca2e125b73e66c08ba030a6ee0ecc9b5dd0cc46babbd2b18b6bee9ee733c44d0775401770949a7a768f9d249e992b45c07bfb27155f380b805eb234",
-		"dest-filename": "@radix-ui__react-direction-1.1.2.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.13.tgz",
-		"sha512": "daffb33405967b4c92c600b40f4c9e5cc3d0db7c595605d94dead3cfe24a9667518fa81f4ea982711dbd8dbe9ddbdd037b35cf1a0aee1d60d7fef61479bb44ae",
-		"dest-filename": "@radix-ui__react-dismissable-layer-1.1.13.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@radix-ui/react-dropdown-menu/-/react-dropdown-menu-2.1.18.tgz",
-		"sha512": "3d9195f368059345a5b43448fff4ac1b6f19223968f403539a83588348cb3735d7883b00cb93e438e6106950f5a4fc58eadee0c5f7dbd50303eaa694bec05977",
-		"dest-filename": "@radix-ui__react-dropdown-menu-2.1.18.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.4.tgz",
-		"sha512": "728b7f681fe63a6d086156134e641c1042b5338f256568bc16561ee670cf410f0d6195255c41609dc27da762b37abdd1292ad8edc4d3a4430b64a368f50a0fe5",
-		"dest-filename": "@radix-ui__react-focus-guards-1.1.4.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.10.tgz",
-		"sha512": "15ab3f95742a855beac006fae2ce5115e1e21d812567a49441b65a35de8491f84ffc097bc13210f56211e10557e3be6d96ee7214211d0dc247ebf530b198cc5b",
-		"dest-filename": "@radix-ui__react-focus-scope-1.1.10.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@radix-ui/react-form/-/react-form-0.1.10.tgz",
-		"sha512": "d4d7eebdcb55b57e2c537326abf21dad1f14ba7c6208c89583703950434a845cf150178ec9a410fa599a41a57b4dcf1caaf04ab092f7fca181b22c4ad03f1616",
-		"dest-filename": "@radix-ui__react-form-0.1.10.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@radix-ui/react-hover-card/-/react-hover-card-1.1.17.tgz",
-		"sha512": "1a365020400d564bae59eced94acfa4041dedf5657da20df1f37133024156570b427242b81f296482f8b38e130e9a555eb8cf28f3a1b233480e0053878a5ab1c",
-		"dest-filename": "@radix-ui__react-hover-card-1.1.17.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.2.tgz",
-		"sha512": "a2b042f3c7eeb55a6a0a6857d69e1cbeab8d1ec10b43ec3ebc1267ba3ddfb444c8e5b25bd1b667dd3aaedd258dd8839c3f27139cc1a7870a1eae6bc84adef6b0",
-		"dest-filename": "@radix-ui__react-id-1.1.2.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@radix-ui/react-label/-/react-label-2.1.10.tgz",
-		"sha512": "89bd33bead99b00a8a9b9b519ea1899f7bcec52808b6ce53a31b174f4ab54bf19f2c3d598fb50e127930f2edb0eac4669f8edd8e9416b925350c22f5476f7fcb",
-		"dest-filename": "@radix-ui__react-label-2.1.10.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@radix-ui/react-menu/-/react-menu-2.1.18.tgz",
-		"sha512": "963f11c63b67eb326ad6849b13fb83b40c026c1f419f18070fef0cc0932e4e1eaed5d3da998856f62b842ebfd9f1dd03fd4cac15b9586077813f08bb4f893461",
-		"dest-filename": "@radix-ui__react-menu-2.1.18.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@radix-ui/react-menubar/-/react-menubar-1.1.18.tgz",
-		"sha512": "857ec41b1fe816ae833d8dbb190b8fff6c0fe3c1877f92c6eabd3a560349946fb39e60d2f0e7e8a59711706972dcbe25b01f45aa998bc7a250484f4fdc1529cb",
-		"dest-filename": "@radix-ui__react-menubar-1.1.18.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@radix-ui/react-navigation-menu/-/react-navigation-menu-1.2.16.tgz",
-		"sha512": "9c9d1292b49082e77262132261e1c0d5ac8b56e76e1090852da9f545964dedcf64ab3cc214b694f64bb2f35b8db6acf078cf586903e05b3c62f4cc10f63674e2",
-		"dest-filename": "@radix-ui__react-navigation-menu-1.2.16.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@radix-ui/react-one-time-password-field/-/react-one-time-password-field-0.1.10.tgz",
-		"sha512": "18791c27e5958fdd40b7e3af5154c3e11dd6d3fc31c3db7fb06e711540585da09bb568a8a195f931ddfbe908c9aa01f856c5725eb6d53473b63b83587268df56",
-		"dest-filename": "@radix-ui__react-one-time-password-field-0.1.10.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@radix-ui/react-password-toggle-field/-/react-password-toggle-field-0.1.5.tgz",
-		"sha512": "7d5b80f36bb46ff7c29696c426ff32a759d4f5e4afa1210e111b14fe185fdc55c63c8be4984ee811a1c4bbca68a30a173b7f7f55aef3ab61344d4718af574146",
-		"dest-filename": "@radix-ui__react-password-toggle-field-0.1.5.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@radix-ui/react-popover/-/react-popover-1.1.17.tgz",
-		"sha512": "fd848039d27b609bdd9fb6e7e6c752c767a05be48a63ebbb3b9472015b3de189ab8367e0e504d214f311933be11b216e138feab263c176bc18a1931987fe1ffa",
-		"dest-filename": "@radix-ui__react-popover-1.1.17.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.3.1.tgz",
-		"sha512": "6e19eaff40c43d38b696c383dc9e6b4cbeb9a942876ca6e1a87b2637d4cc89c9525e98a98bae75a2850a3cfa7a1b9945fd688705d9f5b345aeaac9fe9b2540bf",
-		"dest-filename": "@radix-ui__react-popper-1.3.1.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.12.tgz",
-		"sha512": "9b7d3d85abc6cec8cb1c76885f9d06e4f96f46cdf19203c2b0693fe4f4ef626f03e6adf7c86d09ef0ffbd763d33a189decd4da1444ed9d25e39e01d06afbe157",
-		"dest-filename": "@radix-ui__react-portal-1.1.12.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.6.tgz",
-		"sha512": "cdd4e4e0f9543b4135f079d9df061b5b42a4249c5609d88d629ea0e97d4fb4e345871564834d6f9624c9026c08b3353a9878b204ea16f4fd2b02e825e7f8542d",
-		"dest-filename": "@radix-ui__react-presence-1.1.6.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.6.tgz",
-		"sha512": "c1eb5dd1023bec36efacfa5302f1f54aa3b1b18176c197b94cdc6ac0e7794f2e170e9577769574b3c2bfd4c18c241798e68ee583cb9be5522dd546fec957a7ea",
-		"dest-filename": "@radix-ui__react-primitive-2.1.6.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@radix-ui/react-progress/-/react-progress-1.1.10.tgz",
-		"sha512": "258cc483ad2593bf4fc0a336ed667229decf5bc3b838ce6339a15f44f7cec9e5e6330eed2c98799128fe0848d54de86cceec2697f01d0b33c631705319fe0107",
-		"dest-filename": "@radix-ui__react-progress-1.1.10.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@radix-ui/react-radio-group/-/react-radio-group-1.4.1.tgz",
-		"sha512": "fd24b165d284a36128dbd14544a774e847c50d8a7c1ebc8a83459883b40b5dac9d3f3979d987d2bc21f66b740305176d72ec000aba094fc5158d0560389ecff4",
-		"dest-filename": "@radix-ui__react-radio-group-1.4.1.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.13.tgz",
-		"sha512": "f609309de23482e7fc2439ab1713e3245e8ecf3822a32c3efe5a2760d0b079f4bd647034e5eaf40551e25ebf8b6d6187c547dccef318e86d68899662d55ce347",
-		"dest-filename": "@radix-ui__react-roving-focus-1.1.13.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@radix-ui/react-scroll-area/-/react-scroll-area-1.2.12.tgz",
-		"sha512": "c6e69f5734224c22ecc848da928c13746dce8135ec98eec874288eefba2d21afb3e38c682cdb3d0e8e5e83b3ce16e9883828ed1ba7637e6e912942a951afdcb0",
-		"dest-filename": "@radix-ui__react-scroll-area-1.2.12.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@radix-ui/react-select/-/react-select-2.3.1.tgz",
-		"sha512": "c3a783bd8efc2c4f595223675c20354152bc45837b93d81a945bf4f648d5c9d26a04080777b63d03a874509ffa0c264d199319ac1da885c496d41a3d77cfb058",
-		"dest-filename": "@radix-ui__react-select-2.3.1.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@radix-ui/react-separator/-/react-separator-1.1.10.tgz",
-		"sha512": "63a2ba8cb40255f0a74cbd8c12d1b10cb7df92135f11f1ec120dd66bc254f8859d9f71166cb5dddceb8e7d044dee9fd6fdc51c7b55b24e4dd07ae0280c1ccdf6",
-		"dest-filename": "@radix-ui__react-separator-1.1.10.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@radix-ui/react-slider/-/react-slider-1.4.1.tgz",
-		"sha512": "afdd564a942e70d1852802314fc153d07d33ca3779b4996a39b2e9ecb38c578cf8f4aa030b08f2d35c37bc3394e1ed70c6117d2208d8728ed207a6f2396ec1bb",
-		"dest-filename": "@radix-ui__react-slider-1.4.1.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.3.0.tgz",
-		"sha512": "3288ca92ee14fe688ef00bf80e46fe72d300431ec9998f7a2e6b4342501aac246d77bacde764024b3045f9702faf94ba7284958fd1c43c180700728425593f58",
-		"dest-filename": "@radix-ui__react-slot-1.3.0.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@radix-ui/react-switch/-/react-switch-1.3.1.tgz",
-		"sha512": "e796d0b429ce0740688689921e2eaabd05e924412a5060e6ea146b334069879397c2149e82a91df08aa0040424335225814956648c69c517293847d12208a6cb",
-		"dest-filename": "@radix-ui__react-switch-1.3.1.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.1.15.tgz",
-		"sha512": "93173d808ebf1df714e277cc3154b702640ae35e246d4d4813a502266326c6384eddc44f5cec989e6bf2283f8e0edeeae7a9d1abd97b5a8be2eae686c0a80c96",
-		"dest-filename": "@radix-ui__react-tabs-1.1.15.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@radix-ui/react-toast/-/react-toast-1.2.17.tgz",
-		"sha512": "b8be24cb25b2d34d293cbe377c6182579a93e9972109611064e4a591888fc0fb7c1f2d625b7f118dea6d22fcf5fd265eb2b5ba567e7c0addec57bb5f11f8806f",
-		"dest-filename": "@radix-ui__react-toast-1.2.17.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@radix-ui/react-toggle-group/-/react-toggle-group-1.1.13.tgz",
-		"sha512": "5dbf4f2ed96f53ae85dfa2e229b6ba745b30bba57698392089d3b87cd49b407430999f4e6f13083b5ecc37f2c9e1a58979c56e4952c01cf663c9e33326b81e88",
-		"dest-filename": "@radix-ui__react-toggle-group-1.1.13.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@radix-ui/react-toggle/-/react-toggle-1.1.12.tgz",
-		"sha512": "02c015b18359225441b1c8bb06113e43241e29dd61e937df258b7e945d104247793a94379257c80723ec09be06d21fc5aba3c9c21d4560d96ecc1158ce1938fb",
-		"dest-filename": "@radix-ui__react-toggle-1.1.12.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@radix-ui/react-toolbar/-/react-toolbar-1.1.13.tgz",
-		"sha512": "65ad65e1fe9fcd3906833fe2ca700c37c89aaa229f7f6c26dbf43088b9873ed0d0ade58406bbd28a68101487a4c4c51d44f8482ccef17485f1b92fe8fc31996a",
-		"dest-filename": "@radix-ui__react-toolbar-1.1.13.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@radix-ui/react-tooltip/-/react-tooltip-1.2.10.tgz",
-		"sha512": "36535ef03d1d584a557d71658bdd083ba5f4ec9a2cc7f6f58aef7cb439f1f57bf41d3e302c82fe9b654e85e30784aeea6e9d87a1306a00b105cc6c99b3f95ebf",
-		"dest-filename": "@radix-ui__react-tooltip-1.2.10.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.2.tgz",
-		"sha512": "c42b28f63d7fbbcb0480fd513478c5ad724b0292fc2e2a8e908d51e32c2e374d2bc56758838a105eec0a2d2de2d23e4d58bae89940f6effe279718f650556f23",
-		"dest-filename": "@radix-ui__react-use-callback-ref-1.1.2.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.3.tgz",
-		"sha512": "3cbcc2f74312f917a8a2d9a30b9f7b76fa29a1e96967c43ad472640d76521318ad22aecf2f9e6f1cd9deb001f082e1cad1a3df067a5d37342dbf5ba589aa90ac",
-		"dest-filename": "@radix-ui__react-use-controllable-state-1.2.3.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.3.tgz",
-		"sha512": "e9cf19aaf3d35882c42a7c9590fe771064427299c988a4c2db5b12ffa475185e712b21c92564043df92a95c81491d4508af77ab5bdb769b5307b89e05a663424",
-		"dest-filename": "@radix-ui__react-use-effect-event-0.0.3.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.1.2.tgz",
-		"sha512": "dae54bbcb8e03bb359096c34d7f15da91c26038d89d017233cc50203e9281443806fece3a883fb4a2173ffbcd63eb2a75664aaafbe8e9aad802f20ae5f87612f",
-		"dest-filename": "@radix-ui__react-use-escape-keydown-1.1.2.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@radix-ui/react-use-is-hydrated/-/react-use-is-hydrated-0.1.1.tgz",
-		"sha512": "ab03a2cf84e3a3c08d9eb38b01850c5de6700f35e05e9bcae132903e658b10233d5e85af03afb4676ffb020dc0e22be34b8a2f6cb24f6ec924c62a05c8186bf0",
-		"dest-filename": "@radix-ui__react-use-is-hydrated-0.1.1.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.2.tgz",
-		"sha512": "8eb0563b16484ee19c9e3442336b7653964f9022f10fe626e838dfb2c4b985a4e3da289a93f0ce6fae0978de8e74b7cb829b5bebf7b690a47e66e4eb1a86533c",
-		"dest-filename": "@radix-ui__react-use-layout-effect-1.1.2.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.1.2.tgz",
-		"sha512": "2060503ed44576137a310f1d6de815981ab52d5665bb26b71758d663ea6e21c402dcc1dcb51c130d20560a42ffdd97273092d3309fbe67e92d9af83417cf620b",
-		"dest-filename": "@radix-ui__react-use-previous-1.1.2.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.1.2.tgz",
-		"sha512": "77c6be6c163f1718a434f960249a1a047657fb32956d61d82464cb9cbbef7908054939ed9067442afdc90ed1eb312d03358a65973da746c4cb18b298b6d6e99b",
-		"dest-filename": "@radix-ui__react-use-rect-1.1.2.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.2.tgz",
-		"sha512": "822590a7ee26c6304fb78299d0c9b2bb29053567db0f12ade31f9f3e44589a04452526c2645cd4825bcc6ff2a39f7f2d9b5d183f8b9f890643c77ce76b82d4eb",
-		"dest-filename": "@radix-ui__react-use-size-1.1.2.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.2.6.tgz",
-		"sha512": "8c21345a58d689f4c8e27888302965d3a906a6c25300f899554f47e1647537aa96ec0b7dcacb476cdedd0c1fb07b6c47e77e6ba051e3eea292f911a3d0530359",
-		"dest-filename": "@radix-ui__react-visually-hidden-1.2.6.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.2.tgz",
-		"sha512": "c675c4ef01b5dcf23e73189e56cb185e5409b98551847f4d068c6ddca370ce0843200ebd18c9bb778c17468b872188c4f8abd2e94fccb0c3bbdcd752d8c1fd64",
-		"dest-filename": "@radix-ui__rect-1.1.2.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.3.tgz",
-		"sha512": "0d3e99dcf86f8a878732fc68fb11dcdcab6a820ac8ec20935c2982da1ff9cd4969e63562b6fed7132fbdab9ffbbfc228961962a1ac29328f0a834104072ec9d2",
-		"dest-filename": "@rolldown__binding-android-arm64-1.1.3.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.3.tgz",
-		"sha512": "d0dc20c2c8ccecbaecb959d730ade4a13a5a80134e865a1cfc13632aa663bf8579cc8e6bd77ab1ebdb95851c7ea39674cb2e07ceafa5a72ed3020506fe872faf",
-		"dest-filename": "@rolldown__binding-darwin-arm64-1.1.3.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.3.tgz",
-		"sha512": "62d881a78762b2ee95e7ad25a13e8f8cc76245a5a656f0cdad4ba701a95b885c76820789c31740b2064c72818fd7bbb202c4f0023e55d678a4b319479d54354b",
-		"dest-filename": "@rolldown__binding-darwin-x64-1.1.3.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.3.tgz",
-		"sha512": "c83dc49047579362f2a4fc677ff9126478ab6abb08f2070fcdceb64ae92147d5494f2bd5f85f50fc6c5636e0a88dceec5f2b950b80f144685d0cae17f154ac6f",
-		"dest-filename": "@rolldown__binding-freebsd-x64-1.1.3.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.3.tgz",
-		"sha512": "73ef2f89e41bb03ec73401ca200df8c34189f4579d145b89183fbb13abf3ed0deea8022e80be69e397e196c8f851a02c1e972696aba0056321034fe3ee8d2c22",
-		"dest-filename": "@rolldown__binding-linux-arm-gnueabihf-1.1.3.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.3.tgz",
-		"sha512": "e748c3d2e5302efbabed9cfd2c7cf5ee46807533e39f9c0df77844823be6605459c2247b649628bd37798a9c962430275cabd9fb081cfbf2246ba770485e4e70",
-		"dest-filename": "@rolldown__binding-linux-arm64-gnu-1.1.3.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.3.tgz",
-		"sha512": "04ef7ea0f2fc2bda6864905f60fb1736d6233c4e6e337a9e7a14f7685716e0b2133a5fa24aa869d1a6f38d1da758150d8c865e2978c0116059eb85a33681ddeb",
-		"dest-filename": "@rolldown__binding-linux-arm64-musl-1.1.3.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.3.tgz",
-		"sha512": "7f75692c1d6f434128e9e72bffa71e90b9ef60c145e18045a151a47e4bcf2ead5b0246c0c076103d92a80261ba389c93731c680be02f7b31b1fd2d686cd0b433",
-		"dest-filename": "@rolldown__binding-linux-ppc64-gnu-1.1.3.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.3.tgz",
-		"sha512": "026bab676e8fab1fd123d37583310e0a496429797ddbbca37d7594512d0eecfba1f0044cfce6fca9fac3dea9d692c49c770e9c4ab5b93d21c4f43c8bbbbf8fb4",
-		"dest-filename": "@rolldown__binding-linux-s390x-gnu-1.1.3.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.3.tgz",
-		"sha512": "249a6ab3c6d11884c339d6e434a9e5a23cc169b6ce1ebaa34af0ebd0856c64e6c4d6505c3e3c48b54118f5e5880dbc5a277706ad73d619f1a42311628e0fd446",
-		"dest-filename": "@rolldown__binding-linux-x64-gnu-1.1.3.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.3.tgz",
-		"sha512": "ad225c7633f1cc0fdbcbfebfad8b3ebfe6d753b523be76d45b3f0c25bea487afa49ea075742aed1e0d2ebbb0bfe216aa26fa9d9181d0e481a7fad087f462d6fe",
-		"dest-filename": "@rolldown__binding-linux-x64-musl-1.1.3.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.3.tgz",
-		"sha512": "850dff3d89032480a07afbf235c56b8a155eaaaee4d4fa77559f6563e75ab8061424a3be6aea80a6f00d86f475027f41866a982af5b632ed45f6ee035d230bc5",
-		"dest-filename": "@rolldown__binding-openharmony-arm64-1.1.3.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.3.tgz",
-		"sha512": "12572ffc1b4c2fd957ad5e89b8a21373f82b37691857d823b10a56f097f0e22a0ad133a48c18f27b49e7caa40dcbd49335a236d255cd690051ac3e604a047462",
-		"dest-filename": "@rolldown__binding-wasm32-wasi-1.1.3.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.3.tgz",
-		"sha512": "d83ac47e196e1fdca189a140a66b23b23c2b4986cd718d68153cd848fd5ae77e630db57df330856a703ff7a4c151dd220c57311a6c3d411131c06097cf753efe",
-		"dest-filename": "@rolldown__binding-win32-arm64-msvc-1.1.3.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.3.tgz",
-		"sha512": "38be0e324ed43d739e54619ddeaa39cc9c8f2258dfe0016093940090f3d2f8ea0bb8e3a8ce1b9a4060b5f0cc554e7c3fd3aabdde04a1009ce5c2748263d62da8",
-		"dest-filename": "@rolldown__binding-win32-x64-msvc-1.1.3.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
-		"sha512": "da3f5b1ade4987c863faf3ed8333ed97bda3d324711c0cae9a8a3a4cd7c08ec2c1d3852da52bcf6cf703701331cfb9fef42601d1cd46c501716118368e29aa1b",
-		"dest-filename": "@rolldown__pluginutils-1.0.1.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.1.tgz",
-		"sha512": "e8d0daa91a003125c3d66aff457bb41c1bcd13d6b69f9b473ecc6ef571cbc2cf28e13c1eb39ac1336db4e52514889f60a00b5a76b37ac53197d140c4c29fcde0",
-		"dest-filename": "@tailwindcss__node-4.3.1.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.3.1.tgz",
-		"sha512": "4959727fad60dfbe25e5c1f283cc7d91fe7198b70e6b1bce4ec6eca839d2b0325a28e10567b182be2f38540546a71a2360eb35fb72ba3345235dfa8f53cbe639",
-		"dest-filename": "@tailwindcss__oxide-android-arm64-4.3.1.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.1.tgz",
-		"sha512": "8559d62f0bfe7bf97b73858ac95b4756b20fbd876a5878d107730322a011ca7cc5b67420f399264041426d5f496b4555c78c574c8883598eb463b8b3fe23680c",
-		"dest-filename": "@tailwindcss__oxide-darwin-arm64-4.3.1.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.3.1.tgz",
-		"sha512": "09feda6eed165606e153b00d80f527480be6ee70af3307aeb076fc16768794b7effc26aae0661a11983b6489b3ce68f1e252007ee4bcabe78b212ec0ec8cf122",
-		"dest-filename": "@tailwindcss__oxide-darwin-x64-4.3.1.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.3.1.tgz",
-		"sha512": "659ab35f663e197b575dfa927e92610e6eb43a865fbcb1cb0a09be27b355aa01c72631bf9bdba0648efb4704ec55de1f9c126e0853fa01eea44c96fbd54752f2",
-		"dest-filename": "@tailwindcss__oxide-freebsd-x64-4.3.1.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.3.1.tgz",
-		"sha512": "fc087fc629342da3187eff436744bfb78a4194135839caad470bac8e0a2f1e4bd3f22c6e79608bc898ec685e644087248dbe084fc43a2baa7f88f999322c5882",
-		"dest-filename": "@tailwindcss__oxide-linux-arm-gnueabihf-4.3.1.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.3.1.tgz",
-		"sha512": "82a745a15265c38e381afa6785e64b1e6bd3cd2c48fdc394521d8a48d7a34234dc6245b4eb64950fe127d2b5200fe415f756f3d571881adb751c9778f315066d",
-		"dest-filename": "@tailwindcss__oxide-linux-arm64-gnu-4.3.1.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.3.1.tgz",
-		"sha512": "070bfd2b03af13454a6bceb13c589ff5bf5cdd8d4dc4e5753f480bb62fc861a584b106195c39717c612d03c99d0d9ed21b7c32357016613e52227de088be7ba0",
-		"dest-filename": "@tailwindcss__oxide-linux-arm64-musl-4.3.1.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.3.1.tgz",
-		"sha512": "6268bc3bc4f5e4761074e51652d4c8ea574dd277873fce450be433df6c53719ee2257b5e9bfc7c2137afd28d5ef5ee6b92a8f894e3597d344bbe49a29f5fad2a",
-		"dest-filename": "@tailwindcss__oxide-linux-x64-gnu-4.3.1.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.3.1.tgz",
-		"sha512": "33e3fff75a89eae20b2f0e24d86f7718c0d10178fad5232f15062ddfd02abd4a98804c57a4b2f969ea5f9eceec8f81e20107a8962ad017d13497346f75fe333d",
-		"dest-filename": "@tailwindcss__oxide-linux-x64-musl-4.3.1.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.1.tgz",
-		"sha512": "cec33cb8e7aabd5187b005ec271b13dbcb6da2c15a84b24a08b393501a9102d2a7560192462b5db3d4f8df64224fc6fbed881aec920192e9484519493ed62144",
-		"dest-filename": "@tailwindcss__oxide-wasm32-wasi-4.3.1.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.1.tgz",
-		"sha512": "6a236f4aaf41b1593c579d779432a5ac214081ff2a04c3d94e98048489cbf8dc10aacf7b9989aea5532b3eb8010522fc3efff4cd7bbd32b305f6b32e9f565e36",
-		"dest-filename": "@tailwindcss__oxide-win32-arm64-msvc-4.3.1.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.3.1.tgz",
-		"sha512": "c43132bb5ae0dbdd38ef614419a2879f3c83ca1e501fe0255afb14e6132832d3e9ce62a5448d236982828121c362d6905993986cc69db92c82c05c18e27d4798",
-		"dest-filename": "@tailwindcss__oxide-win32-x64-msvc-4.3.1.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.3.1.tgz",
-		"sha512": "c953f2a3c44d91a6d5af73b61211c413445ec2eed82b37350e122a7cbe3a2cabde16b9aef576c36b334e258eff191bafc3587abb7bad5a7476f47fe9e493e580",
-		"dest-filename": "@tailwindcss__oxide-4.3.1.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@tailwindcss/postcss/-/postcss-4.3.1.tgz",
-		"sha512": "74d26e35b744253fd2591b974d83f55926a67a5b33df3b6452c76d5903e3adec72b2b4e96843cce343ffef59275e25cb604a23a8f3841a2b552cba4f312e53e8",
-		"dest-filename": "@tailwindcss__postcss-4.3.1.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.101.2.tgz",
-		"sha512": "847e4c2e826117b29a20677bab7c535c65efb2523e19894cd59ff7e5a4871d668225607b5ef4d21d8b95dde33bb70f9a134993ff132ba3833843dac21874f497",
-		"dest-filename": "@tanstack__query-core-5.101.2.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.101.2.tgz",
-		"sha512": "b1e0e4afa9331b35f5a2469a4ed64fb6003af3c0833e55d4cf50bac52834112aa7d3856e73cb65ad89acd6cddd7bece706a84f5711517e901f51ffba5ef7cf5a",
-		"dest-filename": "@tanstack__react-query-5.101.2.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@tauri-apps/api/-/api-2.10.1.tgz",
-		"sha512": "84a2ff8d67f6f77503494374f6b47af61ad3a3221705bf028c66960bb81f8a7be742b055be72ebd3c15e162dfc831b6e80057255c4dae7f143fd79e46f5b2207",
-		"dest-filename": "@tauri-apps__api-2.10.1.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@tauri-apps/api/-/api-2.11.1.tgz",
-		"sha512": "33614fb98343da6fb087985f5bd66949dc4c3dd109a2f3c15b0a07266c14a72b1360d1da3a4545378d7d9bf2b42c88236ffeca536bc182c51ea495ae8100af00",
-		"dest-filename": "@tauri-apps__api-2.11.1.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@tauri-apps/cli-darwin-arm64/-/cli-darwin-arm64-2.10.1.tgz",
-		"sha512": "6763a3097899f9f6d8672ecf98fdd64673a933df85cbea289ca0c499413a330378206698aa071e4e3c07b9c73f904118668b391880af7b7e5fed98a2ce0a849d",
-		"dest-filename": "@tauri-apps__cli-darwin-arm64-2.10.1.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@tauri-apps/cli-darwin-x64/-/cli-darwin-x64-2.10.1.tgz",
-		"sha512": "57f8ab415be33cc18e4d0a8d8f9e4f9d03d5b87e1524ff2f64237b6a39e3f994bc2a89b5b44336851dea6db211a12ddd04ab3999b1bcca0d560bef7b76ad7b3f",
-		"dest-filename": "@tauri-apps__cli-darwin-x64-2.10.1.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm-gnueabihf/-/cli-linux-arm-gnueabihf-2.10.1.tgz",
-		"sha512": "1f2cf0b1be159c258a19f4f0fb04add79676a4bc367f425d1417eadaf1c138186f83ba22eae84a885f3b8666d73815d465a1a4c910e4087b1dcc97087e8242db",
-		"dest-filename": "@tauri-apps__cli-linux-arm-gnueabihf-2.10.1.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-gnu/-/cli-linux-arm64-gnu-2.10.1.tgz",
-		"sha512": "3b2398b36b791a4048bf25a3035fa1e026714dc773d4e64f09600fcf90d811f0747275871114e743f48b6b24339dcad3d24c11a127d2cfd2b17a79322684de94",
-		"dest-filename": "@tauri-apps__cli-linux-arm64-gnu-2.10.1.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.10.1.tgz",
-		"sha512": "3088fbf0f0c31a3920dcda86a6d0ce1a07d792ced2609c2188c87c481a194bebdf773ef23f98cdd7c6cd68b9c386c5483c045c0211354e5b197bff18c68db3aa",
-		"dest-filename": "@tauri-apps__cli-linux-arm64-musl-2.10.1.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@tauri-apps/cli-linux-riscv64-gnu/-/cli-linux-riscv64-gnu-2.10.1.tgz",
-		"sha512": "5f496f395520f0f0956a812d1009e9c669e4c2513581c3034ea7e16de7c808a0e739327912cb77a8bd12ad6c62cc369c90838a05cbeda5e8eb4a2569b8923593",
-		"dest-filename": "@tauri-apps__cli-linux-riscv64-gnu-2.10.1.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@tauri-apps/cli-linux-x64-gnu/-/cli-linux-x64-gnu-2.10.1.tgz",
-		"sha512": "dbfd766c4cec252f5f00ac9bc6089c083171603d56108f643beb650f05f9ce7586d86c0c05a896726846959f1f8be0cc7bd09795c55aacc4d87342f7444211c7",
-		"dest-filename": "@tauri-apps__cli-linux-x64-gnu-2.10.1.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@tauri-apps/cli-linux-x64-musl/-/cli-linux-x64-musl-2.10.1.tgz",
-		"sha512": "63c274673b303f3e7451c18e16e5c610caf16e3c0a48f8177edc79aa792e32cdab9b0401e6cb2f2dbead9f9e300d26317bb4babe52e86fdbedd152ae34e68221",
-		"dest-filename": "@tauri-apps__cli-linux-x64-musl-2.10.1.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@tauri-apps/cli-win32-arm64-msvc/-/cli-win32-arm64-msvc-2.10.1.tgz",
-		"sha512": "892b7907cea31d800f25afc8958c3ef925ed14f1a75ad149ae21e7ed7d0d14156e9c5eb3bbdfbfcce9fc3a0a8859297c460ce12c65d0104b4605d478c33a5582",
-		"dest-filename": "@tauri-apps__cli-win32-arm64-msvc-2.10.1.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@tauri-apps/cli-win32-ia32-msvc/-/cli-win32-ia32-msvc-2.10.1.tgz",
-		"sha512": "817cb1804cec15e8269d6cb0614e6910151191c14dfcea38e44030bd9ac7321fb3512100bcee44f135ec80f003626df5775bbb3905373b71ec61f5417f69a81f",
-		"dest-filename": "@tauri-apps__cli-win32-ia32-msvc-2.10.1.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@tauri-apps/cli-win32-x64-msvc/-/cli-win32-x64-msvc-2.10.1.tgz",
-		"sha512": "e829fb6293c5c330a1cb4111cfa7632849947a15ab62533ec5368dcc63e0668730dc10fb39fc1f5872955b15f3763116d8a7ca90775d7ddc4ad575d362a0512e",
-		"dest-filename": "@tauri-apps__cli-win32-x64-msvc-2.10.1.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@tauri-apps/cli/-/cli-2.10.1.tgz",
-		"sha512": "8d034617fe6abb03917594922ed4e5bb2290fa8e9231afc050809f85fe1e80218574c1ea5acb00a5581849b83e8e6ad9a1cf1ed43b1c36f8d39d7b651cb4b5d6",
-		"dest-filename": "@tauri-apps__cli-2.10.1.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@tauri-apps/plugin-dialog/-/plugin-dialog-2.7.1.tgz",
-		"sha512": "38ad5405762dfa88dc9b1324b73ceeca89d8205b5af02980012a57f8203e0d318adb82a51e385823ac7688e27f4e3645e0deff0022b5a059843a3218f4887339",
-		"dest-filename": "@tauri-apps__plugin-dialog-2.7.1.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@tauri-apps/plugin-notification/-/plugin-notification-2.3.3.tgz",
-		"sha512": "670f991f5f1125be351b836b7c7808ba87c98b29aeb2a37eabc7c6508215eefc821fee6c4a7e5ca2a46ffcc581f6a113b14b3deef994d38e6aececac78257742",
-		"dest-filename": "@tauri-apps__plugin-notification-2.3.3.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@tauri-apps/plugin-opener/-/plugin-opener-2.5.4.tgz",
-		"sha512": "d479cf91bf809a03b6f4705ace6e2e3cb281fabef3cdc4c15b57747f2629d6e3fe8f0b69a2234318a30ccf3e7c485a78f67388af1744dda509b53e7b95f3bd09",
-		"dest-filename": "@tauri-apps__plugin-opener-2.5.4.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@tauri-apps/plugin-os/-/plugin-os-2.3.2.tgz",
-		"sha512": "9fe9d759eb92785f70704b123e64670441ab4603b2ea38e4494f94542395f1850629bd9eae10cec62b3b22a457891547858f1730a92cd34049d0e01d9297faf8",
-		"dest-filename": "@tauri-apps__plugin-os-2.3.2.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@tauri-apps/plugin-process/-/plugin-process-2.3.1.tgz",
-		"sha512": "9c26b87c655a0cbfc1f5a8b4dd5c8f3a37c01d11d2073e6fe85fce6ec07bdebfdd0373071e166d95d68330873457fa67530f5e873af68841be5e4484c82d0924",
-		"dest-filename": "@tauri-apps__plugin-process-2.3.1.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@tauri-apps/plugin-store/-/plugin-store-2.4.3.tgz",
-		"sha512": "f4b58f8fdc8ca61462f5ccc4b54bfced71db9756fac6077d117a4fad49eaea71bbfa76eda05f387782b0cfdc6102ffc77f7d2caf9f29abb10e97223ddfacbcab",
-		"dest-filename": "@tauri-apps__plugin-store-2.4.3.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@tauri-apps/plugin-updater/-/plugin-updater-2.10.1.tgz",
-		"sha512": "34560c83eb563993c977313f3e9163daa7eac005b0352de45eb6f5b66d609c127d998cd9e160d1af0cbcb9dcd6a009df1821cbb9e3cd2d8d565423479e1dde44",
-		"dest-filename": "@tauri-apps__plugin-updater-2.10.1.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
-		"sha512": "1777e8d4c62b44960bdf3111d0e50e9a4bad8ebd55a76de6eceb12829ee7ab848fe8ea97e82ff9e971483c09796eddf3681463996ed21b3deeffa2f016961c3a",
-		"dest-filename": "@tybys__wasm-util-0.10.3.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
-		"sha512": "ea8601022e62920e0f97e906b2862d6b050c053db364c0af3cd17ba552e71d97ddd737f7f034625a7fe04f4d51602754aa4bfb161afe0bda2de3fb5bfb6b15bc",
-		"dest-filename": "@types__node-20.19.43.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
-		"sha512": "17a6c4c9a995f632860050449a54277ac44f18e42a4b6f94c22d049b5e717a73b11da7f686fe8bf180959f7acf74f24e8897cf8829cb211cafc156aa318dcc23",
-		"dest-filename": "@types__prop-types-15.7.15.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
-		"sha512": "3047b751ea043585455f3a17116b2f72983a66f96b14d94e43b10eb2f848dc27c05f0ccf7cef10c2ec5de349dea6c60aab2c954274dd11fbfaf2af75c8b70aad",
-		"dest-filename": "@types__react-dom-18.3.7.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@types/react/-/react-18.3.31.tgz",
-		"sha512": "bdf12aa574efc13f75ca19b075fa2e4ad3768522b04efc91b3caa92df003cababf9310f0d2164ced693d520d4510b8fc8486f2f92ffe910092445177da7bf643",
-		"dest-filename": "@types__react-18.3.31.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.3.tgz",
-		"sha512": "be616f728e7f42e0b67fd3a3fb04e4d3ef577831641f149a9b064a61ceccc58c0a2027ef52f94c86a288d15b8808f96d1aa8759dea81283bcee247acd726bcbe",
-		"dest-filename": "@vitejs__plugin-react-6.0.3.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
-		"sha512": "8a4dd9802f5d63f95855533ef8e212b1a6037a0d6d6f456d3f9b8bde8ba1d64a0639a50c0cfa5b1487a2e099058a659414f9fdd2c6cc34c5d000854e96760a24",
-		"dest-filename": "aria-hidden-1.2.6.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/attr-accept/-/attr-accept-2.2.5.tgz",
-		"sha512": "d1b0cd9d8feeea93f01c3328174162794df9e28062d1af2b0fd15cb0bc3370659b73c292f0a3c88bbcbeb35dce95563e80c59cffdc4431480d13a426f1996561",
-		"dest-filename": "attr-accept-2.2.5.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz",
-		"sha512": "29afbd4ebbadbfb1bc33a593e927a2456cfbf762b9a84a881841b35ca84013ac4e58063aa4f1fc53ef48637a0232fea4a9398bb2fed787fdb0d918a091e3ccb2",
-		"dest-filename": "class-variance-authority-0.7.1.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
-		"sha512": "7989b441606d52b0566561b4777f3a386030d7a67df793e2395a3607b6e35926c779d1a5e5ed1959aabae6438681448d7ac1080e407d2126d383f24af5d84264",
-		"dest-filename": "clsx-2.1.1.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
-		"sha512": "7a2f00a2cee36b4c1e469173267100f541c9ffb5d09aa8256d1c277f60138dc07d5aaf3be15287f647e38e2acce94854dbf1397c561a77297284595d72a4a275",
-		"dest-filename": "cookie-1.1.1.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/country-flag-icons/-/country-flag-icons-1.6.20.tgz",
-		"sha512": "a72f098842b38e1630e873c9d0bed2c4b8026229b7e943d14d95f8dff92a1ae7940992d2be7aea022c16f07b5089bbabee67641505248ce81d2bea3ff4506d6b",
-		"dest-filename": "country-flag-icons-1.6.20.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
-		"sha512": "cf51c629c632db103c00641fc2b9f43c0cbe3c1ed7fc64a3dd45495bda8aca7e37c566be825e675e6538aaa2cc4735952c50bc2aeb145fc4ffd240a2398a4021",
-		"dest-filename": "csstype-3.2.3.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
-		"sha512": "06d8f604e38ef37a375b21f9f5ef0c817b3111055c6ab9143a9118aee6c1d2eaf09cdd74c90dfae2bb22072535d67665a966199b4e62fe87fb8a8e26ce2841b5",
-		"dest-filename": "detect-libc-2.1.2.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
-		"sha512": "ca9766254fd36c16f2d83c626eebfb64b5b706cd5012633b9c78c400d7e88492ef1345d5ba38ac9f5a8f25c67183ea83b9cb2bf9b3fa7cb0f5acf4b702127b11",
-		"dest-filename": "detect-node-es-1.1.0.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.6.tgz",
-		"sha512": "68d9c60af6c9fd12325a8d48ba135d5639cd17e1231fdc29ce9347b7e722fe6f477bd2c9bd437cc2b09c5e3a7d716b06340baf4a95454f1fefada00543ca868d",
-		"dest-filename": "enhanced-resolve-5.21.6.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
-		"sha512": "b486d8b596ee70eb340511aa3c992c84951874bf920c7edd54cf208f2f84469dd60148cb105244fb4da46a7c87b708d63a7c2b298062c0098cd29e242c90275e",
-		"dest-filename": "fdir-6.5.0.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/file-selector/-/file-selector-2.1.2.tgz",
-		"sha512": "4205e8fa65d37bc9637aa505697dd0547739a2c488b49fca9bec69a1cc74692a9618c4827faa98b3f567cd9812f3ae0f8e7e6271e31116281e015ec07d395a8a",
-		"dest-filename": "file-selector-2.1.2.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.42.0.tgz",
-		"sha512": "c29ec42677d669a112715ca02afddedb4b9da11cfe2dbb7149cb2e4e46a40317d79adf91782e96c8f5b69c8351006bddfa11bda1dc1c8c12f23933e31f9a4144",
-		"dest-filename": "framer-motion-12.42.0.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-		"sha512": "e71a037d7f9f2fb7da0139da82658fa5b16dc21fd1efb5a630caaa1c64bae42defbc1d181eb805f81d58999df8e35b4c8f99fade4d36d765cda09c339617df43",
-		"dest-filename": "fsevents-2.3.3.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
-		"sha512": "1498584680da89ab5f12450af072a589c9aeff7486143e75ab78ad2831a8493cac4090677ce7315391b19e113513ab2807be8c6d3d0c06d9ca26e5f2031fbde9",
-		"dest-filename": "get-nonce-1.0.1.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-		"sha512": "45b279fe398570d342703579a3d7939c12c9fc7b33595d0fef76dcf857f89d2feb263f98692e881b288e2f45680585fe9755ab97793ade1fcaac7fa7849d17bd",
-		"dest-filename": "graceful-fs-4.2.11.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
-		"sha512": "002ffb2687c9bd91abae779635a12725e38b531f89946b7bb4d6b4c198913d3e0c635c267ca8eddbee8eda9daecf6fac92597c39966624c36a7a47bb90a6cd81",
-		"dest-filename": "jiti-2.7.0.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-		"sha512": "45d2547e5704ddc5332a232a420b02bb4e853eef5474824ed1b7986cf84737893a6a9809b627dca02b53f5b7313a9601b690f690233a49bce0e026aeb16fcf29",
-		"dest-filename": "js-tokens-4.0.0.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
-		"sha512": "60aeff0a54ede2400ad2fa3ac375fe3e79b40f671fdaf3c76e139776836d8b519ad1a9753f84c1661c23013be33702c40429cabe325cda34201d71f4344c2502",
-		"dest-filename": "lightningcss-android-arm64-1.32.0.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
-		"sha512": "473786f49bb96da83606fd7f97095526f044deae93b57b247592cb0b27e0e69b7e1cbcfd06a94808eecb64ced51cd4d39ffe4f4611c50528e4e65738726b1c3d",
-		"dest-filename": "lightningcss-darwin-arm64-1.32.0.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
-		"sha512": "53e42c069da6fecdb0aa95184ffeb09e56a07596ed65d9dd4a6badfcd26a94270c2d35a9e66b82ac80fe2b9509ea3a83d8116c85e8c26179e23c36cd87bdd5f3",
-		"dest-filename": "lightningcss-darwin-x64-1.32.0.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
-		"sha512": "2424e281e74492c664ded1d34ed86731d55f19feb5164cbc262d84e188d44c4417d78c62cbf953cd79eed6fc2265eddb61ed2af92a6c487fc24de0d72ba5878a",
-		"dest-filename": "lightningcss-freebsd-x64-1.32.0.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
-		"sha512": "c7aae79e945ad862f4cd03a4b7aaedb376033f376e2e95afc0017a10c8571556570f8b4fac190416acc6a30cc2b085ac3e3a922beb723443835015de7951d293",
-		"dest-filename": "lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
-		"sha512": "d279ccca8c8e2d12577db30e8a569245c2c7dc9c39cfd1c33467d3fe0c023e06838e7c748bcc3bbc1cc52c54757fa08c2ca17c8156de6e69143777dafe4409a5",
-		"dest-filename": "lightningcss-linux-arm64-gnu-1.32.0.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
-		"sha512": "529424a1e9ebe14244ce054862923cd250c5bd198f560ea8a9ba0d1dfa07e024087cd03e1cead9ecca3b2993f4d9d0ba2e38213d025e06cbd7849a1dff09c806",
-		"dest-filename": "lightningcss-linux-arm64-musl-1.32.0.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
-		"sha512": "57b42be7622166674a3d5afe56dc3ca3e58bb1025809377c96821fa4368c45619465f04e60425ec89224a862033193f03f1db8a5431fc12c7123ca61aff31b38",
-		"dest-filename": "lightningcss-linux-x64-gnu-1.32.0.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
-		"sha512": "6d870ba7e55bd1ac2c89783ff34b8245ecc2607360d7f9779add20cc79d657d5cfd56e6c29ae7f4c274659a47fcc13363de17f1dbb10bff8f651134e895bb15a",
-		"dest-filename": "lightningcss-linux-x64-musl-1.32.0.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
-		"sha512": "f126c2f01478d294ba6da08cf2c6ed6034b011541de099454ce95a0f78161877d385370006734305d6ba79365ea9ba1f6a5209845c74a8ace01c999c3d39c677",
-		"dest-filename": "lightningcss-win32-arm64-msvc-1.32.0.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
-		"sha512": "026abd07f4a86587438b5905ae88e7a2a3cbc58850e16a395e22fc11526b56c07c011a02d4f596e951ad4f458a09e9a3cbc682fa5a2e2678d2ed4d7cc776f4e9",
-		"dest-filename": "lightningcss-win32-x64-msvc-1.32.0.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
-		"sha512": "357601ce29cdadb95fada3c6cab6cfa03d7d0b587d95f23fd66ce0598bd75137b8d781b3fd7d450f65c165264ceeb453acc03c24bdceb4068689fac82a1439c9",
-		"dest-filename": "lightningcss-1.32.0.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-		"sha512": "972bb13c6aff59f86b95e9b608bfd472751cd7372a280226043cee918ed8e45ff242235d928ebe7d12debe5c351e03324b0edfeb5d54218e34f04b71452a0add",
-		"dest-filename": "loose-envify-1.4.0.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/lottie-react/-/lottie-react-2.4.1.tgz",
-		"sha512": "2d0ac7ee39648a0208bfefb0232ace6052c748a429118e337a13e270bf5b42caedd6b9e8291602620a4251ee666aaca536d69ccb9f3fb100d94e4c0c71347167",
-		"dest-filename": "lottie-react-2.4.1.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/lottie-web/-/lottie-web-5.13.0.tgz",
-		"sha512": "fa07c15e5eacc5730f7bcb4a426eeaccb9d4cb90d43c93ca232447c2da42a725046231d84490bfe608d4bdd92e3b673726596b3ed1d71f950924af0b458979c9",
-		"dest-filename": "lottie-web-5.13.0.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.292.0.tgz",
-		"sha512": "ad18149291075a96b95424fae98b1c227090990b8f081d51151ce49313318386fe8da2f4575d84deb896591d92879388894842c065bf644c6e10ee00cf7d84e9",
-		"dest-filename": "lucide-react-0.292.0.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
-		"sha512": "bddd85e1853211728670b1e8abe4c4c828f1b9e49e1e7171cb28cda7cd328345d5e2f5219c37abfe5bef96a33f6ab0796d740de4adbfde88a7c82472c7c4f609",
-		"dest-filename": "magic-string-0.30.21.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.42.0.tgz",
-		"sha512": "33ade1e27f11faab8974d841c2e2e583133e38b61af7e23f4f6a730d16e807d7cb5d175ba2ef86c3b66eaf2f92929682c8008fd491d28c7819d44813901af7d3",
-		"dest-filename": "motion-dom-12.42.0.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.39.0.tgz",
-		"sha512": "f2769d2402634eda91926445dfa168253af2c0af679c59a73f09d2332c5a38253b1838cdf514cc248c71f437bc12b33ebe93e131c72bffa7e8e56722c902e731",
-		"dest-filename": "motion-utils-12.39.0.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/motion/-/motion-12.42.0.tgz",
-		"sha512": "421c2fbbdb15979fd4452ab908dcf0302a5228af14867af06fa54ef7bee46728ffc0e092ee659e6c95270681f1e5c654d59bfc6bd043e4248809628096b2c980",
-		"dest-filename": "motion-12.42.0.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-		"sha512": "cbb5b282fffb9843afc53b8440307c4ad5dd3110567f5911fed961033051505901da37dc2ce0313bf48798e3b6ce0cf5a5580adbdfe4caea67d39f7f6c21dd8c",
-		"dest-filename": "nanoid-3.3.15.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-		"sha512": "ac98134279149c7d6c170f324fa552537cc3dec5a6bbab19848b1e63c557f8646edcfe85ec5bbe24d0e85df9251256cb2529dcdc55101d57b8714e618fe05c52",
-		"dest-filename": "object-assign-4.1.1.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
-		"sha512": "c5c787dac9e1b5be4cf658aa0ec984c39ea57b7efa993664117fe311bfd1c4d1727a036e97b78db250973fd1438ff2dcbb45fc284c8c71e3f69eda5a1eb0c454",
-		"dest-filename": "picocolors-1.1.1.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-		"sha512": "40ff3c0402af31a9bfdcdc47eaf8f6a36d51e8c8f165401dea7970012fe99c6bcdf4854ba1c2c7c46608cc5860e9f510fb9b61e8fe1dbf8796f635f70d2223ec",
-		"dest-filename": "picomatch-4.0.4.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-		"sha512": "15f47cb237787a6d93e9f6f723633000953b1d654cafdcdb6be7a799079e5857c26e6f94382ff45f80d2f17b6951333058c19b8ca60fef18df35e933c86981dc",
-		"dest-filename": "postcss-8.5.15.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
-		"sha512": "a23f3b0a064809dba5528868815011ec08e50b4df6ed4e1e9782fa780bcea827ae74c0d553435384d695f9bf437f87578123f58173139cf7617deff6a831f972",
-		"dest-filename": "prop-types-15.8.1.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/radix-ui/-/radix-ui-1.6.0.tgz",
-		"sha512": "114102ef43b4dc483158c3f96a8a9f059ea22c2e5b73315a806cbbce149846df28e433fb2163623f7cb07adb1edcbf5bf3ce37131074386599be06d8549b8d7a",
-		"dest-filename": "radix-ui-1.6.0.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
-		"sha512": "e66e2740aa7ead945bd3d2cd1f9f463380714e1f76e75ff295b2886e97bb4e91b17c9fbd92fe812e42c15c88e3b296e06e720136a948db7b519d3593d2c9d423",
-		"dest-filename": "react-dom-18.3.1.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/react-dropzone/-/react-dropzone-14.4.1.tgz",
-		"sha512": "403b95efabf7b8a6c7887df84a9c227d9fa038b8b5f9176c08ed64979bf1313e305bc47cdbeb2d863bc1c38b61dcd1c5fd75fa141b2a0d865534dfa99e16b0d2",
-		"dest-filename": "react-dropzone-14.4.1.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-		"sha512": "db87baca71361fe38ab7892ab0ebcd77c901a55eb9ce8c5b038055b04381dc0455590922fc31f3694a02e4ab8e37f06271c0da0824d906e39c7d9b3bd2447c6d",
-		"dest-filename": "react-is-16.13.1.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz",
-		"sha512": "f6bfb28bdfa6814df700a723e886d3f684423bbf16ae24a3eadfdc17c0d605927d68e18f393103bdd503cf51702a29bb4175b0987aad7479d125f840c441b8e9",
-		"dest-filename": "react-remove-scroll-bar-2.3.8.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.2.tgz",
-		"sha512": "22a6fd3630824ede877febce74d21919d4e21f5412aabdbb1ff124f6cbff6bdee07ee788ff9875b37c918b59e783331468e393a229f9748d5d5ca757885faed1",
-		"dest-filename": "react-remove-scroll-2.7.2.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.0.tgz",
-		"sha512": "162d3263a920b4a69efd3876c626dd58ad0a49d619e01e771b27fac11b6898e296829366ec7efe0f27c386771dcfd14a6e94bed63983860dc5e16a0627ec8538",
-		"dest-filename": "react-router-dom-7.18.0.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/react-router/-/react-router-7.18.0.tgz",
-		"sha512": "a534c6b7c27e8e2d4d3a66278f34fe6c0272ff5cc3f89a78ce23ba70bed3dd92ef5cab6eb0eec1a45aa54578adaa970f56a965b085c51d132dfb6fe4dd79fa1d",
-		"dest-filename": "react-router-7.18.0.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
-		"sha512": "6fa8d2bf1bd59f2a6d0222e36e458b13f94e9d1e257d3b43025f9e502ed1672f9041673ac11cc8576084eb106e3260f1736a888a1b430990f934f38597b7d105",
-		"dest-filename": "react-style-singleton-2.2.3.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
-		"sha512": "c12fa1020252851d0a844bcf240adfb8f54dd7e1f3d6dd18ea7e632eb1906e46f8bab80f13fd11bdefb590c075bffa16807826e1621c57e8bb176a53563fb689",
-		"dest-filename": "react-18.3.1.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/reselect/-/reselect-5.2.0.tgz",
-		"sha512": "02067750e666dd89dd7eb2783988e0ad3edb9829bfd62aa48ef11f1ffa188f387a3c3daac3842e4f78e39d722ba5db78313a4c5dc94c4f79576e6458f9745a93",
-		"dest-filename": "reselect-5.2.0.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.3.tgz",
-		"sha512": "d45d5e12d501b45bdc1a6d4743d4e25085073d01bb99200e0eb848ce3c6850416ea3c39c6eb18b8952e47af3608fce131389671ef9ee9b01638493b912ed77e6",
-		"dest-filename": "rolldown-1.1.3.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
-		"sha512": "50e4a1b0fc33ecdacc52a851eadd215a315dbaf3b36edbfbb680c7d7f848adf44d2030679c159dd02c094c6bd3a67815966c0609d3fdfd997fb55ac3a9cb98cd",
-		"dest-filename": "scheduler-0.23.2.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
-		"sha512": "a1e33596953f52f853c70fa0ddc21fc571f225173fba275ddf22b53f6e368331ddb34b9d401633b37cbc8f8802096f9927b69dd3272d95df1160ef9b76eae5bf",
-		"dest-filename": "set-cookie-parser-2.7.2.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
-		"sha512": "51758c2a12cec1529bef6f0852d40f5f17d853ebac7726ed52b2bff2e184f0240cbeb84ea70bf30c1c23d108522fb31073bbc8b084811bc550f3e203431a5f40",
-		"dest-filename": "source-map-js-1.2.1.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.6.0.tgz",
-		"sha512": "bb12fba80550ae2a9140f0322b7a63eba56ab245aaa19dfb3d6f788f0393c0d7eaff3f68caed55f9eaab66ab51dbe7c28977583997bf32876df06b6fa8dceefb",
-		"dest-filename": "tailwind-merge-3.6.0.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.1.tgz",
-		"sha512": "864f930759be2bc09836b3faae341aabf63ee19ca5c296bcee62d804a0ae9f09e743da7e7c76fb92649f1aac84268c45fcee820f200159514469f35260a965f9",
-		"dest-filename": "tailwindcss-4.3.1.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
-		"sha512": "bb173fce9a8583ac7b0bcbce13b961e8b6dd6bc7842fdce6566fcf2de4cf051861d710a0756690f89d42522786a487e6d8776db14a51bfe1ec8626ac04c71ce8",
-		"dest-filename": "tapable-2.3.3.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
-		"sha512": "c1747f758a5ca8a99f5a911d66388a24ec023459dd0f40cc9eb5bf7188d51adb449017d581c2c51e836b963e3b9a339589cf72c8dbbae5a96c805e0d4324dada",
-		"dest-filename": "tinyglobby-0.2.17.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-		"sha512": "a0916ef781d06fe29576e49440bef09e99aa9df98bb0e03f9c087a6fa107d30084a0ad3f98f79753a737c0a0d5f373243ae1cf447b525ca294f7d2016b34bfdb",
-		"dest-filename": "tslib-2.8.1.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/tw-animate-css/-/tw-animate-css-1.4.0.tgz",
-		"sha512": "edbce23a546a1f4849c7cd21ff799b89c2d6ee8f2a2ec1f9f9168b476b7e3873370f426558638340a4387316caed696f994c69723e8a82ee842aa8eb1857b741",
-		"dest-filename": "tw-animate-css-1.4.0.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-		"sha512": "8e5d6f6733c38a72ebf5e52ddc9feded5e8580d130f508ef04f772b33f4a7d00c3e357d0ac2d98e2f290762694a454f86d795bd511e12e9a7cc2d9ba3394e04b",
-		"dest-filename": "typescript-5.9.3.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-		"sha512": "8b00d9aa0d10006ae0f516afe47e27d0ceb87379a4479f5c27ac10a7eec2e2723482c984c5a79d6982cd3b8e1e4f802d041c236d38863cc96dd8c7744fd1fd25",
-		"dest-filename": "undici-types-6.21.0.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
-		"sha512": "8d02f79519e871a16dbb7574d094e8633ff8424356b30c628c368254d6518914cedc74032ec76ed59b66214bd5e323e9fabbd69b98f4cb44c6fd2eb572e8a34e",
-		"dest-filename": "use-callback-ref-1.3.3.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz",
-		"sha512": "15e770d1a66f921ca7a0f625039597acc080326fa7496759b7a973250ece93c4ba43e56c1e61e94569dd55127c05ed196e47cf7392d1607fb95ebcd770478b45",
-		"dest-filename": "use-sidecar-1.1.3.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
-		"sha512": "3e9e864b018ffcdacf22bc551402243907b2c3c9457a73878a34169144eb0efac5e002eaca53f60bf28291e4bd76950cdcabd84508676b9bedec82fde7e650f7",
-		"dest-filename": "use-sync-external-store-1.6.0.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/vite/-/vite-8.1.0.tgz",
-		"sha512": "06e25c40aff9e8d4135831a7e0005e6b7ab849205d34f5b035929392452970c3e72e8aae4981fc96546d494220a0bd4a482a47b797a084b4a19f9d261f7eb2ed",
-		"dest-filename": "vite-8.1.0.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "file",
-		"url": "https://registry.npmjs.org/zustand/-/zustand-5.0.14.tgz",
-		"sha512": "ffcb40b293392cc3ebdbc6f77f02d8aed763efb102a5f66f89a3fbe423139f03bc212c9a138183206ffdac30d8abf707f43d97c360364578252c89e6541401fe",
-		"dest-filename": "zustand-5.0.14.tgz",
-		"dest": "flatpak-node/pnpm-tarballs"
-	},
-	{
-		"type": "inline",
-		"contents": "from __future__ import annotations\n\nimport base64\nimport contextlib\nimport hashlib\nimport json\nimport os\nimport re\nimport sqlite3\nimport struct\nimport sys\nimport tarfile\nimport time\nfrom collections.abc import Mapping\n\n_SANITIZE_RE = re.compile(r'[\\\\/:*?\"<>|]')\n_MAX_LENGTH_WITHOUT_HASH = 120\n\n\ndef _msgpack_pack(obj: object) -> bytes:\n    \"\"\"Minimal msgpack packer matching msgpackr with useRecords: true.\n\n    msgpackr reserves the byte range 0x40-0x7F for record IDs when useRecords\n    is enabled (pnpm's config).  Standard msgpack uses 0x00-0x7F for positive\n    fixints, but this packer caps them at 0x3F and emits a uint 8 prefix (0xcc)\n    for 64-255 to avoid aliasing with record ID bytes.\n    \"\"\"\n\n    def _pack_int(val: int) -> bytes:\n        # Positive fixint capped at 0x3F \u2014 0x40-0x7F are msgpackr record IDs\n        if 0 <= val <= 0x3F:\n            return val.to_bytes(1, 'big')\n        if -32 <= val < 0:\n            return val.to_bytes(1, 'big', signed=True)\n        if val >= 0:\n            if val <= 0xFF:\n                return b'\\xcc' + val.to_bytes(1, 'big')\n            if val <= 0xFFFF:\n                return b'\\xcd' + val.to_bytes(2, 'big')\n            if val <= 0xFFFFFFFF:\n                return b'\\xce' + val.to_bytes(4, 'big')\n            return b'\\xcf' + val.to_bytes(8, 'big')\n        if val >= -0x80:\n            return b'\\xd0' + val.to_bytes(1, 'big', signed=True)\n        if val >= -0x8000:\n            return b'\\xd1' + val.to_bytes(2, 'big', signed=True)\n        if val >= -0x80000000:\n            return b'\\xd2' + val.to_bytes(4, 'big', signed=True)\n        return b'\\xd3' + val.to_bytes(8, 'big', signed=True)\n\n    def _pack_str(val: str) -> bytes:\n        data = val.encode('utf-8')\n        length = len(data)\n        if length <= 0x1F:\n            return (0xA0 | length).to_bytes(1, 'big') + data\n        if length <= 0xFF:\n            return b'\\xd9' + length.to_bytes(1, 'big') + data\n        if length <= 0xFFFF:\n            return b'\\xda' + length.to_bytes(2, 'big') + data\n        return b'\\xdb' + length.to_bytes(4, 'big') + data\n\n    if obj is None:\n        return b'\\xc0'\n    if isinstance(obj, bool):\n        return b'\\xc3' if obj else b'\\xc2'\n    if isinstance(obj, int):\n        return _pack_int(obj)\n    if isinstance(obj, float):\n        return b'\\xcb' + struct.pack('>d', obj)\n    if isinstance(obj, str):\n        return _pack_str(obj)\n    if isinstance(obj, dict):\n        length = len(obj)\n        if length <= 0x0F:\n            result = (0x80 | length).to_bytes(1, 'big')\n        elif length <= 0xFFFF:\n            result = b'\\xde' + length.to_bytes(2, 'big')\n        else:\n            result = b'\\xdf' + length.to_bytes(4, 'big')\n        for key, val in obj.items():\n            result += _msgpack_pack(key) + _msgpack_pack(val)\n        return result\n    if isinstance(obj, (list, tuple)):\n        length = len(obj)\n        if length <= 0x0F:\n            result = (0x90 | length).to_bytes(1, 'big')\n        elif length <= 0xFFFF:\n            result = b'\\xdc' + length.to_bytes(2, 'big')\n        else:\n            result = b'\\xdd' + length.to_bytes(4, 'big')\n        for item in obj:\n            result += _msgpack_pack(item)\n        return result\n    raise TypeError(f'Unsupported type for msgpack: {type(obj)}')\n\n\nRECORD_HEADER = b'\\xd4\\x72'\n\n\ndef _pack_v11_store_entry(\n    files: dict[str, dict[str, object]],\n    manifest: dict[str, str] | None = None,\n) -> bytes:\n    \"\"\"Encode a store v11 entry using msgpackr-compatible record extensions.\n\n    msgpackr with ``useRecords: true, moreTypes: true`` decodes:\n\n    - standard msgpack maps (0x80/0xde/0xdf) as JavaScript ``Map`` objects\n      (iterable, supports ``for..of``)\n    - record extensions (0x72) as plain objects (dot-notation access)\n\n    The ``files`` field must be a Map so pnpm can iterate it with ``for..of``.\n    Everything else must use record extensions so dot-notation works\n    (e.g. ``pkgIndex.algo``, ``info.digest``, ``manifest.name``).\n    \"\"\"\n\n    def _record(obj: Mapping[str, object], struct_id: int) -> bytes:\n        keys = list(obj.keys())\n        result = RECORD_HEADER + struct_id.to_bytes(1, 'big')\n        result += _msgpack_pack(keys)\n        for k in keys:\n            result += _msgpack_pack(obj[k])\n        return result\n\n    def _fixmap(length: int) -> bytes:\n        if length <= 0x0F:\n            return (0x80 | length).to_bytes(1, 'big')\n        if length <= 0xFFFF:\n            return b'\\xde' + length.to_bytes(2, 'big')\n        return b'\\xdf' + length.to_bytes(4, 'big')\n\n    # Pack file entries as records, build files map as standard msgpack map\n    files_map_bytes = _fixmap(len(files))\n    for fname, finfo in files.items():\n        files_map_bytes += _msgpack_pack(fname) + _record(finfo, 0x41)\n\n    # Outer store_entry as record (struct_id 0x40)\n    store_entry_keys = ['algo', 'requiresBuild', 'files']\n    if manifest is not None:\n        store_entry_keys.append('manifest')\n\n    # Record with fixed entries\n    result = RECORD_HEADER + b'\\x40' + _msgpack_pack(store_entry_keys)\n    # This is hardcoded to use sha512 per pnpm's behavior, see @pnpm/store.cafs/index and\n    # file digest logic below\n    result += _msgpack_pack('sha512')  # algo\n    result += _msgpack_pack(False)  # requiresBuild\n    result += files_map_bytes  # files (standard map \u2192 iterable Map in JS)\n\n    if manifest is not None:\n        result += _record(manifest, 0x42)\n    return result\n\n\ndef populate_store(manifest_path: str, tarball_dir: str, store_dir: str) -> None:\n    with open(manifest_path, encoding='utf-8') as f:\n        manifest = json.load(f)\n\n    store_version = manifest['store_version']\n    packages = manifest['packages']\n\n    index_db: sqlite3.Connection | None = None\n\n    store = os.path.join(store_dir, store_version)\n    os.makedirs(os.path.join(store, 'files'), exist_ok=True)\n    if store_version == 'v11':\n        index_db = sqlite3.connect(os.path.join(store, 'index.db'))\n        index_db.execute('PRAGMA busy_timeout=5000')\n        index_db.execute('PRAGMA journal_mode=WAL')\n        index_db.execute('PRAGMA synchronous=NORMAL')\n        index_db.execute('PRAGMA temp_store=MEMORY')\n        index_db.execute(\n            'CREATE TABLE IF NOT EXISTS package_index ('\n            '  key TEXT PRIMARY KEY,'\n            '  data BLOB NOT NULL'\n            ') WITHOUT ROWID'\n        )\n    else:\n        os.makedirs(os.path.join(store, 'index'), exist_ok=True)\n\n    now = int(time.time() * 1000)\n\n    for tarball_name, info in packages.items():\n        tarball_path = os.path.join(tarball_dir, tarball_name)\n        if not os.path.isfile(tarball_path):\n            raise FileNotFoundError(tarball_path)\n\n        _process_tarball(\n            tarball_path=tarball_path,\n            pkg_name=info['name'],\n            pkg_version=info['version'],\n            integrity=info['integrity'],\n            integrity_digest=info['integrity_digest'],\n            integrity_algo=info['integrity_algo'],\n            store=store,\n            now=now,\n            tarball_url=info.get('tarball_url'),\n            store_version=store_version,\n            index_db=index_db,\n        )\n\n    if index_db is not None:\n        index_db.commit()\n        index_db.close()\n\n\ndef _process_tarball(\n    *,\n    tarball_path: str,\n    pkg_name: str,\n    pkg_version: str,\n    integrity: str,\n    integrity_digest: str,\n    integrity_algo: str,\n    store: str,\n    now: int,\n    tarball_url: str | None = None,\n    store_version: str = 'v3',\n    index_db: sqlite3.Connection | None = None,\n) -> None:\n    index_files: dict[str, dict[str, object]] = {}\n    file_digests: dict[str, str] = {}\n    real_pkg_name = pkg_name\n    real_pkg_version = pkg_version\n\n    with tarfile.open(tarball_path, 'r:gz') as tf:\n        for member in tf.getmembers():\n            if not member.isfile():\n                continue\n            fobj = tf.extractfile(member)\n            if fobj is None:\n                continue\n            data = fobj.read()\n\n            if member.name.endswith('package.json') and member.name.count('/') <= 1:\n                with contextlib.suppress(ValueError, TypeError, UnicodeDecodeError):\n                    pkg_data = json.loads(data.decode('utf-8'))\n                    if isinstance(pkg_data, dict):\n                        if 'name' in pkg_data and isinstance(pkg_data['name'], str):\n                            real_pkg_name = pkg_data['name']\n                        if 'version' in pkg_data and isinstance(\n                            pkg_data['version'], str\n                        ):\n                            real_pkg_version = pkg_data['version']\n\n            digest = hashlib.sha512(data).digest()\n            file_hex = digest.hex()\n            is_exec = bool(member.mode & 0o111)\n\n            cas_dir = os.path.join(store, 'files', file_hex[:2])\n            cas_name = file_hex[2:] + ('-exec' if is_exec else '')\n            cas_path = os.path.join(cas_dir, cas_name)\n            if not os.path.exists(cas_path):\n                os.makedirs(cas_dir, exist_ok=True)\n                with open(cas_path, 'wb') as out:\n                    out.write(data)\n                if is_exec:\n                    os.chmod(cas_path, 0o755)\n\n            rel_name = member.name\n            if '/' in rel_name:\n                rel_name = rel_name.split('/', 1)[1]\n\n            b64 = base64.b64encode(digest).decode()\n            index_files[rel_name] = {\n                'checkedAt': now,\n                'integrity': f'sha512-{b64}',\n                'mode': member.mode,\n                'size': len(data),\n            }\n            file_digests[rel_name] = file_hex\n\n    if store_version == 'v11':\n        assert index_db is not None\n        # pnpm v11 store index keys use the raw package name (e.g. @scope/pkg),\n        # not the filesystem-sanitized form (@scope+pkg), since keys are stored\n        # in SQLite, not as filenames.\n        raw_pkg_id = f'{pkg_name}@{pkg_version}'\n        key = f'{integrity_algo}-{integrity}\\t{raw_pkg_id}'\n\n        v11_files: dict[str, dict[str, object]] = {}\n        for rel_name, finfo in index_files.items():\n            checked_at = finfo['checkedAt']\n            assert isinstance(checked_at, int)\n            v11_files[rel_name] = {\n                'checkedAt': float(checked_at),  # float64 avoids msgpackr BigInt\n                'digest': file_digests[rel_name],\n                'mode': finfo['mode'],\n                'size': finfo['size'],\n            }\n\n        manifest = None\n        if real_pkg_name or real_pkg_version:\n            manifest = {\n                'name': real_pkg_name,\n                'version': real_pkg_version,\n            }\n\n        entry_bytes = _pack_v11_store_entry(v11_files, manifest)\n\n        # It's currently not possible to fully determine which store key pnpm will use,\n        # so we insert multiple keys to ensure pnpm can find the entry it wants.\n\n        index_db.execute(\n            'INSERT OR REPLACE INTO package_index (key, data) VALUES (?, ?)',\n            (key, entry_bytes),\n        )\n\n        if tarball_url:\n            url_key = f'{tarball_url}\\t{raw_pkg_id}'\n            index_db.execute(\n                'INSERT OR REPLACE INTO package_index (key, data) VALUES (?, ?)',\n                (url_key, entry_bytes),\n            )\n\n            # pnpm looks up git-hosted tarballs (codeload.github.com,\n            # bitbucket.org, gitlab.com) and tarballs without integrity by\n            # {tarball_url}\\tbuilt(not-built) \u2014 see pickStoreIndexKey in @pnpm/store.index.\n            pkgid_key = f'{tarball_url}\\t'\n            index_db.execute(\n                'INSERT OR REPLACE INTO package_index (key, data) VALUES (?, ?)',\n                (pkgid_key + 'built', entry_bytes),\n            )\n            index_db.execute(\n                'INSERT OR REPLACE INTO package_index (key, data) VALUES (?, ?)',\n                (pkgid_key + 'not-built', entry_bytes),\n            )\n    else:\n        pkg_id = _SANITIZE_RE.sub('+', f'{pkg_name}@{pkg_version}')\n\n        index_data = {\n            'name': real_pkg_name,\n            'version': real_pkg_version,\n            'requiresBuild': False,\n            'files': index_files,\n        }\n\n        idx_prefix = integrity_digest[:2]\n        idx_rest = integrity_digest[2:64]\n        idx_dir = os.path.join(store, 'index', idx_prefix)\n        os.makedirs(idx_dir, exist_ok=True)\n        idx_path = os.path.join(idx_dir, f'{idx_rest}-{pkg_id}.json')\n        with open(idx_path, 'w', encoding='utf-8') as out:\n            json.dump(index_data, out)\n\n        # For tarball-URL packages, also create an index entry keyed by the URL hash\n        # this is how pnpm looks up tarball deps without integrity\n        if tarball_url:\n            if store_version == 'v3':\n                url_hash = hashlib.sha256(tarball_url.encode()).hexdigest()\n                url_idx_prefix = url_hash[:2]\n                url_idx_rest = url_hash[2:64]\n                url_idx_dir = os.path.join(store, 'index', url_idx_prefix)\n                os.makedirs(url_idx_dir, exist_ok=True)\n                url_idx_path = os.path.join(\n                    url_idx_dir, f'{url_idx_rest}-{pkg_id}.json'\n                )\n                with open(url_idx_path, 'w', encoding='utf-8') as out:\n                    json.dump(index_data, out)\n            else:\n                url_dir_name = re.sub(r'[:/]', '+', tarball_url)\n                if (\n                    len(url_dir_name) > _MAX_LENGTH_WITHOUT_HASH\n                    or url_dir_name != url_dir_name.lower()\n                ):\n                    url_dir_name = f'{url_dir_name[: _MAX_LENGTH_WITHOUT_HASH - 33]}_{hashlib.sha256(url_dir_name.encode()).hexdigest()[:32]}'\n                url_idx_dir = os.path.join(store, url_dir_name)\n                os.makedirs(url_idx_dir, exist_ok=True)\n                url_idx_path = os.path.join(url_idx_dir, 'integrity.json')\n                with open(url_idx_path, 'w', encoding='utf-8') as out:\n                    json.dump(index_data, out)\n\n\nif __name__ == '__main__':\n    if len(sys.argv) != 4:\n        print(\n            f'Usage: {sys.argv[0]} <manifest.json> <tarball-dir> <store-dir>',\n            file=sys.stderr,\n        )\n        sys.exit(1)\n    populate_store(sys.argv[1], sys.argv[2], sys.argv[3])\n",
-		"dest-filename": "populate_pnpm_store.py",
-		"dest": "flatpak-node"
-	},
-	{
-		"type": "inline",
-		"contents": "{\"packages\":{\"@alloc__quick-lru-5.2.0.tgz\":{\"integrity\":\"UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"52b700041fb86d4ac5001c1b96e4c8044ad7c2f6ec53f57b4d959f99b8097db930881bb3892f60c5d383532ba279c7dd190f398e094c5ba8ee4b7fb3e53b0a2f\",\"name\":\"@alloc/quick-lru\",\"version\":\"5.2.0\"},\"@babel__runtime-7.29.7.tgz\":{\"integrity\":\"Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"36af0e8465a264864657a84b1e8c8028b2dc26284fff115e04c189a14af14d7da9b08f1d0a27f32e16484856fe5564b7c053110e6086c3947e74ec920aa3cb87\",\"name\":\"@babel/runtime\",\"version\":\"7.29.7\"},\"@base-ui__react-1.6.0.tgz\":{\"integrity\":\"/jzjTWJYXhRFO45Bev9lc3cHbmjzCMpUqbMZ2AgKy/z25mY9B6shGSNcXcjQar9n5doM0KYW1W8fcFv2jZBuMw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"fe3ce34d62585e14453b8e417aff657377076e68f308ca54a9b319d8080acbfcf6e6663d07ab2119235c5dc8d06abf67e5da0cd0a616d56f1f705bf68d906e33\",\"name\":\"@base-ui/react\",\"version\":\"1.6.0\"},\"@base-ui__utils-0.3.1.tgz\":{\"integrity\":\"gFFiltORVmW/N6IILTGxizP3PBpVpysqML1ALY5Vk0mH+7faVkCknOU31goYHN5Aoek2dkjxva1XOD2Ce9WuIg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"80516296d3915665bf37a2082d31b18b33f73c1a55a72b2a30bd402d8e55934987fbb7da5640a49ce537d60a181cde40a1e9367648f1bdad57383d827bd5ae22\",\"name\":\"@base-ui/utils\",\"version\":\"0.3.1\"},\"@biomejs__biome-2.5.1.tgz\":{\"integrity\":\"IXWLCxKmae+rI7LOHS1B3EbVisQ6GRAWbhN9msa6KjNCyFWrvKZWR4oUdinaNssrV852OrSHuSPa95h1GPJc7Q==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"21758b0b12a669efab23b2ce1d2d41dc46d58ac43a1910166e137d9ac6ba2a3342c855abbca656478a147629da36cb2b57ce763ab487b923daf7987518f25ced\",\"name\":\"@biomejs/biome\",\"version\":\"2.5.1\"},\"@biomejs__cli-darwin-arm64-2.5.1.tgz\":{\"integrity\":\"npqDzvqv7vFaWRiNN1Te71siRgPaqS9MpqgYCdP/CrUbkJ7ApezaeaKjueKHRN/JH/6lRjJQAHi8acQDCAz22w==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"9e9a83cefaafeef15a59188d3754deef5b224603daa92f4ca6a81809d3ff0ab51b909ec0a5ecda79a2a3b9e28744dfc91ffea54632500078bc69c403080cf6db\",\"name\":\"@biomejs/cli-darwin-arm64\",\"version\":\"2.5.1\"},\"@biomejs__cli-darwin-x64-2.5.1.tgz\":{\"integrity\":\"RgwTqPAM8g2tn1j+b5oRjF/DbSBX8a4gwojtuG9XuhfK7GgomvZ9+T+tqjXiVbjLEeGJOoL6VEk8mvRTVeSybw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"460c13a8f00cf20dad9f58fe6f9a118c5fc36d2057f1ae20c288edb86f57ba17caec68289af67df93fadaa35e255b8cb11e1893a82fa54493c9af45355e4b26f\",\"name\":\"@biomejs/cli-darwin-x64\",\"version\":\"2.5.1\"},\"@biomejs__cli-linux-arm64-2.5.1.tgz\":{\"integrity\":\"yhV35CzZh38VyMvTEXi3JTjxZBs++oCKK9KG8vB6VI5+uvQvZNR3BFWEKKzuOmx9DJJj7sQpZ4LQJcmbGTs3+Q==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"ca1577e42cd9877f15c8cbd31178b72538f1641b3efa808a2bd286f2f07a548e7ebaf42f64d47704558428acee3a6c7d0c9263eec4296782d025c99b193b37f9\",\"name\":\"@biomejs/cli-linux-arm64\",\"version\":\"2.5.1\"},\"@biomejs__cli-linux-arm64-musl-2.5.1.tgz\":{\"integrity\":\"WMcvMLgByyTqVxGlq918NBBYliq9FRR9GAQVETHb+VjGVqXCZFfHlZHC1FX4ibuYY/Hg6TJE3rHU0xVrdJXNRw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"58c72f30b801cb24ea5711a5abdd7c341058962abd15147d1804151131dbf958c656a5c26457c79591c2d455f889bb9863f1e0e93244deb1d4d3156b7495cd47\",\"name\":\"@biomejs/cli-linux-arm64-musl\",\"version\":\"2.5.1\"},\"@biomejs__cli-linux-x64-2.5.1.tgz\":{\"integrity\":\"J/7uHSX7NfoYDI7HijAkd8lnQIOrRb2W7j3X+tw4R+N5ExvXGsyXFiGdQcfcxfOmNQmZVSQOCDk757fwpzqQcg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"27feee1d25fb35fa180c8ec78a302477c9674083ab45bd96ee3dd7fadc3847e379131bd71acc9716219d41c7dcc5f3a635099955240e08393be7b7f0a73a9072\",\"name\":\"@biomejs/cli-linux-x64\",\"version\":\"2.5.1\"},\"@biomejs__cli-linux-x64-musl-2.5.1.tgz\":{\"integrity\":\"ANTowtlLmPYm5yeMckWY8Xzb9Ix+JJP3tgHR/n6xRj1VWyIzzWtfRfih9hv9VmClwadpBvZduISZIbBsIlYG3A==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"00d4e8c2d94b98f626e7278c724598f17cdbf48c7e2493f7b601d1fe7eb1463d555b2233cd6b5f45f8a1f61bfd5660a5c1a76906f65db8849921b06c225606dc\",\"name\":\"@biomejs/cli-linux-x64-musl\",\"version\":\"2.5.1\"},\"@biomejs__cli-win32-arm64-2.5.1.tgz\":{\"integrity\":\"zgXnKNgWPC4iPF7Y1lR3STUeCUuZRpD6IiOrC7TZTlh0Lx6FiVUT05myuMQHQ9D+1cc7uyMldi4forE6lp0ivQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"ce05e728d8163c2e223c5ed8d6547749351e094b994690fa2223ab0bb4d94e58742f1e85895513d399b2b8c40743d0fed5c73bbb2325762e1fa2b13a969d22bd\",\"name\":\"@biomejs/cli-win32-arm64\",\"version\":\"2.5.1\"},\"@biomejs__cli-win32-x64-2.5.1.tgz\":{\"integrity\":\"6uxpR9hvaglANkZemeSiN/FhYgkGasrEGn267eXIWvjrjJ2LhDlk251IhjVJq6MXzkV2/bcXwLwSroLyPtqRZg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"eaec6947d86f6a094036465e99e4a237f1616209066acac41a7dbaede5c85af8eb8c9d8b843964db9d48863549aba317ce4576fdb717c0bc12ae82f23eda9166\",\"name\":\"@biomejs/cli-win32-x64\",\"version\":\"2.5.1\"},\"@emnapi__core-1.11.1.tgz\":{\"integrity\":\"RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"452bdb4261f374accdb0b61aff01eb6dcdca378b182ca01d3d9c6a88cd87013aaffd2064dbf10d487a6f5c668b38c72c032cf4a68106aa49a62981b739688911\",\"name\":\"@emnapi/core\",\"version\":\"1.11.1\"},\"@emnapi__runtime-1.11.1.tgz\":{\"integrity\":\"vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"be08fb477cb75a0c76e0841a18f03f47a6055cb1d530e674b951322103da5acfab7750337c43179400b6d856303b55e4291e8d3ecabb9946a7747f2821175917\",\"name\":\"@emnapi/runtime\",\"version\":\"1.11.1\"},\"@emnapi__wasi-threads-1.2.2.tgz\":{\"integrity\":\"c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"73de6a39790777274d2a1b1c05379ba840b5095019a72a8e7d57c1cd0d6a833ca5de07de95d5232208036c86600cab072e09ec33e8a01fb4c9fde01ab1a56e30\",\"name\":\"@emnapi/wasi-threads\",\"version\":\"1.2.2\"},\"@floating-ui__core-1.7.5.tgz\":{\"integrity\":\"1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"d488785935b2c34fa52b214c7011c66dbe54e45b6e1c9bae8e8cb2af9cd36964b911831e4fa25bd80b8379fb6c0ac12e7213be98cda28f9faaf5cae1c9dccb85\",\"name\":\"@floating-ui/core\",\"version\":\"1.7.5\"},\"@floating-ui__dom-1.7.6.tgz\":{\"integrity\":\"9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"f60652008e57337ebcf343cf326ffff5d7e2127818a02e809b68b3112d45178d3a605b23bf204c99e2768384808eedf15b0b6eca735114bdacf61831a4b23949\",\"name\":\"@floating-ui/dom\",\"version\":\"1.7.6\"},\"@floating-ui__react-dom-2.1.8.tgz\":{\"integrity\":\"cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"702e766c7c0cfe7fc2c52f3b147d3259d9e0119ae376d2d6fea56bba8ebcaa0fa9acaed943860676eb761b20d5a6819e0187bf87cf7dad578e566e8e8b8d24d8\",\"name\":\"@floating-ui/react-dom\",\"version\":\"2.1.8\"},\"@floating-ui__utils-0.2.11.tgz\":{\"integrity\":\"RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"46207fc8887bf29708c65ea52cc1b40a0057019d98d1e547a8c3d8ba0bbef54d00793e9805e889a5fee56dd24d22e8053f94888f0351828e03851d50c62dba1a\",\"name\":\"@floating-ui/utils\",\"version\":\"0.2.11\"},\"@jridgewell__gen-mapping-0.3.13.tgz\":{\"integrity\":\"2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"da492dffb9e227a32010fc45d1b61d43a7ad65a03e7d0bc370b29c921cb5c8840ecdaa0a8c10634a3eb7fda2d58d8137aa146de5dbccfae5327c283a50a0816c\",\"name\":\"@jridgewell/gen-mapping\",\"version\":\"0.3.13\"},\"@jridgewell__remapping-2.3.5.tgz\":{\"integrity\":\"LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"2c8f6effe95a606e03b354c3292256d983eb22571560ec22d9f502eb1078de5b9e0a383157895f7ce0990ad605887e9334e5feb50297c7ded3e082876e1c8711\",\"name\":\"@jridgewell/remapping\",\"version\":\"2.3.5\"},\"@jridgewell__resolve-uri-3.1.2.tgz\":{\"integrity\":\"bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"6d12128022233f6d3fb5b5923d63048b9e1054f45913192e0fd9492fe508c542adc15240f305b54eb6f58ccb354455e8d42053359ff98690bd42f98a59da292b\",\"name\":\"@jridgewell/resolve-uri\",\"version\":\"3.1.2\"},\"@jridgewell__sourcemap-codec-1.5.5.tgz\":{\"integrity\":\"cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"71843ddf5d20aeac6e7966e5f96b885086a251a0dc8fb58eab97d58449633558117ce52163d7f2db34ef7e8a96b2779b87c4a5ef45527056c80af2672ca0743a\",\"name\":\"@jridgewell/sourcemap-codec\",\"version\":\"1.5.5\"},\"@jridgewell__trace-mapping-0.3.31.tgz\":{\"integrity\":\"zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"cf3351f9275048327373c8e869e3fc410a0242bf0db98c76748232b65d507811191c9f6e5ba85e6ecad881bcfc849c1441aa374d608cb667d5f0dbb5b7038b03\",\"name\":\"@jridgewell/trace-mapping\",\"version\":\"0.3.31\"},\"@napi-rs__wasm-runtime-1.1.6.tgz\":{\"integrity\":\"ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"64bbff25d51f92f3b2f5e0a79c16867e23be5e299b8de6c078ef8c450a83fc1f85475b6744dd2da4a4891d16c4f2c15f4ba6aab1767aed34237f07ecc542d56e\",\"name\":\"@napi-rs/wasm-runtime\",\"version\":\"1.1.6\"},\"@oxc-project__types-0.137.0.tgz\":{\"integrity\":\"WT+Gb24i8hmvo85AIv2oEYouEXkRlKAlT9WaCa3TfLgNCN+GhrJOGZuIlMouAh38Qe4QOx26eUOVsq70qXrywA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"593f866f6e22f219afa3ce4022fda8118a2e11791194a0254fd59a09add37cb80d08df8686b24e199b8894ca2e021dfc41ee103b1dba794395b2aef4a97af2c0\",\"name\":\"@oxc-project/types\",\"version\":\"0.137.0\"},\"@phosphor-icons__react-2.1.10.tgz\":{\"integrity\":\"vt8Tvq8GLjheAZZYa+YG/pW7HDbov8El/MANW8pOAz4eGxrwhnbfrQZq0Cp4q8zBEu8NIhHdnr+r8thnfRSNYA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"bedf13beaf062e385e0196586be606fe95bb1c36e8bfc125fcc00d5bca4e033e1e1b1af08676dfad066ad02a78abccc112ef0d2211dd9ebfabf2d8677d148d60\",\"name\":\"@phosphor-icons/react\",\"version\":\"2.1.10\"},\"@radix-ui__number-1.1.2.tgz\":{\"integrity\":\"ceTwaxc4I5IOi97DgCotl3pqiyRGvffcc0oOsE2dQYaJOFIDsDt4VWG6xEbg1QePv9QWausCEIppud/tJ1wNig==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"71e4f06b173823920e8bdec3802a2d977a6a8b2446bdf7dc734a0eb04d9d418689385203b03b785561bac446e0d5078fbfd4166aeb02108a69b9dfed275c0d8a\",\"name\":\"@radix-ui/number\",\"version\":\"1.1.2\"},\"@radix-ui__primitive-1.1.4.tgz\":{\"integrity\":\"7AdCK9PQyiljKoBDbN8OuctCbd/esdwZPQ8RtOE3SsyQtUpiPb+ND75q0jEhC1m1ecBI0MFNeLJvwIh9iKHRcQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"ec07422bd3d0ca29632a80436cdf0eb9cb426ddfdeb1dc193d0f11b4e1374acc90b54a623dbf8d0fbe6ad231210b59b579c048d0c14d78b26fc0887d88a1d171\",\"name\":\"@radix-ui/primitive\",\"version\":\"1.1.4\"},\"@radix-ui__react-accessible-icon-1.1.10.tgz\":{\"integrity\":\"TraSwZUqTcVbiDV2/RXzAXC7aeVVXchq0daPFZE7zAxYFaMzjOUggLOfQH9KFLgRizuwVKZO/crveV1eeO3/ZQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"4eb692c1952a4dc55b883576fd15f30170bb69e5555dc86ad1d68f15913bcc0c5815a3338ce52080b39f407f4a14b8118b3bb054a64efdcaef795d5e78edff65\",\"name\":\"@radix-ui/react-accessible-icon\",\"version\":\"1.1.10\"},\"@radix-ui__react-accordion-1.2.14.tgz\":{\"integrity\":\"iE8YB9nmTBH8zd73ofBISZ8JCzgMoMkATJr7qDwa6u5F1+7mTM81V6fa71jgZ65rpjVpecDf1vSnwIFP9Ly1zw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"884f1807d9e64c11fccddef7a1f048499f090b380ca0c9004c9afba83c1aeaee45d7eee64ccf3557a7daef58e067ae6ba6356979c0dfd6f4a7c0814ff4bcb5cf\",\"name\":\"@radix-ui/react-accordion\",\"version\":\"1.2.14\"},\"@radix-ui__react-alert-dialog-1.1.17.tgz\":{\"integrity\":\"563ygGeyWPrxyVCNp7OV4rE2aIXhFPknpFyo4wbDlcyMMPZ6ySh+zC5WTvY0ZFLgPTg/QB6tA8PyDQyJ2b4cPg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"e7adf28067b258faf1c9508da7b395e2b1366885e114f927a45ca8e306c395cc8c30f67ac9287ecc2e564ef6346452e03d383f401ead03c3f20d0c89d9be1c3e\",\"name\":\"@radix-ui/react-alert-dialog\",\"version\":\"1.1.17\"},\"@radix-ui__react-arrow-1.1.10.tgz\":{\"integrity\":\"j2VTDz1vgCsmuG0k5lBfOcM8n5JPFqZBcMryasFjHYMhwxYL5SRUV5lMSUpRdNtw3D/Sv8pzJtrlAgkssYSsQQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"8f65530f3d6f802b26b86d24e6505f39c33c9f924f16a64170caf26ac1631d8321c3160be5245457994c494a5174db70dc3fd2bfca7326dae502092cb184ac41\",\"name\":\"@radix-ui/react-arrow\",\"version\":\"1.1.10\"},\"@radix-ui__react-aspect-ratio-1.1.10.tgz\":{\"integrity\":\"kbI7NrqhDeuytYrq7JjAsoXczvL8wgj2tc1MyaYWm+50bMKHCHQtVWCryslx4cCpmCTTkBcwQckE4CmmGV2haQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"91b23b36baa10debb2b58aeaec98c0b285dccef2fcc208f6b5cd4cc9a6169bee746cc28708742d5560abcac971e1c0a99824d390173041c904e029a6195da169\",\"name\":\"@radix-ui/react-aspect-ratio\",\"version\":\"1.1.10\"},\"@radix-ui__react-avatar-1.2.0.tgz\":{\"integrity\":\"am/CwltXtmtdtP+5FbYblYDnMa/zuKcMJP1i3/SJMDXXfj2mG+BTqLH2wucqeyyiQMursUtg/5cK+Nh2pCaSOA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"6a6fc2c25b57b66b5db4ffb915b61b9580e731aff3b8a70c24fd62dff4893035d77e3da61be053a8b1f6c2e72a7b2ca240cbabb14b60ff970af8d876a4269238\",\"name\":\"@radix-ui/react-avatar\",\"version\":\"1.2.0\"},\"@radix-ui__react-checkbox-1.3.5.tgz\":{\"integrity\":\"pREzrmNnVwGvYaBoM64huTRK7B3lrTRuwj8A9nwhPiEtMb+yudiWh6zWAqEtP0Dzd5+iBa1Ki7V1pCxV8ExMdA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"a51133ae63675701af61a06833ae21b9344aec1de5ad346ec23f00f67c213e212d31bfb2b9d89687acd602a12d3f40f3779fa205ad4a8bb575a42c55f04c4c74\",\"name\":\"@radix-ui/react-checkbox\",\"version\":\"1.3.5\"},\"@radix-ui__react-collapsible-1.1.14.tgz\":{\"integrity\":\"9bT+FvifX1FK2Mj6UEsTdyu0cN3JaA3KdfhaBao+ONrYFy/pyOy3TU1TNw7iOk1o+0hOEq67RojlUUmoFGwxyA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"f5b4fe16f89f5f514ad8c8fa504b13772bb470ddc9680dca75f85a05aa3e38dad8172fe9c8ecb74d4d53370ee23a4d68fb484e12aebb4688e55149a8146c31c8\",\"name\":\"@radix-ui/react-collapsible\",\"version\":\"1.1.14\"},\"@radix-ui__react-collection-1.1.10.tgz\":{\"integrity\":\"IVVz4EvBcKjrzKgof714qDnz/SzQAkLA2Emh5edlHbgcE6fNd3Un6CJLlaYcnm8N4JmAtzQgse4dOKxcD2yc9g==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"215573e04bc170a8ebcca8287fbd78a839f3fd2cd00242c0d849a1e5e7651db81c13a7cd777527e8224b95a61c9e6f0de09980b73420b1ee1d38ac5c0f6c9cf6\",\"name\":\"@radix-ui/react-collection\",\"version\":\"1.1.10\"},\"@radix-ui__react-compose-refs-1.1.3.tgz\":{\"integrity\":\"rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"ad838ff0e327bae3cc405d6e84f56518d7020e592890aa86144dc97311558889005cfec4bc5594962240b2dadaa72a5a04b24d1db64bea31a16d50c64f099584\",\"name\":\"@radix-ui/react-compose-refs\",\"version\":\"1.1.3\"},\"@radix-ui__react-context-1.1.4.tgz\":{\"integrity\":\"QwH4PO5urrbO+FaGd5Aglg+YJgWTyyuZ3g/6mKvsqraLkglDdckw9JafgL5McL5VEJ6EPNduPaT3ZE9BttDAqg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"4301f83cee6eaeb6cef85686779020960f98260593cb2b99de0ffa98abecaab68b92094375c930f4969f80be4c70be55109e843cd76e3da4f7644f41b6d0c0aa\",\"name\":\"@radix-ui/react-context\",\"version\":\"1.1.4\"},\"@radix-ui__react-context-menu-2.3.1.tgz\":{\"integrity\":\"XbrxS68W5dyiE4fAb96yvJwSVU5x66B20A99sD5Mk3xSWK/LqeOnx6TZnim1KieMjXS/CTFq8reOAjWxas2G8Q==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"5dbaf14baf16e5dca21387c06fdeb2bc9c12554e71eba076d00f7db03e4c937c5258afcba9e3a7c7a4d99e29b52a278c8d74bf09316af2b78e0235b16acd86f1\",\"name\":\"@radix-ui/react-context-menu\",\"version\":\"2.3.1\"},\"@radix-ui__react-dialog-1.1.17.tgz\":{\"integrity\":\"TDTYmpdq8dI2+Xgvgj9AJ8Ghqq+Eph/TRVEdaFQPDItIY+6QSkU7MJMeevw1568Yw/2Ijz8BTphPSP2XejKphw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"4c34d89a976af1d236f9782f823f4027c1a1aaaf84a61fd345511d68540f0c8b4863ee904a453b30931e7afc35e7af18c3fd888f3f014e984f48fd977a32a987\",\"name\":\"@radix-ui/react-dialog\",\"version\":\"1.1.17\"},\"@radix-ui__react-direction-1.1.2.tgz\":{\"integrity\":\"C3vFhbyi4SW3PmbAi6Awpu4OzJtd0MxGurvSsYtr7p7nM8RNB3VAF3CUmnp2j50knpkrRcB7+ycVXzgLgF6yNA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"0b7bc585bca2e125b73e66c08ba030a6ee0ecc9b5dd0cc46babbd2b18b6bee9ee733c44d0775401770949a7a768f9d249e992b45c07bfb27155f380b805eb234\",\"name\":\"@radix-ui/react-direction\",\"version\":\"1.1.2\"},\"@radix-ui__react-dismissable-layer-1.1.13.tgz\":{\"integrity\":\"2v+zNAWWe0ySxgC0D0yeXMPQ23xZVgXZTerTz+JKlmdRj6gfTqmCcR29jb6d290DezXPGgruHWDX/vYUebtErg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"daffb33405967b4c92c600b40f4c9e5cc3d0db7c595605d94dead3cfe24a9667518fa81f4ea982711dbd8dbe9ddbdd037b35cf1a0aee1d60d7fef61479bb44ae\",\"name\":\"@radix-ui/react-dismissable-layer\",\"version\":\"1.1.13\"},\"@radix-ui__react-dropdown-menu-2.1.18.tgz\":{\"integrity\":\"PZGV82gFk0WltDRI//SsG28ZIjlo9ANTmoNYg0jLNzXXiDsAy5PkOOYQaVD1pPxY6t7gxffb1QMD6qaUvsBZdw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"3d9195f368059345a5b43448fff4ac1b6f19223968f403539a83588348cb3735d7883b00cb93e438e6106950f5a4fc58eadee0c5f7dbd50303eaa694bec05977\",\"name\":\"@radix-ui/react-dropdown-menu\",\"version\":\"2.1.18\"},\"@radix-ui__react-focus-guards-1.1.4.tgz\":{\"integrity\":\"cot/aB/mOm0IYVYTTmQcEEK1M48lZWi8FlYe5nDPQQ8NYZUlXEFgncJ9p2Kzer3RKSrY7cTTpEMLZKNo9QoP5Q==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"728b7f681fe63a6d086156134e641c1042b5338f256568bc16561ee670cf410f0d6195255c41609dc27da762b37abdd1292ad8edc4d3a4430b64a368f50a0fe5\",\"name\":\"@radix-ui/react-focus-guards\",\"version\":\"1.1.4\"},\"@radix-ui__react-focus-scope-1.1.10.tgz\":{\"integrity\":\"Fas/lXQqhVvqwAb64s5RFeHiHYElZ6SUQbZaNd6EkfhP/Al7wTIQ9WIR4QVX475tlu5yFCEdDcJH6/UwsZjMWw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"15ab3f95742a855beac006fae2ce5115e1e21d812567a49441b65a35de8491f84ffc097bc13210f56211e10557e3be6d96ee7214211d0dc247ebf530b198cc5b\",\"name\":\"@radix-ui/react-focus-scope\",\"version\":\"1.1.10\"},\"@radix-ui__react-form-0.1.10.tgz\":{\"integrity\":\"1NfuvctVtX4sU3Mmq/IdrR8UunxiCMiVg3A5UENKhFzxUBeOyaQQ+lmaQaV7Tc8cqvBKsJL3/KGBsixK0D8WFg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"d4d7eebdcb55b57e2c537326abf21dad1f14ba7c6208c89583703950434a845cf150178ec9a410fa599a41a57b4dcf1caaf04ab092f7fca181b22c4ad03f1616\",\"name\":\"@radix-ui/react-form\",\"version\":\"0.1.10\"},\"@radix-ui__react-hover-card-1.1.17.tgz\":{\"integrity\":\"GjZQIEANVkuuWeztlKz6QEHe31ZX2iDfHzcTMCQVZXC0JyQrgfKWSC+LOOEw6aVV64zyjzobIzSA4AU4eKWrHA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"1a365020400d564bae59eced94acfa4041dedf5657da20df1f37133024156570b427242b81f296482f8b38e130e9a555eb8cf28f3a1b233480e0053878a5ab1c\",\"name\":\"@radix-ui/react-hover-card\",\"version\":\"1.1.17\"},\"@radix-ui__react-id-1.1.2.tgz\":{\"integrity\":\"orBC88futVpqCmhX1p4cvquNHsELQ+w+vBJnuj3ftETI5bJb0bZn3Tqu3SWN2IOcPycTnMGnhwoermvISt72sA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"a2b042f3c7eeb55a6a0a6857d69e1cbeab8d1ec10b43ec3ebc1267ba3ddfb444c8e5b25bd1b667dd3aaedd258dd8839c3f27139cc1a7870a1eae6bc84adef6b0\",\"name\":\"@radix-ui/react-id\",\"version\":\"1.1.2\"},\"@radix-ui__react-label-2.1.10.tgz\":{\"integrity\":\"ib0zvq2ZsAqKm5tRnqGJn3vOxSgIts5ToxsXT0q1S/GfLD1Zj7UOEnkw8u2w6sRmn47djpQWuSU1DCL1R29/yw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"89bd33bead99b00a8a9b9b519ea1899f7bcec52808b6ce53a31b174f4ab54bf19f2c3d598fb50e127930f2edb0eac4669f8edd8e9416b925350c22f5476f7fcb\",\"name\":\"@radix-ui/react-label\",\"version\":\"2.1.10\"},\"@radix-ui__react-menu-2.1.18.tgz\":{\"integrity\":\"lj8Rxjtn6zJq1oSbE/uDtAwCbB9BnxgHD+8MwJMuTh6u1dPamYhW9iuELr/Z8d0D/UysFblYYHeBPwi7T4k0YQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"963f11c63b67eb326ad6849b13fb83b40c026c1f419f18070fef0cc0932e4e1eaed5d3da998856f62b842ebfd9f1dd03fd4cac15b9586077813f08bb4f893461\",\"name\":\"@radix-ui/react-menu\",\"version\":\"2.1.18\"},\"@radix-ui__react-menubar-1.1.18.tgz\":{\"integrity\":\"hX7EGx/oFq6DPY27GQuP/2wP48GHf5LG6r06VgNJlG+znmDS8OfopZcRcGly3L4lsB9FqpmLx6JQSE9P3BUpyw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"857ec41b1fe816ae833d8dbb190b8fff6c0fe3c1877f92c6eabd3a560349946fb39e60d2f0e7e8a59711706972dcbe25b01f45aa998bc7a250484f4fdc1529cb\",\"name\":\"@radix-ui/react-menubar\",\"version\":\"1.1.18\"},\"@radix-ui__react-navigation-menu-1.2.16.tgz\":{\"integrity\":\"nJ0SkrSQgudyYhMiYeHA1ayLVuduEJCFLan1RZZN7c9kqzzCFLaU9kuy81uNtqzweM9YaQPgWzxi9MwQ9jZ04g==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"9c9d1292b49082e77262132261e1c0d5ac8b56e76e1090852da9f545964dedcf64ab3cc214b694f64bb2f35b8db6acf078cf586903e05b3c62f4cc10f63674e2\",\"name\":\"@radix-ui/react-navigation-menu\",\"version\":\"1.2.16\"},\"@radix-ui__react-one-time-password-field-0.1.10.tgz\":{\"integrity\":\"GHkcJ+WVj91At+OvUVTD4R3W0/wxw9t/sG5xFUBYXaCbtWiooZX5Md376QjJqgH4VsVyXrbVNHO2O4NYcmjfVg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"18791c27e5958fdd40b7e3af5154c3e11dd6d3fc31c3db7fb06e711540585da09bb568a8a195f931ddfbe908c9aa01f856c5725eb6d53473b63b83587268df56\",\"name\":\"@radix-ui/react-one-time-password-field\",\"version\":\"0.1.10\"},\"@radix-ui__react-password-toggle-field-0.1.5.tgz\":{\"integrity\":\"fVuA82u0b/fClpbEJv8yp1nU9eSvoSEOERsU/hhf3FXGPIvkmE7oEaHEu8poowoXO39/Va7zq2E0TUcYr1dBRg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"7d5b80f36bb46ff7c29696c426ff32a759d4f5e4afa1210e111b14fe185fdc55c63c8be4984ee811a1c4bbca68a30a173b7f7f55aef3ab61344d4718af574146\",\"name\":\"@radix-ui/react-password-toggle-field\",\"version\":\"0.1.5\"},\"@radix-ui__react-popover-1.1.17.tgz\":{\"integrity\":\"/YSAOdJ7YJvdn7bn5sdSx2egW+SKY+u7O5RyAVs94Ymrg2fg5QTSFPMRkzvhGyFuE4/qsmPBdrwYoZMZh/4f+g==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"fd848039d27b609bdd9fb6e7e6c752c767a05be48a63ebbb3b9472015b3de189ab8367e0e504d214f311933be11b216e138feab263c176bc18a1931987fe1ffa\",\"name\":\"@radix-ui/react-popover\",\"version\":\"1.1.17\"},\"@radix-ui__react-popper-1.3.1.tgz\":{\"integrity\":\"bhnq/0DEPTi2lsOD3J5rTL65qUKHbKbhqHsmN9TMiclSXpipi651ooUKPPp6G5lF/WiHBdn1s0Wuqsn+myVAvw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"6e19eaff40c43d38b696c383dc9e6b4cbeb9a942876ca6e1a87b2637d4cc89c9525e98a98bae75a2850a3cfa7a1b9945fd688705d9f5b345aeaac9fe9b2540bf\",\"name\":\"@radix-ui/react-popper\",\"version\":\"1.3.1\"},\"@radix-ui__react-portal-1.1.12.tgz\":{\"integrity\":\"m309havGzsjLHHaIX50G5PlvRs3xkgPCsGk/5PTvYm8D5q33yG0J7w/712PTOhid7NTaFETtnSXjngHQavvhVw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"9b7d3d85abc6cec8cb1c76885f9d06e4f96f46cdf19203c2b0693fe4f4ef626f03e6adf7c86d09ef0ffbd763d33a189decd4da1444ed9d25e39e01d06afbe157\",\"name\":\"@radix-ui/react-portal\",\"version\":\"1.1.12\"},\"@radix-ui__react-presence-1.1.6.tgz\":{\"integrity\":\"zdTk4PlUO0E18HnZ3wYbW0KkJJxWCdiNYp6g6X1PtONFhxVkg01vliTJAmwIszU6mHiyBOoW9P0rAugl5/hULQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"cdd4e4e0f9543b4135f079d9df061b5b42a4249c5609d88d629ea0e97d4fb4e345871564834d6f9624c9026c08b3353a9878b204ea16f4fd2b02e825e7f8542d\",\"name\":\"@radix-ui/react-presence\",\"version\":\"1.1.6\"},\"@radix-ui__react-primitive-2.1.6.tgz\":{\"integrity\":\"wetd0QI77DbvrPpTAvH1SqOxsYF2wZe5TNxqwOd5Ty4XDpV3dpV0s8K/1MGMJBeY5o7lg8ub5VIt1Ub+yVen6g==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"c1eb5dd1023bec36efacfa5302f1f54aa3b1b18176c197b94cdc6ac0e7794f2e170e9577769574b3c2bfd4c18c241798e68ee583cb9be5522dd546fec957a7ea\",\"name\":\"@radix-ui/react-primitive\",\"version\":\"2.1.6\"},\"@radix-ui__react-progress-1.1.10.tgz\":{\"integrity\":\"JYzEg60lk79PwKM27WZyKd7PW8O4OM5jOaFfRPfOyeXmMw7tLJh5kSj+CEjVTehszuwml/AdCzPGMXBTGf4BBw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"258cc483ad2593bf4fc0a336ed667229decf5bc3b838ce6339a15f44f7cec9e5e6330eed2c98799128fe0848d54de86cceec2697f01d0b33c631705319fe0107\",\"name\":\"@radix-ui/react-progress\",\"version\":\"1.1.10\"},\"@radix-ui__react-radio-group-1.4.1.tgz\":{\"integrity\":\"/SSxZdKEo2Eo29FFRKd06EfFDYp8HryKg0WYg7QLXaydPzl52YfSvCH2a3QDBRdtcuwACroJT8UVjQVgOJ7P9A==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"fd24b165d284a36128dbd14544a774e847c50d8a7c1ebc8a83459883b40b5dac9d3f3979d987d2bc21f66b740305176d72ec000aba094fc5158d0560389ecff4\",\"name\":\"@radix-ui/react-radio-group\",\"version\":\"1.4.1\"},\"@radix-ui__react-roving-focus-1.1.13.tgz\":{\"integrity\":\"9gkwneI0guf8JDmrFxPjJF6Ozzgioyw+/lonYNCwefS9ZHA05er0BVHiXr+LbWGHxUfczvMY6G1oiZZi1VzjRw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"f609309de23482e7fc2439ab1713e3245e8ecf3822a32c3efe5a2760d0b079f4bd647034e5eaf40551e25ebf8b6d6187c547dccef318e86d68899662d55ce347\",\"name\":\"@radix-ui/react-roving-focus\",\"version\":\"1.1.13\"},\"@radix-ui__react-scroll-area-1.2.12.tgz\":{\"integrity\":\"xuafVzQiTCLsyEjakowTdG3OgTXsmO7IdCiO77otIa+z44xoLNs9Do5eg7POFumIOCjtG6djfm6RKUKpUa/csA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"c6e69f5734224c22ecc848da928c13746dce8135ec98eec874288eefba2d21afb3e38c682cdb3d0e8e5e83b3ce16e9883828ed1ba7637e6e912942a951afdcb0\",\"name\":\"@radix-ui/react-scroll-area\",\"version\":\"1.2.12\"},\"@radix-ui__react-select-2.3.1.tgz\":{\"integrity\":\"w6eDvY78LE9ZUiNnXCA1QVK8RYN7k9galFv09kjVydJqBAgHd7Y9A6h0UJ/6DCZNGZMZrB2ohcSW1Bo9d8+wWA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"c3a783bd8efc2c4f595223675c20354152bc45837b93d81a945bf4f648d5c9d26a04080777b63d03a874509ffa0c264d199319ac1da885c496d41a3d77cfb058\",\"name\":\"@radix-ui/react-select\",\"version\":\"2.3.1\"},\"@radix-ui__react-separator-1.1.10.tgz\":{\"integrity\":\"Y6K6jLQCVfCnTL2MEtGxDLffkhNfEfHsEg3Wa8JU+IWdn3EWbLXd3OuOfQRN7p/W/cUce1WyTk3QeuAoDBzN9g==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"63a2ba8cb40255f0a74cbd8c12d1b10cb7df92135f11f1ec120dd66bc254f8859d9f71166cb5dddceb8e7d044dee9fd6fdc51c7b55b24e4dd07ae0280c1ccdf6\",\"name\":\"@radix-ui/react-separator\",\"version\":\"1.1.10\"},\"@radix-ui__react-slider-1.4.1.tgz\":{\"integrity\":\"r91WSpQucNGFKAIxT8FT0H0zyjd5tJlqObLp7LOMV4z49KoDCwjy01w3vDOU4e1wxhF9IgjYco7SB6byOW7Buw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"afdd564a942e70d1852802314fc153d07d33ca3779b4996a39b2e9ecb38c578cf8f4aa030b08f2d35c37bc3394e1ed70c6117d2208d8728ed207a6f2396ec1bb\",\"name\":\"@radix-ui/react-slider\",\"version\":\"1.4.1\"},\"@radix-ui__react-slot-1.3.0.tgz\":{\"integrity\":\"MojKku4U/miO8Av4Dkb+ctMAQx7JmY96LmtDQlAarCRtd7rN52QCSzBF+XAvr5S6coSVj9HEPBgHAHKEJVk/WA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"3288ca92ee14fe688ef00bf80e46fe72d300431ec9998f7a2e6b4342501aac246d77bacde764024b3045f9702faf94ba7284958fd1c43c180700728425593f58\",\"name\":\"@radix-ui/react-slot\",\"version\":\"1.3.0\"},\"@radix-ui__react-switch-1.3.1.tgz\":{\"integrity\":\"55bQtCnOB0BohomSHi6qvQXpJEEqUGDm6hRrM0Bph5OXwhSegqkd8IqgBAQkM1IlgUlWZIxpxRcpOEfRIgimyw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"e796d0b429ce0740688689921e2eaabd05e924412a5060e6ea146b334069879397c2149e82a91df08aa0040424335225814956648c69c517293847d12208a6cb\",\"name\":\"@radix-ui/react-switch\",\"version\":\"1.3.1\"},\"@radix-ui__react-tabs-1.1.15.tgz\":{\"integrity\":\"kxc9gI6/HfcU4nfMMVS3AmQK414kbU1IE6UCJmMmxjhO3cRPXOyYnmvyKD+ODt7q56nRq9l7Wovi6uaGwKgMlg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"93173d808ebf1df714e277cc3154b702640ae35e246d4d4813a502266326c6384eddc44f5cec989e6bf2283f8e0edeeae7a9d1abd97b5a8be2eae686c0a80c96\",\"name\":\"@radix-ui/react-tabs\",\"version\":\"1.1.15\"},\"@radix-ui__react-toast-1.2.17.tgz\":{\"integrity\":\"uL4kyyWy000pPL43fGGCV5qT6ZchCWEQZOSlkYiPwPt8Hy1iW38RjeptIvz1/SZesrW6Vn58Ct3sV7tfEfiAbw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"b8be24cb25b2d34d293cbe377c6182579a93e9972109611064e4a591888fc0fb7c1f2d625b7f118dea6d22fcf5fd265eb2b5ba567e7c0addec57bb5f11f8806f\",\"name\":\"@radix-ui/react-toast\",\"version\":\"1.2.17\"},\"@radix-ui__react-toggle-1.1.12.tgz\":{\"integrity\":\"AsAVsYNZIlRBsci7BhE+QyQeKd1h6TffJYt+lF0QQkd5OpQ3klfIByPsCb4G0h/Fq6PJwh1FYNluzBFYzhk4+w==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"02c015b18359225441b1c8bb06113e43241e29dd61e937df258b7e945d104247793a94379257c80723ec09be06d21fc5aba3c9c21d4560d96ecc1158ce1938fb\",\"name\":\"@radix-ui/react-toggle\",\"version\":\"1.1.12\"},\"@radix-ui__react-toggle-group-1.1.13.tgz\":{\"integrity\":\"Xb9PLtlvU66F36LiKba6dFswu6V2mDkgidO4fNSbQHQwmZ9ObxMIO17MN/LJ4aWJecVuSVLAHPZjyeMzJrgeiA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"5dbf4f2ed96f53ae85dfa2e229b6ba745b30bba57698392089d3b87cd49b407430999f4e6f13083b5ecc37f2c9e1a58979c56e4952c01cf663c9e33326b81e88\",\"name\":\"@radix-ui/react-toggle-group\",\"version\":\"1.1.13\"},\"@radix-ui__react-toolbar-1.1.13.tgz\":{\"integrity\":\"Za1l4f6fzTkGgz/iynAMN8iaqiKff2wm2/QwiLmHPtDQreWEBrvSimgQFIekxMUdRPhILM7xdIXxuS/o/DGZag==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"65ad65e1fe9fcd3906833fe2ca700c37c89aaa229f7f6c26dbf43088b9873ed0d0ade58406bbd28a68101487a4c4c51d44f8482ccef17485f1b92fe8fc31996a\",\"name\":\"@radix-ui/react-toolbar\",\"version\":\"1.1.13\"},\"@radix-ui__react-tooltip-1.2.10.tgz\":{\"integrity\":\"NlNe8D0dWEpVfXFli90IO6X07Josx/b1iu98tDnx9Xv0HT4wLIL+m2VOheMHhK7qbp2HoTBqALEFzGyZs/levw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"36535ef03d1d584a557d71658bdd083ba5f4ec9a2cc7f6f58aef7cb439f1f57bf41d3e302c82fe9b654e85e30784aeea6e9d87a1306a00b105cc6c99b3f95ebf\",\"name\":\"@radix-ui/react-tooltip\",\"version\":\"1.2.10\"},\"@radix-ui__react-use-callback-ref-1.1.2.tgz\":{\"integrity\":\"xCso9j1/u8sEgP1RNHjFrXJLApL8LiqOkI1R4ywuN00rxWdYg4oQXuwKLS3i0j5NWLromUD27/4nlxj2UFVvIw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"c42b28f63d7fbbcb0480fd513478c5ad724b0292fc2e2a8e908d51e32c2e374d2bc56758838a105eec0a2d2de2d23e4d58bae89940f6effe279718f650556f23\",\"name\":\"@radix-ui/react-use-callback-ref\",\"version\":\"1.1.2\"},\"@radix-ui__react-use-controllable-state-1.2.3.tgz\":{\"integrity\":\"PLzC90MS+ReootmjC597dvopoelpZ8Q61HJkDXZSExitIq7PL55vHNnesAHwguHK0aPfBnpdNzQtv1uliaqQrA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"3cbcc2f74312f917a8a2d9a30b9f7b76fa29a1e96967c43ad472640d76521318ad22aecf2f9e6f1cd9deb001f082e1cad1a3df067a5d37342dbf5ba589aa90ac\",\"name\":\"@radix-ui/react-use-controllable-state\",\"version\":\"1.2.3\"},\"@radix-ui__react-use-effect-event-0.0.3.tgz\":{\"integrity\":\"6c8ZqvPTWILEKnyVkP53EGRCcpnJiKTC21sS/6R1GF5xKyHJJWQEPfkqlcgUkdRQivd6tb23abUwe4ngWmY0JA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"e9cf19aaf3d35882c42a7c9590fe771064427299c988a4c2db5b12ffa475185e712b21c92564043df92a95c81491d4508af77ab5bdb769b5307b89e05a663424\",\"name\":\"@radix-ui/react-use-effect-event\",\"version\":\"0.0.3\"},\"@radix-ui__react-use-escape-keydown-1.1.2.tgz\":{\"integrity\":\"2uVLvLjgO7NZCWw01/FdqRwmA42J0BcjPMUCA+koFEOAb+zjqIP7SiFz/7zWPrKnVmSqr76Omq2ALyCuX4dhLw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"dae54bbcb8e03bb359096c34d7f15da91c26038d89d017233cc50203e9281443806fece3a883fb4a2173ffbcd63eb2a75664aaafbe8e9aad802f20ae5f87612f\",\"name\":\"@radix-ui/react-use-escape-keydown\",\"version\":\"1.1.2\"},\"@radix-ui__react-use-is-hydrated-0.1.1.tgz\":{\"integrity\":\"qwOiz4Tjo8CNnrOLAYUMXeZwDzXgXpvK4TKQPmWLECM9XoWvA6+0Z2/7Ag3A4ivjS4ovbLJPbskkxioFyBhr8A==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"ab03a2cf84e3a3c08d9eb38b01850c5de6700f35e05e9bcae132903e658b10233d5e85af03afb4676ffb020dc0e22be34b8a2f6cb24f6ec924c62a05c8186bf0\",\"name\":\"@radix-ui/react-use-is-hydrated\",\"version\":\"0.1.1\"},\"@radix-ui__react-use-layout-effect-1.1.2.tgz\":{\"integrity\":\"jrBWOxZITuGcnjRCM2t2U5ZPkCLxD+Ym6DjfssS5haTj2iiak/DOb64JeN6OdLfLgptb6/e2kKR+ZuTrGoZTPA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"8eb0563b16484ee19c9e3442336b7653964f9022f10fe626e838dfb2c4b985a4e3da289a93f0ce6fae0978de8e74b7cb829b5bebf7b690a47e66e4eb1a86533c\",\"name\":\"@radix-ui/react-use-layout-effect\",\"version\":\"1.1.2\"},\"@radix-ui__react-use-previous-1.1.2.tgz\":{\"integrity\":\"IGBQPtRFdhN6MQ8dbegVmBq1LVZluya3F1jWY+puIcQC3MHctRwTDSBWCkL/3ZcnMJLTMJ++Z+ktmvg0F89iCw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"2060503ed44576137a310f1d6de815981ab52d5665bb26b71758d663ea6e21c402dcc1dcb51c130d20560a42ffdd97273092d3309fbe67e92d9af83417cf620b\",\"name\":\"@radix-ui/react-use-previous\",\"version\":\"1.1.2\"},\"@radix-ui__react-use-rect-1.1.2.tgz\":{\"integrity\":\"d8a+bBY/FxikNPlgJJoaBHZX+zKVbWHYJGTLnLvveQgFSTntkGdEKv3JDtHrMS0DNYpllz2nRsTLGLKYttbpmw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"77c6be6c163f1718a434f960249a1a047657fb32956d61d82464cb9cbbef7908054939ed9067442afdc90ed1eb312d03358a65973da746c4cb18b298b6d6e99b\",\"name\":\"@radix-ui/react-use-rect\",\"version\":\"1.1.2\"},\"@radix-ui__react-use-size-1.1.2.tgz\":{\"integrity\":\"giWQp+4mxjBPt4KZ0MmyuykFNWfbDxKt4x+fPkRYmgRFJSbCZFzUglvMb/Kjn38tm10YP4ufiQZDx3zna4LU6w==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"822590a7ee26c6304fb78299d0c9b2bb29053567db0f12ade31f9f3e44589a04452526c2645cd4825bcc6ff2a39f7f2d9b5d183f8b9f890643c77ce76b82d4eb\",\"name\":\"@radix-ui/react-use-size\",\"version\":\"1.1.2\"},\"@radix-ui__react-visually-hidden-1.2.6.tgz\":{\"integrity\":\"jCE0WljWifTI4niIMCll06kGpsJTAPiZVU9H4WR1N6qW7At9ystHbN7dDB+we2xH535roFHj7qKS+RGj0FMDWQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"8c21345a58d689f4c8e27888302965d3a906a6c25300f899554f47e1647537aa96ec0b7dcacb476cdedd0c1fb07b6c47e77e6ba051e3eea292f911a3d0530359\",\"name\":\"@radix-ui/react-visually-hidden\",\"version\":\"1.2.6\"},\"@radix-ui__rect-1.1.2.tgz\":{\"integrity\":\"xnXE7wG13PI+cxieVssYXlQJuYVRhH9NBoxt3KNwzghDIA69GMm7d4wXRouHIYjE+KvS6U/MsMO73NdS2MH9ZA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"c675c4ef01b5dcf23e73189e56cb185e5409b98551847f4d068c6ddca370ce0843200ebd18c9bb778c17468b872188c4f8abd2e94fccb0c3bbdcd752d8c1fd64\",\"name\":\"@radix-ui/rect\",\"version\":\"1.1.2\"},\"@rolldown__binding-android-arm64-1.1.3.tgz\":{\"integrity\":\"DT6Z3PhvioeHMvxo+xHc3KtqggrI7CCTXCmC2h/5zUlp5jVitv7XEy+9q5/7v8IolhlioawpMo8Kg0EEBy7J0g==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"0d3e99dcf86f8a878732fc68fb11dcdcab6a820ac8ec20935c2982da1ff9cd4969e63562b6fed7132fbdab9ffbbfc228961962a1ac29328f0a834104072ec9d2\",\"name\":\"@rolldown/binding-android-arm64\",\"version\":\"1.1.3\"},\"@rolldown__binding-darwin-arm64-1.1.3.tgz\":{\"integrity\":\"0NwgwsjM7LrsuVnXMK3koTpagBNOhloc/BNjKqZjv4V5zI5r13qx69uVhRx+o5Z0yy4Hzq+lpy7TAgUG/ocvrw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"d0dc20c2c8ccecbaecb959d730ade4a13a5a80134e865a1cfc13632aa663bf8579cc8e6bd77ab1ebdb95851c7ea39674cb2e07ceafa5a72ed3020506fe872faf\",\"name\":\"@rolldown/binding-darwin-arm64\",\"version\":\"1.1.3\"},\"@rolldown__binding-darwin-x64-1.1.3.tgz\":{\"integrity\":\"YtiBp4disu6V560loT6PjMdiRaWmVvDNrUunAalbiFx2ggeJwxdAsgZMcoGP17uyAsTwAj5V1niksxlHnVQ1Sw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"62d881a78762b2ee95e7ad25a13e8f8cc76245a5a656f0cdad4ba701a95b885c76820789c31740b2064c72818fd7bbb202c4f0023e55d678a4b319479d54354b\",\"name\":\"@rolldown/binding-darwin-x64\",\"version\":\"1.1.3\"},\"@rolldown__binding-freebsd-x64-1.1.3.tgz\":{\"integrity\":\"yD3EkEdXk2LypPxnf/kSZHirarsI8gcPzc62SukhR9VJTyvV+F9Q/GxWNuCojc7sXyuVC4DxRGhdDK4X8VSsbw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"c83dc49047579362f2a4fc677ff9126478ab6abb08f2070fcdceb64ae92147d5494f2bd5f85f50fc6c5636e0a88dceec5f2b950b80f144685d0cae17f154ac6f\",\"name\":\"@rolldown/binding-freebsd-x64\",\"version\":\"1.1.3\"},\"@rolldown__binding-linux-arm-gnueabihf-1.1.3.tgz\":{\"integrity\":\"c+8vieQbsD7HNAHKIA34w0GJ9FedFFuJGD+7E6vz7Q3uqAIugL5p45fhlsj4UaAsHpcmlqugBWMhA0/j7o0sIg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"73ef2f89e41bb03ec73401ca200df8c34189f4579d145b89183fbb13abf3ed0deea8022e80be69e397e196c8f851a02c1e972696aba0056321034fe3ee8d2c22\",\"name\":\"@rolldown/binding-linux-arm-gnueabihf\",\"version\":\"1.1.3\"},\"@rolldown__binding-linux-arm64-gnu-1.1.3.tgz\":{\"integrity\":\"50jD0uUwLvur7Zz9LHz17kaAdTPjn5wN93hEgjvmYFRZwiR7ZJYovTd5ipyWJDAnXKvZ+wgc+/Ika6dwSF5OcA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"e748c3d2e5302efbabed9cfd2c7cf5ee46807533e39f9c0df77844823be6605459c2247b649628bd37798a9c962430275cabd9fb081cfbf2246ba770485e4e70\",\"name\":\"@rolldown/binding-linux-arm64-gnu\",\"version\":\"1.1.3\"},\"@rolldown__binding-linux-arm64-musl-1.1.3.tgz\":{\"integrity\":\"BO9+oPL8K9poZJBfYPsXNtYjPE5uM3qeehT3aFcW4LITOl+iSqhp0abzjR2nWBUNjIZeKXjAEWBZ64WjNoHd6w==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"04ef7ea0f2fc2bda6864905f60fb1736d6233c4e6e337a9e7a14f7685716e0b2133a5fa24aa869d1a6f38d1da758150d8c865e2978c0116059eb85a33681ddeb\",\"name\":\"@rolldown/binding-linux-arm64-musl\",\"version\":\"1.1.3\"},\"@rolldown__binding-linux-ppc64-gnu-1.1.3.tgz\":{\"integrity\":\"f3VpLB1vQ0Eo6ecr/6cekLnvYMFF4YBFoVGkfkvPLq1bAkbAwHYQPZKoAmG6OJyTcxxoC+AvezGx/S1obNC0Mw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"7f75692c1d6f434128e9e72bffa71e90b9ef60c145e18045a151a47e4bcf2ead5b0246c0c076103d92a80261ba389c93731c680be02f7b31b1fd2d686cd0b433\",\"name\":\"@rolldown/binding-linux-ppc64-gnu\",\"version\":\"1.1.3\"},\"@rolldown__binding-linux-s390x-gnu-1.1.3.tgz\":{\"integrity\":\"AmurZ26Pqx/RI9N1gzEOCklkKXl927yjfXWUUS0O7Puh8ARM/Ob8qfrD3qnWksScdw6cSrW5PSHE9DyLu7+PtA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"026bab676e8fab1fd123d37583310e0a496429797ddbbca37d7594512d0eecfba1f0044cfce6fca9fac3dea9d692c49c770e9c4ab5b93d21c4f43c8bbbbf8fb4\",\"name\":\"@rolldown/binding-linux-s390x-gnu\",\"version\":\"1.1.3\"},\"@rolldown__binding-linux-x64-gnu-1.1.3.tgz\":{\"integrity\":\"JJpqs8bRGITDOdbkNKnlojzBabbOHrqjSvDr0IVsZObE1lBcPjxItUEY9eWIDbxaJ3cGrXPWGfGkIxFijg/URg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"249a6ab3c6d11884c339d6e434a9e5a23cc169b6ce1ebaa34af0ebd0856c64e6c4d6505c3e3c48b54118f5e5880dbc5a277706ad73d619f1a42311628e0fd446\",\"name\":\"@rolldown/binding-linux-x64-gnu\",\"version\":\"1.1.3\"},\"@rolldown__binding-linux-x64-musl-1.1.3.tgz\":{\"integrity\":\"rSJcdjPxzA/by/6/rYs+v+bXU7UjvnbUWz8MJb6kh6+knqB1dCrtHg0uu7C/4haqJvqdkYHQ5IGn+tCH9GLW/g==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"ad225c7633f1cc0fdbcbfebfad8b3ebfe6d753b523be76d45b3f0c25bea487afa49ea075742aed1e0d2ebbb0bfe216aa26fa9d9181d0e481a7fad087f462d6fe\",\"name\":\"@rolldown/binding-linux-x64-musl\",\"version\":\"1.1.3\"},\"@rolldown__binding-openharmony-arm64-1.1.3.tgz\":{\"integrity\":\"hQ3/PYkDJICgevvyNcVrihVeqq7k1Pp3VZ9lY+dauAYUJKO+auqApvANhvR1An9BhmqYKvW2Mu1F9u4DXSMLxQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"850dff3d89032480a07afbf235c56b8a155eaaaee4d4fa77559f6563e75ab8061424a3be6aea80a6f00d86f475027f41866a982af5b632ed45f6ee035d230bc5\",\"name\":\"@rolldown/binding-openharmony-arm64\",\"version\":\"1.1.3\"},\"@rolldown__binding-wasm32-wasi-1.1.3.tgz\":{\"integrity\":\"Elcv/BtML9lXrV6JuKITc/grN2kYV9gjsQpW8Jfw4ioK0TOkjBjye0nnyqQNy9STNaI20lXNaQBRrD5gSgR0Yg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"12572ffc1b4c2fd957ad5e89b8a21373f82b37691857d823b10a56f097f0e22a0ad133a48c18f27b49e7caa40dcbd49335a236d255cd690051ac3e604a047462\",\"name\":\"@rolldown/binding-wasm32-wasi\",\"version\":\"1.1.3\"},\"@rolldown__binding-win32-arm64-msvc-1.1.3.tgz\":{\"integrity\":\"2DrEfhluH9yhiaFApmsjsjwrSYbNcY1oFTzYSP1a535jDbV98zCFanA/96TBUd0iDFcxGmw9QRExwGCXz3U+/g==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"d83ac47e196e1fdca189a140a66b23b23c2b4986cd718d68153cd848fd5ae77e630db57df330856a703ff7a4c151dd220c57311a6c3d411131c06097cf753efe\",\"name\":\"@rolldown/binding-win32-arm64-msvc\",\"version\":\"1.1.3\"},\"@rolldown__binding-win32-x64-msvc-1.1.3.tgz\":{\"integrity\":\"OL4OMk7UPXOeVGGd3qo5zJyPIljf4AFgk5QAkPPS+OoLuOOozhuaQGC18MxVTnw/06q93gShAJzlwnSCY9YtqA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"38be0e324ed43d739e54619ddeaa39cc9c8f2258dfe0016093940090f3d2f8ea0bb8e3a8ce1b9a4060b5f0cc554e7c3fd3aabdde04a1009ce5c2748263d62da8\",\"name\":\"@rolldown/binding-win32-x64-msvc\",\"version\":\"1.1.3\"},\"@rolldown__pluginutils-1.0.1.tgz\":{\"integrity\":\"2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"da3f5b1ade4987c863faf3ed8333ed97bda3d324711c0cae9a8a3a4cd7c08ec2c1d3852da52bcf6cf703701331cfb9fef42601d1cd46c501716118368e29aa1b\",\"name\":\"@rolldown/pluginutils\",\"version\":\"1.0.1\"},\"@tailwindcss__node-4.3.1.tgz\":{\"integrity\":\"6NDaqRoAMSXD1mr/RXu0HBvNE9a2n5tHPsxu9XHLws8o4Twes5rBM2205SUUiJ9goAtadrN6xTGX0UDEwp/N4A==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"e8d0daa91a003125c3d66aff457bb41c1bcd13d6b69f9b473ecc6ef571cbc2cf28e13c1eb39ac1336db4e52514889f60a00b5a76b37ac53197d140c4c29fcde0\",\"name\":\"@tailwindcss/node\",\"version\":\"4.3.1\"},\"@tailwindcss__oxide-4.3.1.tgz\":{\"integrity\":\"yVPyo8RNkabVr3O2EhHEE0Rewu7YKzc1DhIqfL46LKveFrmu9XbDazNOJY7/GRuvw1h6u3utWnR29H/p5JPlgA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"c953f2a3c44d91a6d5af73b61211c413445ec2eed82b37350e122a7cbe3a2cabde16b9aef576c36b334e258eff191bafc3587abb7bad5a7476f47fe9e493e580\",\"name\":\"@tailwindcss/oxide\",\"version\":\"4.3.1\"},\"@tailwindcss__oxide-android-arm64-4.3.1.tgz\":{\"integrity\":\"SVlyf61g374l5cHyg8x9kf5xmLcOaxvOTsbsqDnSsDJaKOEFZ7GCvi84VAVGpxojYOs1+3K6M0UjXfqPU8vmOQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"4959727fad60dfbe25e5c1f283cc7d91fe7198b70e6b1bce4ec6eca839d2b0325a28e10567b182be2f38540546a71a2360eb35fb72ba3345235dfa8f53cbe639\",\"name\":\"@tailwindcss/oxide-android-arm64\",\"version\":\"4.3.1\"},\"@tailwindcss__oxide-darwin-arm64-4.3.1.tgz\":{\"integrity\":\"hVnWLwv+e/l7c4WKyVtHVrIPvYdqWHjRB3MDIqARynzFtnQg85kmQEFCbV9Ja0VVx4xXTIiDWY60Y7iz/iNoDA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"8559d62f0bfe7bf97b73858ac95b4756b20fbd876a5878d107730322a011ca7cc5b67420f399264041426d5f496b4555c78c574c8883598eb463b8b3fe23680c\",\"name\":\"@tailwindcss/oxide-darwin-arm64\",\"version\":\"4.3.1\"},\"@tailwindcss__oxide-darwin-x64-4.3.1.tgz\":{\"integrity\":\"Cf7abu0WVgbhU7ANgPUnSAvm7nCvMweusHb8FnaHlLfv/Caq4GYaEZg7ZImzzmjx4lIAfuS8q+eLIS7A7IzxIg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"09feda6eed165606e153b00d80f527480be6ee70af3307aeb076fc16768794b7effc26aae0661a11983b6489b3ce68f1e252007ee4bcabe78b212ec0ec8cf122\",\"name\":\"@tailwindcss/oxide-darwin-x64\",\"version\":\"4.3.1\"},\"@tailwindcss__oxide-freebsd-x64-4.3.1.tgz\":{\"integrity\":\"ZZqzX2Y+GXtXXfqSfpJhDm60OoZfvLHLCgm+J7NVqgHHJjG/m9ugZI77RwTsVd4fnBJuCFP6Ae6kTJb71UdS8g==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"659ab35f663e197b575dfa927e92610e6eb43a865fbcb1cb0a09be27b355aa01c72631bf9bdba0648efb4704ec55de1f9c126e0853fa01eea44c96fbd54752f2\",\"name\":\"@tailwindcss/oxide-freebsd-x64\",\"version\":\"4.3.1\"},\"@tailwindcss__oxide-linux-arm-gnueabihf-4.3.1.tgz\":{\"integrity\":\"/Ah/xik0LaMYfv9DZ0S/t4pBlBNYOcqtRwusjgovHkvT8ixueWCLyJjsaF5kQIckjb4IT8Q6K6p/iPmZMixYgg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"fc087fc629342da3187eff436744bfb78a4194135839caad470bac8e0a2f1e4bd3f22c6e79608bc898ec685e644087248dbe084fc43a2baa7f88f999322c5882\",\"name\":\"@tailwindcss/oxide-linux-arm-gnueabihf\",\"version\":\"4.3.1\"},\"@tailwindcss__oxide-linux-arm64-gnu-4.3.1.tgz\":{\"integrity\":\"gqdFoVJlw444GvpnheZLHmvTzSxI/cOUUh2KSNejQjTcYkW062SVD+En0rUgD+QV91bz1XGIGtt1HJd48xUGbQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"82a745a15265c38e381afa6785e64b1e6bd3cd2c48fdc394521d8a48d7a34234dc6245b4eb64950fe127d2b5200fe415f756f3d571881adb751c9778f315066d\",\"name\":\"@tailwindcss/oxide-linux-arm64-gnu\",\"version\":\"4.3.1\"},\"@tailwindcss__oxide-linux-arm64-musl-4.3.1.tgz\":{\"integrity\":\"Bwv9KwOvE0VKa86xPFif9b9c3Y1NxOV1P0gLti/IYaWEsQYZXDlxfGEtA8mdDZ7SG3wyNXAWYT5SIn3giL57oA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"070bfd2b03af13454a6bceb13c589ff5bf5cdd8d4dc4e5753f480bb62fc861a584b106195c39717c612d03c99d0d9ed21b7c32357016613e52227de088be7ba0\",\"name\":\"@tailwindcss/oxide-linux-arm64-musl\",\"version\":\"4.3.1\"},\"@tailwindcss__oxide-linux-x64-gnu-4.3.1.tgz\":{\"integrity\":\"Ymi8O8T15HYQdOUWUtTI6ldN0neHP85FC+Qz32xTcZ7iJXtem/x8ITev0o1e9e5rkqj4lONZfTRLvkmin1+tKg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"6268bc3bc4f5e4761074e51652d4c8ea574dd277873fce450be433df6c53719ee2257b5e9bfc7c2137afd28d5ef5ee6b92a8f894e3597d344bbe49a29f5fad2a\",\"name\":\"@tailwindcss/oxide-linux-x64-gnu\",\"version\":\"4.3.1\"},\"@tailwindcss__oxide-linux-x64-musl-4.3.1.tgz\":{\"integrity\":\"M+P/91qJ6uILLw4k2G93GMDRAXj61SMvFQYt39AqvUqYgExXpLL5aepfns7sj4HiAQeolirQF9E0lzRvdf4zPQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"33e3fff75a89eae20b2f0e24d86f7718c0d10178fad5232f15062ddfd02abd4a98804c57a4b2f969ea5f9eceec8f81e20107a8962ad017d13497346f75fe333d\",\"name\":\"@tailwindcss/oxide-linux-x64-musl\",\"version\":\"4.3.1\"},\"@tailwindcss__oxide-wasm32-wasi-4.3.1.tgz\":{\"integrity\":\"zsM8uOeqvVGHsAXsJxsT28ttosFahLJKCLOTUBqRAtKnVgGSRitds9T432QiT8b77Yga7JIBkulIRRlJPtYhRA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"cec33cb8e7aabd5187b005ec271b13dbcb6da2c15a84b24a08b393501a9102d2a7560192462b5db3d4f8df64224fc6fbed881aec920192e9484519493ed62144\",\"name\":\"@tailwindcss/oxide-wasm32-wasi\",\"version\":\"4.3.1\"},\"@tailwindcss__oxide-win32-arm64-msvc-4.3.1.tgz\":{\"integrity\":\"aiNvSq9BsVk8V513lDKlrCFAgf8qBMPZTpgEhInL+NwQqs97mYmupVMrPrgBBSL8Pv/0zXu9MrMF9rMun1ZeNg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"6a236f4aaf41b1593c579d779432a5ac214081ff2a04c3d94e98048489cbf8dc10aacf7b9989aea5532b3eb8010522fc3efff4cd7bbd32b305f6b32e9f565e36\",\"name\":\"@tailwindcss/oxide-win32-arm64-msvc\",\"version\":\"4.3.1\"},\"@tailwindcss__oxide-win32-x64-msvc-4.3.1.tgz\":{\"integrity\":\"xDEyu1rg290472FEGaKHnzyDyh5QH+AlWvsU5hMoMtPpzmKlRI0jaYKCgSHDYtaQWZOYbMaduSyCwFwY4n1HmA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"c43132bb5ae0dbdd38ef614419a2879f3c83ca1e501fe0255afb14e6132832d3e9ce62a5448d236982828121c362d6905993986cc69db92c82c05c18e27d4798\",\"name\":\"@tailwindcss/oxide-win32-x64-msvc\",\"version\":\"4.3.1\"},\"@tailwindcss__postcss-4.3.1.tgz\":{\"integrity\":\"dNJuNbdEJT/SWRuXTYP1WSamelsz3ztkUsdtWQPjrexysrTpaEPM40P/71knXiXLYEojqPOEGitVLLpPMS5T6A==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"74d26e35b744253fd2591b974d83f55926a67a5b33df3b6452c76d5903e3adec72b2b4e96843cce343ffef59275e25cb604a23a8f3841a2b552cba4f312e53e8\",\"name\":\"@tailwindcss/postcss\",\"version\":\"4.3.1\"},\"@tanstack__query-core-5.101.2.tgz\":{\"integrity\":\"hH5MLoJhF7KaIGd7q3xTXGXvslI+GYlM1Z/35aSHHWaCJWB7XvTSHYuV3eM7tw+aE0mT/xMro4M4Q9rCGHT0lw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"847e4c2e826117b29a20677bab7c535c65efb2523e19894cd59ff7e5a4871d668225607b5ef4d21d8b95dde33bb70f9a134993ff132ba3833843dac21874f497\",\"name\":\"@tanstack/query-core\",\"version\":\"5.101.2\"},\"@tanstack__react-query-5.101.2.tgz\":{\"integrity\":\"seDkr6kzGzX1okaaTtZPtgA688CDPlXUz1C6xSg0ESqn04Vuc8tlrYms1s3de+znBqhPVxFRfpAfUf+6XvfPWg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"b1e0e4afa9331b35f5a2469a4ed64fb6003af3c0833e55d4cf50bac52834112aa7d3856e73cb65ad89acd6cddd7bece706a84f5711517e901f51ffba5ef7cf5a\",\"name\":\"@tanstack/react-query\",\"version\":\"5.101.2\"},\"@tauri-apps__api-2.10.1.tgz\":{\"integrity\":\"hKL/jWf293UDSUN09rR69hrToyIXBb8CjGaWC7gfinvnQrBVvnLr08FeFi38gxtugAVyVcTa5/FD/Xnkb1siBw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"84a2ff8d67f6f77503494374f6b47af61ad3a3221705bf028c66960bb81f8a7be742b055be72ebd3c15e162dfc831b6e80057255c4dae7f143fd79e46f5b2207\",\"name\":\"@tauri-apps/api\",\"version\":\"2.10.1\"},\"@tauri-apps__api-2.11.1.tgz\":{\"integrity\":\"M2FPuYND2m+wh5hfW9ZpSdxMPdEJovPBWwoHJmwUpysTYNHaOkVFN419m/K0LIgjb/7KU2vBgsUepJWugQCvAA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"33614fb98343da6fb087985f5bd66949dc4c3dd109a2f3c15b0a07266c14a72b1360d1da3a4545378d7d9bf2b42c88236ffeca536bc182c51ea495ae8100af00\",\"name\":\"@tauri-apps/api\",\"version\":\"2.11.1\"},\"@tauri-apps__cli-2.10.1.tgz\":{\"integrity\":\"jQNGF/5quwORdZSSLtTluyKQ+o6SMa/AUICfhf4egCGFdMHqWssApVgYSbg+jmrZoc8e1DscNvjTnXtlHLS11g==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"8d034617fe6abb03917594922ed4e5bb2290fa8e9231afc050809f85fe1e80218574c1ea5acb00a5581849b83e8e6ad9a1cf1ed43b1c36f8d39d7b651cb4b5d6\",\"name\":\"@tauri-apps/cli\",\"version\":\"2.10.1\"},\"@tauri-apps__cli-darwin-arm64-2.10.1.tgz\":{\"integrity\":\"Z2OjCXiZ+fbYZy7PmP3WRnOpM9+Fy+oonKDEmUE6MwN4IGaYqgceTjwHucc/kEEYZos5GICve35f7ZiizgqEnQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"6763a3097899f9f6d8672ecf98fdd64673a933df85cbea289ca0c499413a330378206698aa071e4e3c07b9c73f904118668b391880af7b7e5fed98a2ce0a849d\",\"name\":\"@tauri-apps/cli-darwin-arm64\",\"version\":\"2.10.1\"},\"@tauri-apps__cli-darwin-x64-2.10.1.tgz\":{\"integrity\":\"V/irQVvjPMGOTQqNj55PnQPVuH4VJP8vZCN7ajnj+ZS8Kom1tEM2hR3qbbIRoS3dBKs5mbG8yg1WC+97dq17Pw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"57f8ab415be33cc18e4d0a8d8f9e4f9d03d5b87e1524ff2f64237b6a39e3f994bc2a89b5b44336851dea6db211a12ddd04ab3999b1bcca0d560bef7b76ad7b3f\",\"name\":\"@tauri-apps/cli-darwin-x64\",\"version\":\"2.10.1\"},\"@tauri-apps__cli-linux-arm-gnueabihf-2.10.1.tgz\":{\"integrity\":\"Hyzwsb4VnCWKGfTw+wSt15Z2pLw2f0JdFBfq2vHBOBhvg7oi6uhKiF87hmbXOBXUZaGkyRDkCHsdzJcIfoJC2w==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"1f2cf0b1be159c258a19f4f0fb04add79676a4bc367f425d1417eadaf1c138186f83ba22eae84a885f3b8666d73815d465a1a4c910e4087b1dcc97087e8242db\",\"name\":\"@tauri-apps/cli-linux-arm-gnueabihf\",\"version\":\"2.10.1\"},\"@tauri-apps__cli-linux-arm64-gnu-2.10.1.tgz\":{\"integrity\":\"OyOYs2t5GkBIvyWjA1+h4CZxTcdz1OZPCWAPz5DYEfB0cnWHERTnQ/SLayQzncrT0kwRoSfSz9KxenkyJoTelA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"3b2398b36b791a4048bf25a3035fa1e026714dc773d4e64f09600fcf90d811f0747275871114e743f48b6b24339dcad3d24c11a127d2cfd2b17a79322684de94\",\"name\":\"@tauri-apps/cli-linux-arm64-gnu\",\"version\":\"2.10.1\"},\"@tauri-apps__cli-linux-arm64-musl-2.10.1.tgz\":{\"integrity\":\"MIj78PDDGjkg3NqGptDOGgfXks7SYJwhiMh8SBoZS+vfdz7yP5jN18bNaLnDhsVIPARcAhE1TlsZe/8Yxo2zqg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"3088fbf0f0c31a3920dcda86a6d0ce1a07d792ced2609c2188c87c481a194bebdf773ef23f98cdd7c6cd68b9c386c5483c045c0211354e5b197bff18c68db3aa\",\"name\":\"@tauri-apps/cli-linux-arm64-musl\",\"version\":\"2.10.1\"},\"@tauri-apps__cli-linux-riscv64-gnu-2.10.1.tgz\":{\"integrity\":\"X0lvOVUg8PCVaoEtEAnpxmnkwlE1gcMDTqfhbefICKDnOTJ5Est3qL0SrWxizDackIOKBcvtpejrSiVpuJI1kw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"5f496f395520f0f0956a812d1009e9c669e4c2513581c3034ea7e16de7c808a0e739327912cb77a8bd12ad6c62cc369c90838a05cbeda5e8eb4a2569b8923593\",\"name\":\"@tauri-apps/cli-linux-riscv64-gnu\",\"version\":\"2.10.1\"},\"@tauri-apps__cli-linux-x64-gnu-2.10.1.tgz\":{\"integrity\":\"2/12bEzsJS9fAKybxgicCDFxYD1WEI9kO+tlDwX5znWG2GwMBaiWcmhGlZ8fi+DMe9CXlcVarMTYc0L3REIRxw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"dbfd766c4cec252f5f00ac9bc6089c083171603d56108f643beb650f05f9ce7586d86c0c05a896726846959f1f8be0cc7bd09795c55aacc4d87342f7444211c7\",\"name\":\"@tauri-apps/cli-linux-x64-gnu\",\"version\":\"2.10.1\"},\"@tauri-apps__cli-linux-x64-musl-2.10.1.tgz\":{\"integrity\":\"Y8J0ZzswPz50UcGOFuXGEMrxbjwKSPgXftx5qnkuMs2rmwQB5ssvLb6tn54wDSYxe7S6vlLob9vt0VKuNOaCIQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"63c274673b303f3e7451c18e16e5c610caf16e3c0a48f8177edc79aa792e32cdab9b0401e6cb2f2dbead9f9e300d26317bb4babe52e86fdbedd152ae34e68221\",\"name\":\"@tauri-apps/cli-linux-x64-musl\",\"version\":\"2.10.1\"},\"@tauri-apps__cli-win32-arm64-msvc-2.10.1.tgz\":{\"integrity\":\"iSt5B86jHYAPJa/IlYw++SXtFPGnWtFJriHn7X0NFBVunF6zu9+/zOn8OgqIWSl8RgzhLGXQEEtGBdR4wzpVgg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"892b7907cea31d800f25afc8958c3ef925ed14f1a75ad149ae21e7ed7d0d14156e9c5eb3bbdfbfcce9fc3a0a8859297c460ce12c65d0104b4605d478c33a5582\",\"name\":\"@tauri-apps/cli-win32-arm64-msvc\",\"version\":\"2.10.1\"},\"@tauri-apps__cli-win32-ia32-msvc-2.10.1.tgz\":{\"integrity\":\"gXyxgEzsFegmnWywYU5pEBURkcFN/Oo45EAwvZrHMh+zUSEAvO5E8TXsgPADYm31d1u7OQU3O3HsYfVBf2moHw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"817cb1804cec15e8269d6cb0614e6910151191c14dfcea38e44030bd9ac7321fb3512100bcee44f135ec80f003626df5775bbb3905373b71ec61f5417f69a81f\",\"name\":\"@tauri-apps/cli-win32-ia32-msvc\",\"version\":\"2.10.1\"},\"@tauri-apps__cli-win32-x64-msvc-2.10.1.tgz\":{\"integrity\":\"6Cn7YpPFwzChy0ERz6djKEmUehWrYlM+xTaNzGPgZocw3BD7OfwfWHKVWxXzdjEW2KfKkHddfdxK1XXTYqBRLg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"e829fb6293c5c330a1cb4111cfa7632849947a15ab62533ec5368dcc63e0668730dc10fb39fc1f5872955b15f3763116d8a7ca90775d7ddc4ad575d362a0512e\",\"name\":\"@tauri-apps/cli-win32-x64-msvc\",\"version\":\"2.10.1\"},\"@tauri-apps__plugin-dialog-2.7.1.tgz\":{\"integrity\":\"OK1UBXYt+ojcmxMktzzuyonYIFta8CmAASpX+CA+DTGK24KlHjhYI6x2iOJ/TjZF4N7/ACK1oFmEOjIY9IhzOQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"38ad5405762dfa88dc9b1324b73ceeca89d8205b5af02980012a57f8203e0d318adb82a51e385823ac7688e27f4e3645e0deff0022b5a059843a3218f4887339\",\"name\":\"@tauri-apps/plugin-dialog\",\"version\":\"2.7.1\"},\"@tauri-apps__plugin-notification-2.3.3.tgz\":{\"integrity\":\"Zw+ZH18RJb41G4NrfHgIuofJiymusqN+q8fGUIIV7vyCH+5sSn5coqRv/MWB9qETsUs97vmU045q7OyseCV3Qg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"670f991f5f1125be351b836b7c7808ba87c98b29aeb2a37eabc7c6508215eefc821fee6c4a7e5ca2a46ffcc581f6a113b14b3deef994d38e6aececac78257742\",\"name\":\"@tauri-apps/plugin-notification\",\"version\":\"2.3.3\"},\"@tauri-apps__plugin-opener-2.5.4.tgz\":{\"integrity\":\"1HnPkb+AmgO29HBazm4uPLKB+r7zzcTBW1d0fyYp1uP+jwtpoiNDGKMMzz58SFp49nOIrxdE3aUJtT57lfO9CQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"d479cf91bf809a03b6f4705ace6e2e3cb281fabef3cdc4c15b57747f2629d6e3fe8f0b69a2234318a30ccf3e7c485a78f67388af1744dda509b53e7b95f3bd09\",\"name\":\"@tauri-apps/plugin-opener\",\"version\":\"2.5.4\"},\"@tauri-apps__plugin-os-2.3.2.tgz\":{\"integrity\":\"n+nXWeuSeF9wcEsSPmRnBEGrRgOy6jjkSU+UVCOV8YUGKb2erhDOxis7IqRXiRVHhY8XMKks00BJ0OAdkpf6+A==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"9fe9d759eb92785f70704b123e64670441ab4603b2ea38e4494f94542395f1850629bd9eae10cec62b3b22a457891547858f1730a92cd34049d0e01d9297faf8\",\"name\":\"@tauri-apps/plugin-os\",\"version\":\"2.3.2\"},\"@tauri-apps__plugin-process-2.3.1.tgz\":{\"integrity\":\"nCa4fGVaDL/B9ai03VyPOjfAHRHSBz5v6F/ObsB73r/dA3MHHhZtldaDMIc0V/pnUw9ehzr2iEG+XkSEyC0JJA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"9c26b87c655a0cbfc1f5a8b4dd5c8f3a37c01d11d2073e6fe85fce6ec07bdebfdd0373071e166d95d68330873457fa67530f5e873af68841be5e4484c82d0924\",\"name\":\"@tauri-apps/plugin-process\",\"version\":\"2.3.1\"},\"@tauri-apps__plugin-store-2.4.3.tgz\":{\"integrity\":\"9LWPj9yMphRi9czEtUv87XHbl1b6xgd9EXpPrUnq6nG7+nbtoF84d4Kwz9xhAv/Hf30sr58pq7EOlyI936y8qw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"f4b58f8fdc8ca61462f5ccc4b54bfced71db9756fac6077d117a4fad49eaea71bbfa76eda05f387782b0cfdc6102ffc77f7d2caf9f29abb10e97223ddfacbcab\",\"name\":\"@tauri-apps/plugin-store\",\"version\":\"2.4.3\"},\"@tauri-apps__plugin-updater-2.10.1.tgz\":{\"integrity\":\"NFYMg+tWOZPJdzE/PpFj2qfqwAWwNS3kXrb1tm1gnBJ9mYzZ4WDRrwy8udzWoAnfGCHLuePNLY1WVCNHnh3eRA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"34560c83eb563993c977313f3e9163daa7eac005b0352de45eb6f5b66d609c127d998cd9e160d1af0cbcb9dcd6a009df1821cbb9e3cd2d8d565423479e1dde44\",\"name\":\"@tauri-apps/plugin-updater\",\"version\":\"2.10.1\"},\"@tybys__wasm-util-0.10.3.tgz\":{\"integrity\":\"F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"1777e8d4c62b44960bdf3111d0e50e9a4bad8ebd55a76de6eceb12829ee7ab848fe8ea97e82ff9e971483c09796eddf3681463996ed21b3deeffa2f016961c3a\",\"name\":\"@tybys/wasm-util\",\"version\":\"0.10.3\"},\"@types__node-20.19.43.tgz\":{\"integrity\":\"6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"ea8601022e62920e0f97e906b2862d6b050c053db364c0af3cd17ba552e71d97ddd737f7f034625a7fe04f4d51602754aa4bfb161afe0bda2de3fb5bfb6b15bc\",\"name\":\"@types/node\",\"version\":\"20.19.43\"},\"@types__prop-types-15.7.15.tgz\":{\"integrity\":\"F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"17a6c4c9a995f632860050449a54277ac44f18e42a4b6f94c22d049b5e717a73b11da7f686fe8bf180959f7acf74f24e8897cf8829cb211cafc156aa318dcc23\",\"name\":\"@types/prop-types\",\"version\":\"15.7.15\"},\"@types__react-18.3.31.tgz\":{\"integrity\":\"vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"bdf12aa574efc13f75ca19b075fa2e4ad3768522b04efc91b3caa92df003cababf9310f0d2164ced693d520d4510b8fc8486f2f92ffe910092445177da7bf643\",\"name\":\"@types/react\",\"version\":\"18.3.31\"},\"@types__react-dom-18.3.7.tgz\":{\"integrity\":\"MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"3047b751ea043585455f3a17116b2f72983a66f96b14d94e43b10eb2f848dc27c05f0ccf7cef10c2ec5de349dea6c60aab2c954274dd11fbfaf2af75c8b70aad\",\"name\":\"@types/react-dom\",\"version\":\"18.3.7\"},\"@vitejs__plugin-react-6.0.3.tgz\":{\"integrity\":\"vmFvco5/QuC2f9Oj+wTk0+9XeDFkHxSamwZKYc7MxYwKICfvUvlMhqKI0VuICPltGqh1neqBKDvO4kes1ya8vg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"be616f728e7f42e0b67fd3a3fb04e4d3ef577831641f149a9b064a61ceccc58c0a2027ef52f94c86a288d15b8808f96d1aa8759dea81283bcee247acd726bcbe\",\"name\":\"@vitejs/plugin-react\",\"version\":\"6.0.3\"},\"aria-hidden-1.2.6.tgz\":{\"integrity\":\"ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"8a4dd9802f5d63f95855533ef8e212b1a6037a0d6d6f456d3f9b8bde8ba1d64a0639a50c0cfa5b1487a2e099058a659414f9fdd2c6cc34c5d000854e96760a24\",\"name\":\"aria-hidden\",\"version\":\"1.2.6\"},\"attr-accept-2.2.5.tgz\":{\"integrity\":\"0bDNnY/u6pPwHDMoF0FieU354oBi0a8rD9FcsLwzcGWbc8KS8KPIi7y+s13OlVY+gMWc/9xEMUgNE6Qm8ZllYQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"d1b0cd9d8feeea93f01c3328174162794df9e28062d1af2b0fd15cb0bc3370659b73c292f0a3c88bbcbeb35dce95563e80c59cffdc4431480d13a426f1996561\",\"name\":\"attr-accept\",\"version\":\"2.2.5\"},\"class-variance-authority-0.7.1.tgz\":{\"integrity\":\"Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"29afbd4ebbadbfb1bc33a593e927a2456cfbf762b9a84a881841b35ca84013ac4e58063aa4f1fc53ef48637a0232fea4a9398bb2fed787fdb0d918a091e3ccb2\",\"name\":\"class-variance-authority\",\"version\":\"0.7.1\"},\"clsx-2.1.1.tgz\":{\"integrity\":\"eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"7989b441606d52b0566561b4777f3a386030d7a67df793e2395a3607b6e35926c779d1a5e5ed1959aabae6438681448d7ac1080e407d2126d383f24af5d84264\",\"name\":\"clsx\",\"version\":\"2.1.1\"},\"cookie-1.1.1.tgz\":{\"integrity\":\"ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"7a2f00a2cee36b4c1e469173267100f541c9ffb5d09aa8256d1c277f60138dc07d5aaf3be15287f647e38e2acce94854dbf1397c561a77297284595d72a4a275\",\"name\":\"cookie\",\"version\":\"1.1.1\"},\"country-flag-icons-1.6.20.tgz\":{\"integrity\":\"py8JiEKzjhYw6HPJ0L7SxLgCYim36UPRTZX43/kqGueUCZLSvnrqAiwW8HtQibur7mdkFQUkjOgdK+o/9FBtaw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"a72f098842b38e1630e873c9d0bed2c4b8026229b7e943d14d95f8dff92a1ae7940992d2be7aea022c16f07b5089bbabee67641505248ce81d2bea3ff4506d6b\",\"name\":\"country-flag-icons\",\"version\":\"1.6.20\"},\"csstype-3.2.3.tgz\":{\"integrity\":\"z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"cf51c629c632db103c00641fc2b9f43c0cbe3c1ed7fc64a3dd45495bda8aca7e37c566be825e675e6538aaa2cc4735952c50bc2aeb145fc4ffd240a2398a4021\",\"name\":\"csstype\",\"version\":\"3.2.3\"},\"detect-libc-2.1.2.tgz\":{\"integrity\":\"Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"06d8f604e38ef37a375b21f9f5ef0c817b3111055c6ab9143a9118aee6c1d2eaf09cdd74c90dfae2bb22072535d67665a966199b4e62fe87fb8a8e26ce2841b5\",\"name\":\"detect-libc\",\"version\":\"2.1.2\"},\"detect-node-es-1.1.0.tgz\":{\"integrity\":\"ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"ca9766254fd36c16f2d83c626eebfb64b5b706cd5012633b9c78c400d7e88492ef1345d5ba38ac9f5a8f25c67183ea83b9cb2bf9b3fa7cb0f5acf4b702127b11\",\"name\":\"detect-node-es\",\"version\":\"1.1.0\"},\"enhanced-resolve-5.21.6.tgz\":{\"integrity\":\"aNnGCvbJ/RIyWo1IuhNdVjnNF+EjH9wpzpNHt+ci/m9He9LJvUN8wrCcXjp9cWsGNAuvSpVFTx/vraAFQ8qGjQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"68d9c60af6c9fd12325a8d48ba135d5639cd17e1231fdc29ce9347b7e722fe6f477bd2c9bd437cc2b09c5e3a7d716b06340baf4a95454f1fefada00543ca868d\",\"name\":\"enhanced-resolve\",\"version\":\"5.21.6\"},\"fdir-6.5.0.tgz\":{\"integrity\":\"tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"b486d8b596ee70eb340511aa3c992c84951874bf920c7edd54cf208f2f84469dd60148cb105244fb4da46a7c87b708d63a7c2b298062c0098cd29e242c90275e\",\"name\":\"fdir\",\"version\":\"6.5.0\"},\"file-selector-2.1.2.tgz\":{\"integrity\":\"QgXo+mXTe8ljeqUFaX3QVHc5osSItJ/Km+xpocx0aSqWGMSCf6qYs/VnzZgS864Pjn5iceMRFigeAV7AfTlaig==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"4205e8fa65d37bc9637aa505697dd0547739a2c488b49fca9bec69a1cc74692a9618c4827faa98b3f567cd9812f3ae0f8e7e6271e31116281e015ec07d395a8a\",\"name\":\"file-selector\",\"version\":\"2.1.2\"},\"framer-motion-12.42.0.tgz\":{\"integrity\":\"wp7EJnfWaaEScVygKv3e20udoRz+LbtxScsuTkakAxfXmt+ReC6WyPW2nINRAGvd+hG9odwcjBLyOTPjH5pBRA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"c29ec42677d669a112715ca02afddedb4b9da11cfe2dbb7149cb2e4e46a40317d79adf91782e96c8f5b69c8351006bddfa11bda1dc1c8c12f23933e31f9a4144\",\"name\":\"framer-motion\",\"version\":\"12.42.0\"},\"fsevents-2.3.3.tgz\":{\"integrity\":\"5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"e71a037d7f9f2fb7da0139da82658fa5b16dc21fd1efb5a630caaa1c64bae42defbc1d181eb805f81d58999df8e35b4c8f99fade4d36d765cda09c339617df43\",\"name\":\"fsevents\",\"version\":\"2.3.3\"},\"get-nonce-1.0.1.tgz\":{\"integrity\":\"FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"1498584680da89ab5f12450af072a589c9aeff7486143e75ab78ad2831a8493cac4090677ce7315391b19e113513ab2807be8c6d3d0c06d9ca26e5f2031fbde9\",\"name\":\"get-nonce\",\"version\":\"1.0.1\"},\"graceful-fs-4.2.11.tgz\":{\"integrity\":\"RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"45b279fe398570d342703579a3d7939c12c9fc7b33595d0fef76dcf857f89d2feb263f98692e881b288e2f45680585fe9755ab97793ade1fcaac7fa7849d17bd\",\"name\":\"graceful-fs\",\"version\":\"4.2.11\"},\"jiti-2.7.0.tgz\":{\"integrity\":\"AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"002ffb2687c9bd91abae779635a12725e38b531f89946b7bb4d6b4c198913d3e0c635c267ca8eddbee8eda9daecf6fac92597c39966624c36a7a47bb90a6cd81\",\"name\":\"jiti\",\"version\":\"2.7.0\"},\"js-tokens-4.0.0.tgz\":{\"integrity\":\"RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"45d2547e5704ddc5332a232a420b02bb4e853eef5474824ed1b7986cf84737893a6a9809b627dca02b53f5b7313a9601b690f690233a49bce0e026aeb16fcf29\",\"name\":\"js-tokens\",\"version\":\"4.0.0\"},\"lightningcss-1.32.0.tgz\":{\"integrity\":\"NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"357601ce29cdadb95fada3c6cab6cfa03d7d0b587d95f23fd66ce0598bd75137b8d781b3fd7d450f65c165264ceeb453acc03c24bdceb4068689fac82a1439c9\",\"name\":\"lightningcss\",\"version\":\"1.32.0\"},\"lightningcss-android-arm64-1.32.0.tgz\":{\"integrity\":\"YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"60aeff0a54ede2400ad2fa3ac375fe3e79b40f671fdaf3c76e139776836d8b519ad1a9753f84c1661c23013be33702c40429cabe325cda34201d71f4344c2502\",\"name\":\"lightningcss-android-arm64\",\"version\":\"1.32.0\"},\"lightningcss-darwin-arm64-1.32.0.tgz\":{\"integrity\":\"RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"473786f49bb96da83606fd7f97095526f044deae93b57b247592cb0b27e0e69b7e1cbcfd06a94808eecb64ced51cd4d39ffe4f4611c50528e4e65738726b1c3d\",\"name\":\"lightningcss-darwin-arm64\",\"version\":\"1.32.0\"},\"lightningcss-darwin-x64-1.32.0.tgz\":{\"integrity\":\"U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"53e42c069da6fecdb0aa95184ffeb09e56a07596ed65d9dd4a6badfcd26a94270c2d35a9e66b82ac80fe2b9509ea3a83d8116c85e8c26179e23c36cd87bdd5f3\",\"name\":\"lightningcss-darwin-x64\",\"version\":\"1.32.0\"},\"lightningcss-freebsd-x64-1.32.0.tgz\":{\"integrity\":\"JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"2424e281e74492c664ded1d34ed86731d55f19feb5164cbc262d84e188d44c4417d78c62cbf953cd79eed6fc2265eddb61ed2af92a6c487fc24de0d72ba5878a\",\"name\":\"lightningcss-freebsd-x64\",\"version\":\"1.32.0\"},\"lightningcss-linux-arm-gnueabihf-1.32.0.tgz\":{\"integrity\":\"x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"c7aae79e945ad862f4cd03a4b7aaedb376033f376e2e95afc0017a10c8571556570f8b4fac190416acc6a30cc2b085ac3e3a922beb723443835015de7951d293\",\"name\":\"lightningcss-linux-arm-gnueabihf\",\"version\":\"1.32.0\"},\"lightningcss-linux-arm64-gnu-1.32.0.tgz\":{\"integrity\":\"0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"d279ccca8c8e2d12577db30e8a569245c2c7dc9c39cfd1c33467d3fe0c023e06838e7c748bcc3bbc1cc52c54757fa08c2ca17c8156de6e69143777dafe4409a5\",\"name\":\"lightningcss-linux-arm64-gnu\",\"version\":\"1.32.0\"},\"lightningcss-linux-arm64-musl-1.32.0.tgz\":{\"integrity\":\"UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"529424a1e9ebe14244ce054862923cd250c5bd198f560ea8a9ba0d1dfa07e024087cd03e1cead9ecca3b2993f4d9d0ba2e38213d025e06cbd7849a1dff09c806\",\"name\":\"lightningcss-linux-arm64-musl\",\"version\":\"1.32.0\"},\"lightningcss-linux-x64-gnu-1.32.0.tgz\":{\"integrity\":\"V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"57b42be7622166674a3d5afe56dc3ca3e58bb1025809377c96821fa4368c45619465f04e60425ec89224a862033193f03f1db8a5431fc12c7123ca61aff31b38\",\"name\":\"lightningcss-linux-x64-gnu\",\"version\":\"1.32.0\"},\"lightningcss-linux-x64-musl-1.32.0.tgz\":{\"integrity\":\"bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"6d870ba7e55bd1ac2c89783ff34b8245ecc2607360d7f9779add20cc79d657d5cfd56e6c29ae7f4c274659a47fcc13363de17f1dbb10bff8f651134e895bb15a\",\"name\":\"lightningcss-linux-x64-musl\",\"version\":\"1.32.0\"},\"lightningcss-win32-arm64-msvc-1.32.0.tgz\":{\"integrity\":\"8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"f126c2f01478d294ba6da08cf2c6ed6034b011541de099454ce95a0f78161877d385370006734305d6ba79365ea9ba1f6a5209845c74a8ace01c999c3d39c677\",\"name\":\"lightningcss-win32-arm64-msvc\",\"version\":\"1.32.0\"},\"lightningcss-win32-x64-msvc-1.32.0.tgz\":{\"integrity\":\"Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"026abd07f4a86587438b5905ae88e7a2a3cbc58850e16a395e22fc11526b56c07c011a02d4f596e951ad4f458a09e9a3cbc682fa5a2e2678d2ed4d7cc776f4e9\",\"name\":\"lightningcss-win32-x64-msvc\",\"version\":\"1.32.0\"},\"loose-envify-1.4.0.tgz\":{\"integrity\":\"lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"972bb13c6aff59f86b95e9b608bfd472751cd7372a280226043cee918ed8e45ff242235d928ebe7d12debe5c351e03324b0edfeb5d54218e34f04b71452a0add\",\"name\":\"loose-envify\",\"version\":\"1.4.0\"},\"lottie-react-2.4.1.tgz\":{\"integrity\":\"LQrH7jlkigIIv++wIyrOYFLHSKQpEY4zehPicL9bQsrt1rnoKRYCYgpCUe5maqylNtacy58/sQDZTkwMcTRxZw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"2d0ac7ee39648a0208bfefb0232ace6052c748a429118e337a13e270bf5b42caedd6b9e8291602620a4251ee666aaca536d69ccb9f3fb100d94e4c0c71347167\",\"name\":\"lottie-react\",\"version\":\"2.4.1\"},\"lottie-web-5.13.0.tgz\":{\"integrity\":\"+gfBXl6sxXMPe8tKQm7qzLnUy5DUPJPKIyRHwtpCpyUEYjHYRJC/5gjUvdkuO2c3JllrPtHXH5UJJK8LRYl5yQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"fa07c15e5eacc5730f7bcb4a426eeaccb9d4cb90d43c93ca232447c2da42a725046231d84490bfe608d4bdd92e3b673726596b3ed1d71f950924af0b458979c9\",\"name\":\"lottie-web\",\"version\":\"5.13.0\"},\"lucide-react-0.292.0.tgz\":{\"integrity\":\"rRgUkpEHWpa5VCT66YscInCQmQuPCB1RFRzkkxMxg4b+jaL0V12E3riWWR2Sh5OIiUhCwGW/ZExuEO4Az32E6Q==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"ad18149291075a96b95424fae98b1c227090990b8f081d51151ce49313318386fe8da2f4575d84deb896591d92879388894842c065bf644c6e10ee00cf7d84e9\",\"name\":\"lucide-react\",\"version\":\"0.292.0\"},\"magic-string-0.30.21.tgz\":{\"integrity\":\"vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"bddd85e1853211728670b1e8abe4c4c828f1b9e49e1e7171cb28cda7cd328345d5e2f5219c37abfe5bef96a33f6ab0796d740de4adbfde88a7c82472c7c4f609\",\"name\":\"magic-string\",\"version\":\"0.30.21\"},\"motion-12.42.0.tgz\":{\"integrity\":\"Qhwvu9sVl5/URSq5CNzwMCpSKK8Uhnrwb6VO977kZyj/wOCS7mWebJUnBoHx5cZU1Zv8a9BD5CSICWKAlrLJgA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"421c2fbbdb15979fd4452ab908dcf0302a5228af14867af06fa54ef7bee46728ffc0e092ee659e6c95270681f1e5c654d59bfc6bd043e4248809628096b2c980\",\"name\":\"motion\",\"version\":\"12.42.0\"},\"motion-dom-12.42.0.tgz\":{\"integrity\":\"M63h4n8R+quJdNhBwuLlgxM+OLYa9+I/T2pzDRboB9fLXRdbou+Gw7Zury+SkpaCyACP1JHSjHgZ1EgTkBr30w==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"33ade1e27f11faab8974d841c2e2e583133e38b61af7e23f4f6a730d16e807d7cb5d175ba2ef86c3b66eaf2f92929682c8008fd491d28c7819d44813901af7d3\",\"name\":\"motion-dom\",\"version\":\"12.42.0\"},\"motion-utils-12.39.0.tgz\":{\"integrity\":\"8nadJAJjTtqRkmRF36FoJTrywK9nnFmnPwnSMyxaOCU7GDjN9RTMJIxx9De8ErM+vpPhMccr/6fo5WciyQLnMQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"f2769d2402634eda91926445dfa168253af2c0af679c59a73f09d2332c5a38253b1838cdf514cc248c71f437bc12b33ebe93e131c72bffa7e8e56722c902e731\",\"name\":\"motion-utils\",\"version\":\"12.39.0\"},\"nanoid-3.3.15.tgz\":{\"integrity\":\"y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"cbb5b282fffb9843afc53b8440307c4ad5dd3110567f5911fed961033051505901da37dc2ce0313bf48798e3b6ce0cf5a5580adbdfe4caea67d39f7f6c21dd8c\",\"name\":\"nanoid\",\"version\":\"3.3.15\"},\"object-assign-4.1.1.tgz\":{\"integrity\":\"rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"ac98134279149c7d6c170f324fa552537cc3dec5a6bbab19848b1e63c557f8646edcfe85ec5bbe24d0e85df9251256cb2529dcdc55101d57b8714e618fe05c52\",\"name\":\"object-assign\",\"version\":\"4.1.1\"},\"picocolors-1.1.1.tgz\":{\"integrity\":\"xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"c5c787dac9e1b5be4cf658aa0ec984c39ea57b7efa993664117fe311bfd1c4d1727a036e97b78db250973fd1438ff2dcbb45fc284c8c71e3f69eda5a1eb0c454\",\"name\":\"picocolors\",\"version\":\"1.1.1\"},\"picomatch-4.0.4.tgz\":{\"integrity\":\"QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"40ff3c0402af31a9bfdcdc47eaf8f6a36d51e8c8f165401dea7970012fe99c6bcdf4854ba1c2c7c46608cc5860e9f510fb9b61e8fe1dbf8796f635f70d2223ec\",\"name\":\"picomatch\",\"version\":\"4.0.4\"},\"postcss-8.5.15.tgz\":{\"integrity\":\"FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"15f47cb237787a6d93e9f6f723633000953b1d654cafdcdb6be7a799079e5857c26e6f94382ff45f80d2f17b6951333058c19b8ca60fef18df35e933c86981dc\",\"name\":\"postcss\",\"version\":\"8.5.15\"},\"prop-types-15.8.1.tgz\":{\"integrity\":\"oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"a23f3b0a064809dba5528868815011ec08e50b4df6ed4e1e9782fa780bcea827ae74c0d553435384d695f9bf437f87578123f58173139cf7617deff6a831f972\",\"name\":\"prop-types\",\"version\":\"15.8.1\"},\"radix-ui-1.6.0.tgz\":{\"integrity\":\"EUEC70O03EgxWMP5aoqfBZ6iLC5bczFagGy7zhSYRt8o5DP7IWNiP3ywetse3L9b8843ExB0OGWZvgbYVJuNeg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"114102ef43b4dc483158c3f96a8a9f059ea22c2e5b73315a806cbbce149846df28e433fb2163623f7cb07adb1edcbf5bf3ce37131074386599be06d8549b8d7a\",\"name\":\"radix-ui\",\"version\":\"1.6.0\"},\"react-18.3.1.tgz\":{\"integrity\":\"wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"c12fa1020252851d0a844bcf240adfb8f54dd7e1f3d6dd18ea7e632eb1906e46f8bab80f13fd11bdefb590c075bffa16807826e1621c57e8bb176a53563fb689\",\"name\":\"react\",\"version\":\"18.3.1\"},\"react-dom-18.3.1.tgz\":{\"integrity\":\"5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"e66e2740aa7ead945bd3d2cd1f9f463380714e1f76e75ff295b2886e97bb4e91b17c9fbd92fe812e42c15c88e3b296e06e720136a948db7b519d3593d2c9d423\",\"name\":\"react-dom\",\"version\":\"18.3.1\"},\"react-dropzone-14.4.1.tgz\":{\"integrity\":\"QDuV76v3uKbHiH34SpwifZ+gOLi1+RdsCO1kl5vxMT4wW8R82+sthjvBw4th3NHF/XX6FBsqDYZVNN+pnhaw0g==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"403b95efabf7b8a6c7887df84a9c227d9fa038b8b5f9176c08ed64979bf1313e305bc47cdbeb2d863bc1c38b61dcd1c5fd75fa141b2a0d865534dfa99e16b0d2\",\"name\":\"react-dropzone\",\"version\":\"14.4.1\"},\"react-is-16.13.1.tgz\":{\"integrity\":\"24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"db87baca71361fe38ab7892ab0ebcd77c901a55eb9ce8c5b038055b04381dc0455590922fc31f3694a02e4ab8e37f06271c0da0824d906e39c7d9b3bd2447c6d\",\"name\":\"react-is\",\"version\":\"16.13.1\"},\"react-remove-scroll-2.7.2.tgz\":{\"integrity\":\"Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"22a6fd3630824ede877febce74d21919d4e21f5412aabdbb1ff124f6cbff6bdee07ee788ff9875b37c918b59e783331468e393a229f9748d5d5ca757885faed1\",\"name\":\"react-remove-scroll\",\"version\":\"2.7.2\"},\"react-remove-scroll-bar-2.3.8.tgz\":{\"integrity\":\"9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"f6bfb28bdfa6814df700a723e886d3f684423bbf16ae24a3eadfdc17c0d605927d68e18f393103bdd503cf51702a29bb4175b0987aad7479d125f840c441b8e9\",\"name\":\"react-remove-scroll-bar\",\"version\":\"2.3.8\"},\"react-router-7.18.0.tgz\":{\"integrity\":\"pTTGt8J+ji1NOmYnjzT+bAJy/1zD+Jp4ziO6cL7T3ZLvXKtusO7BpFqlRXitqpcPVqllsIXFHRMt+2/k3Xn6HQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"a534c6b7c27e8e2d4d3a66278f34fe6c0272ff5cc3f89a78ce23ba70bed3dd92ef5cab6eb0eec1a45aa54578adaa970f56a965b085c51d132dfb6fe4dd79fa1d\",\"name\":\"react-router\",\"version\":\"7.18.0\"},\"react-router-dom-7.18.0.tgz\":{\"integrity\":\"Fi0yY6kgtKae/Th2xibdWK0KSdYZ4B53Gyf6wRtomOKWgpNm7H7+DyfDhncdz9FKbpS+1jmDhg3F4WoGJ+yFOA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"162d3263a920b4a69efd3876c626dd58ad0a49d619e01e771b27fac11b6898e296829366ec7efe0f27c386771dcfd14a6e94bed63983860dc5e16a0627ec8538\",\"name\":\"react-router-dom\",\"version\":\"7.18.0\"},\"react-style-singleton-2.2.3.tgz\":{\"integrity\":\"b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"6fa8d2bf1bd59f2a6d0222e36e458b13f94e9d1e257d3b43025f9e502ed1672f9041673ac11cc8576084eb106e3260f1736a888a1b430990f934f38597b7d105\",\"name\":\"react-style-singleton\",\"version\":\"2.2.3\"},\"reselect-5.2.0.tgz\":{\"integrity\":\"AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"02067750e666dd89dd7eb2783988e0ad3edb9829bfd62aa48ef11f1ffa188f387a3c3daac3842e4f78e39d722ba5db78313a4c5dc94c4f79576e6458f9745a93\",\"name\":\"reselect\",\"version\":\"5.2.0\"},\"rolldown-1.1.3.tgz\":{\"integrity\":\"1F1eEtUBtFvcGm1HQ9TiUIUHPQG7mSAODrhIzjxoUEFuo8OcbrGLiVLkevNgj84TE4lnHvnumwFjhJO5Eu135g==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"d45d5e12d501b45bdc1a6d4743d4e25085073d01bb99200e0eb848ce3c6850416ea3c39c6eb18b8952e47af3608fce131389671ef9ee9b01638493b912ed77e6\",\"name\":\"rolldown\",\"version\":\"1.1.3\"},\"scheduler-0.23.2.tgz\":{\"integrity\":\"UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"50e4a1b0fc33ecdacc52a851eadd215a315dbaf3b36edbfbb680c7d7f848adf44d2030679c159dd02c094c6bd3a67815966c0609d3fdfd997fb55ac3a9cb98cd\",\"name\":\"scheduler\",\"version\":\"0.23.2\"},\"set-cookie-parser-2.7.2.tgz\":{\"integrity\":\"oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"a1e33596953f52f853c70fa0ddc21fc571f225173fba275ddf22b53f6e368331ddb34b9d401633b37cbc8f8802096f9927b69dd3272d95df1160ef9b76eae5bf\",\"name\":\"set-cookie-parser\",\"version\":\"2.7.2\"},\"source-map-js-1.2.1.tgz\":{\"integrity\":\"UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"51758c2a12cec1529bef6f0852d40f5f17d853ebac7726ed52b2bff2e184f0240cbeb84ea70bf30c1c23d108522fb31073bbc8b084811bc550f3e203431a5f40\",\"name\":\"source-map-js\",\"version\":\"1.2.1\"},\"tailwind-merge-3.6.0.tgz\":{\"integrity\":\"uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"bb12fba80550ae2a9140f0322b7a63eba56ab245aaa19dfb3d6f788f0393c0d7eaff3f68caed55f9eaab66ab51dbe7c28977583997bf32876df06b6fa8dceefb\",\"name\":\"tailwind-merge\",\"version\":\"3.6.0\"},\"tailwindcss-4.3.1.tgz\":{\"integrity\":\"hk+TB1m+K8CYNrP6rjQaq/Y+4Zylwpa87mLYBKCunwnnQ9p+fHb7kmSfGqyEJoxF/O6CDyABWVFEafNSYKll+Q==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"864f930759be2bc09836b3faae341aabf63ee19ca5c296bcee62d804a0ae9f09e743da7e7c76fb92649f1aac84268c45fcee820f200159514469f35260a965f9\",\"name\":\"tailwindcss\",\"version\":\"4.3.1\"},\"tapable-2.3.3.tgz\":{\"integrity\":\"uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"bb173fce9a8583ac7b0bcbce13b961e8b6dd6bc7842fdce6566fcf2de4cf051861d710a0756690f89d42522786a487e6d8776db14a51bfe1ec8626ac04c71ce8\",\"name\":\"tapable\",\"version\":\"2.3.3\"},\"tinyglobby-0.2.17.tgz\":{\"integrity\":\"wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"c1747f758a5ca8a99f5a911d66388a24ec023459dd0f40cc9eb5bf7188d51adb449017d581c2c51e836b963e3b9a339589cf72c8dbbae5a96c805e0d4324dada\",\"name\":\"tinyglobby\",\"version\":\"0.2.17\"},\"tslib-2.8.1.tgz\":{\"integrity\":\"oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"a0916ef781d06fe29576e49440bef09e99aa9df98bb0e03f9c087a6fa107d30084a0ad3f98f79753a737c0a0d5f373243ae1cf447b525ca294f7d2016b34bfdb\",\"name\":\"tslib\",\"version\":\"2.8.1\"},\"tw-animate-css-1.4.0.tgz\":{\"integrity\":\"7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"edbce23a546a1f4849c7cd21ff799b89c2d6ee8f2a2ec1f9f9168b476b7e3873370f426558638340a4387316caed696f994c69723e8a82ee842aa8eb1857b741\",\"name\":\"tw-animate-css\",\"version\":\"1.4.0\"},\"typescript-5.9.3.tgz\":{\"integrity\":\"jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"8e5d6f6733c38a72ebf5e52ddc9feded5e8580d130f508ef04f772b33f4a7d00c3e357d0ac2d98e2f290762694a454f86d795bd511e12e9a7cc2d9ba3394e04b\",\"name\":\"typescript\",\"version\":\"5.9.3\"},\"undici-types-6.21.0.tgz\":{\"integrity\":\"iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"8b00d9aa0d10006ae0f516afe47e27d0ceb87379a4479f5c27ac10a7eec2e2723482c984c5a79d6982cd3b8e1e4f802d041c236d38863cc96dd8c7744fd1fd25\",\"name\":\"undici-types\",\"version\":\"6.21.0\"},\"use-callback-ref-1.3.3.tgz\":{\"integrity\":\"jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"8d02f79519e871a16dbb7574d094e8633ff8424356b30c628c368254d6518914cedc74032ec76ed59b66214bd5e323e9fabbd69b98f4cb44c6fd2eb572e8a34e\",\"name\":\"use-callback-ref\",\"version\":\"1.3.3\"},\"use-sidecar-1.1.3.tgz\":{\"integrity\":\"Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"15e770d1a66f921ca7a0f625039597acc080326fa7496759b7a973250ece93c4ba43e56c1e61e94569dd55127c05ed196e47cf7392d1607fb95ebcd770478b45\",\"name\":\"use-sidecar\",\"version\":\"1.1.3\"},\"use-sync-external-store-1.6.0.tgz\":{\"integrity\":\"Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"3e9e864b018ffcdacf22bc551402243907b2c3c9457a73878a34169144eb0efac5e002eaca53f60bf28291e4bd76950cdcabd84508676b9bedec82fde7e650f7\",\"name\":\"use-sync-external-store\",\"version\":\"1.6.0\"},\"vite-8.1.0.tgz\":{\"integrity\":\"BuJcQK/56NQTWDGn4ABea3q4SSBdNPWwNZKTkkUpcMPnLoquSYH8llRtSUIgoL1KSCpHt5eghLShn50mH36y7Q==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"06e25c40aff9e8d4135831a7e0005e6b7ab849205d34f5b035929392452970c3e72e8aae4981fc96546d494220a0bd4a482a47b797a084b4a19f9d261f7eb2ed\",\"name\":\"vite\",\"version\":\"8.1.0\"},\"zustand-5.0.14.tgz\":{\"integrity\":\"/8tAspM5LMPr28b3fwLYrtdj77ECpfZviaP75CMTnwO8ISyaE4GDIG/9rDDYq/cH9D2Xw2A2RXglLInmVBQB/g==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"ffcb40b293392cc3ebdbc6f77f02d8aed763efb102a5f66f89a3fbe423139f03bc212c9a138183206ffdac30d8abf707f43d97c360364578252c89e6541401fe\",\"name\":\"zustand\",\"version\":\"5.0.14\"}},\"store_version\":\"v10\"}",
-		"dest-filename": "pnpm-manifest.json",
-		"dest": "flatpak-node"
-	},
-	{
-		"type": "script",
-		"commands": [
-			"version=$(node --version | sed \"s/^v//\")",
-			"nodedir=$(dirname \"$(dirname \"$(which node)\")\")",
-			"mkdir -p \"flatpak-node/cache/node-gyp/$version\"",
-			"ln -s \"$nodedir/include\" \"flatpak-node/cache/node-gyp/$version/include\"",
-			"echo 11 > \"flatpak-node/cache/node-gyp/$version/installVersion\""
-		],
-		"dest-filename": "setup_sdk_node_headers.sh",
-		"dest": "flatpak-node"
-	},
-	{
-		"type": "shell",
-		"commands": [
-			"python3 flatpak-node/populate_pnpm_store.py flatpak-node/pnpm-manifest.json flatpak-node/pnpm-tarballs flatpak-node/pnpm-store",
-			"echo \"store-dir=$PWD/flatpak-node/pnpm-store\" >> .npmrc",
-			"bash flatpak-node/setup_sdk_node_headers.sh"
-		]
-	}
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
+        "sha512": "52b700041fb86d4ac5001c1b96e4c8044ad7c2f6ec53f57b4d959f99b8097db930881bb3892f60c5d383532ba279c7dd190f398e094c5ba8ee4b7fb3e53b0a2f",
+        "dest-filename": "@alloc__quick-lru-5.2.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+        "sha512": "02ea7b69439fa5b01483644e38937a230e5ff43301973bb4988926fe66a52d014dfd84203b8f300a3d0ac5adec10726f3d5160eec891faa4489f05dddaa8502b",
+        "dest-filename": "@babel__code-frame-7.29.7.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+        "sha512": "a9e8711a4463e7987f7dff0431a27e71887268a947231a980e7ebcdb0403ed1369f54ba3390b07a20dae4b4af6bf3af8a56fac5dff7435e79aca370d697ddf16",
+        "dest-filename": "@babel__helper-validator-identifier-7.29.7.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+        "sha512": "36af0e8465a264864657a84b1e8c8028b2dc26284fff115e04c189a14af14d7da9b08f1d0a27f32e16484856fe5564b7c053110e6086c3947e74ec920aa3cb87",
+        "dest-filename": "@babel__runtime-7.29.7.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@base-ui/react/-/react-1.6.0.tgz",
+        "sha512": "fe3ce34d62585e14453b8e417aff657377076e68f308ca54a9b319d8080acbfcf6e6663d07ab2119235c5dc8d06abf67e5da0cd0a616d56f1f705bf68d906e33",
+        "dest-filename": "@base-ui__react-1.6.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@base-ui/utils/-/utils-0.3.1.tgz",
+        "sha512": "80516296d3915665bf37a2082d31b18b33f73c1a55a72b2a30bd402d8e55934987fbb7da5640a49ce537d60a181cde40a1e9367648f1bdad57383d827bd5ae22",
+        "dest-filename": "@base-ui__utils-0.3.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.5.1.tgz",
+        "sha512": "21758b0b12a669efab23b2ce1d2d41dc46d58ac43a1910166e137d9ac6ba2a3342c855abbca656478a147629da36cb2b57ce763ab487b923daf7987518f25ced",
+        "dest-filename": "@biomejs__biome-2.5.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.5.1.tgz",
+        "sha512": "9e9a83cefaafeef15a59188d3754deef5b224603daa92f4ca6a81809d3ff0ab51b909ec0a5ecda79a2a3b9e28744dfc91ffea54632500078bc69c403080cf6db",
+        "dest-filename": "@biomejs__cli-darwin-arm64-2.5.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.5.1.tgz",
+        "sha512": "460c13a8f00cf20dad9f58fe6f9a118c5fc36d2057f1ae20c288edb86f57ba17caec68289af67df93fadaa35e255b8cb11e1893a82fa54493c9af45355e4b26f",
+        "dest-filename": "@biomejs__cli-darwin-x64-2.5.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.5.1.tgz",
+        "sha512": "58c72f30b801cb24ea5711a5abdd7c341058962abd15147d1804151131dbf958c656a5c26457c79591c2d455f889bb9863f1e0e93244deb1d4d3156b7495cd47",
+        "dest-filename": "@biomejs__cli-linux-arm64-musl-2.5.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.5.1.tgz",
+        "sha512": "ca1577e42cd9877f15c8cbd31178b72538f1641b3efa808a2bd286f2f07a548e7ebaf42f64d47704558428acee3a6c7d0c9263eec4296782d025c99b193b37f9",
+        "dest-filename": "@biomejs__cli-linux-arm64-2.5.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.5.1.tgz",
+        "sha512": "00d4e8c2d94b98f626e7278c724598f17cdbf48c7e2493f7b601d1fe7eb1463d555b2233cd6b5f45f8a1f61bfd5660a5c1a76906f65db8849921b06c225606dc",
+        "dest-filename": "@biomejs__cli-linux-x64-musl-2.5.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.5.1.tgz",
+        "sha512": "27feee1d25fb35fa180c8ec78a302477c9674083ab45bd96ee3dd7fadc3847e379131bd71acc9716219d41c7dcc5f3a635099955240e08393be7b7f0a73a9072",
+        "dest-filename": "@biomejs__cli-linux-x64-2.5.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.5.1.tgz",
+        "sha512": "ce05e728d8163c2e223c5ed8d6547749351e094b994690fa2223ab0bb4d94e58742f1e85895513d399b2b8c40743d0fed5c73bbb2325762e1fa2b13a969d22bd",
+        "dest-filename": "@biomejs__cli-win32-arm64-2.5.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.5.1.tgz",
+        "sha512": "eaec6947d86f6a094036465e99e4a237f1616209066acac41a7dbaede5c85af8eb8c9d8b843964db9d48863549aba317ce4576fdb717c0bc12ae82f23eda9166",
+        "dest-filename": "@biomejs__cli-win32-x64-2.5.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@commitlint/cli/-/cli-21.2.1.tgz",
+        "sha512": "6e5b1919edbd849ef6546105565ef6215617fb5bec7c83698c0f7259003a8bb38a0ff31c184397834f2c28844a8c593826fce157ff67d25de2e8da283cb4cd7e",
+        "dest-filename": "@commitlint__cli-21.2.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-21.2.0.tgz",
+        "sha512": "41ff1644355cc95775e227fa55359e9de6f115b2a75676f33d42639738e4c8919e1cadb108677adc3af55d9ce3d299572906fd3f405f3b1a1cd4755e0a8d8159",
+        "dest-filename": "@commitlint__config-conventional-21.2.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@commitlint/config-validator/-/config-validator-21.2.0.tgz",
+        "sha512": "b7b03334700a788768ff73511b0ce9b9f287b0a90f1e616cff9e8dd859ec874febd2b1ad9d0cd3c64eaf9c5823686af885d49028d079d3f280851f589382c928",
+        "dest-filename": "@commitlint__config-validator-21.2.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-21.2.0.tgz",
+        "sha512": "efa205f6f0cd4b5de50331048a4f5e2b0cedf1ff616215a2c155d9d809f22c2cf9fdfe75d45b04437a70d57dffcd24297512d053b8b9a833152b25e2d465a34a",
+        "dest-filename": "@commitlint__ensure-21.2.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@commitlint/execute-rule/-/execute-rule-21.0.1.tgz",
+        "sha512": "4627c7f859889a8cca044ea6a33845e0adebd9144a3fb48c8bf43fccb0a6131b69e5ed399611ce518a86065141006347699c54fd6630d57bae8182bd8d0cea9c",
+        "dest-filename": "@commitlint__execute-rule-21.0.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@commitlint/format/-/format-21.2.0.tgz",
+        "sha512": "738abae3169abf653cdedee4ed1cb325eac166eacf7abec5c54398d112f92ffe826628d9ecaface872011888218f47b2d4fdbeb1e457d09f57418b43b9e77ab6",
+        "dest-filename": "@commitlint__format-21.2.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-21.2.0.tgz",
+        "sha512": "e3f781d2f04decbf3c3bfa02e1a8c012a8bb8f665f360c65ffed7545f015f58a2c7a36600d7858d82f557079c72613b33cba12cb93f7320ff8ea4a9ec897d72b",
+        "dest-filename": "@commitlint__is-ignored-21.2.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@commitlint/lint/-/lint-21.2.0.tgz",
+        "sha512": "71e3b9769f692e3119eb2eaa6eafee5d65c33f292aaa54eccb3a10d0dcde7298ac48984ade44f2f6acd0a0f789b961bf20c35d57594ed11826ceaa009528b5bb",
+        "dest-filename": "@commitlint__lint-21.2.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@commitlint/load/-/load-21.2.0.tgz",
+        "sha512": "463973590aabb91c087a72447d9b6aee41bdedca3dee72a81e97e513962717ad6d0cb5f11cfadd5889a0cf0e952fa32517268e715964ef878157c65099cde820",
+        "dest-filename": "@commitlint__load-21.2.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@commitlint/message/-/message-21.2.0.tgz",
+        "sha512": "6311a88970ff1d73572c93eb430139a685daf971f4081126fa676f6c740fd20e8c57f7662725050b33cdcd96f12fddc6bd9ef44e6b532b4674fc806902a1eff2",
+        "dest-filename": "@commitlint__message-21.2.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@commitlint/parse/-/parse-21.2.0.tgz",
+        "sha512": "4075b11b87743cb4c5eb7e3f01dc99d0c412f822e7e583ae26508584c325486285c7360651eb641c18f5f318010fee9f57352b03696b09d8bfbe54b67ffa185e",
+        "dest-filename": "@commitlint__parse-21.2.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@commitlint/read/-/read-21.2.1.tgz",
+        "sha512": "8545bb1094273532f4bcf3a654c34ae02ae7acd04dd2737e2491d178591d1cee72e22c87784993070b82d79382a944e3c56a3b89d9c7d4b7ed7e959521a3d620",
+        "dest-filename": "@commitlint__read-21.2.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-21.2.0.tgz",
+        "sha512": "e0eff58f9d7eefd5ad87db3f306c6dff982cd1760b0e036562996d41f840bcb1348adbac2cab3dcebbb16e2360d683a49a46fd2fd2f85126068c48fb9fcecdc4",
+        "dest-filename": "@commitlint__resolve-extends-21.2.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@commitlint/rules/-/rules-21.2.0.tgz",
+        "sha512": "0b6c9730da6207c11364a7f1e490fcf84c6017cbd353555030a3d2514630a8aa70f68256401ae55c1a5d534dfc9a3d963e3a1fee8f54cc5a664f205e18c67066",
+        "dest-filename": "@commitlint__rules-21.2.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@commitlint/to-lines/-/to-lines-21.0.1.tgz",
+        "sha512": "6ddd4114823ba7511066b7bd29a8fe90a68c14fddc14276ddb52bb0c8b55bb1f573f95a32e0274fd4cb5a49261f5a3f0549e922a0eb63f1aa565a1c8f214005f",
+        "dest-filename": "@commitlint__to-lines-21.0.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@commitlint/top-level/-/top-level-21.2.0.tgz",
+        "sha512": "63982643e2b1cea0ab04525f2ef1443efbf00f72c388d6684d3db2785066f7a33caa19aa4b341ce43bd7deb85e01a00c8f222f3173822d2fe659f76938db23c9",
+        "dest-filename": "@commitlint__top-level-21.2.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@commitlint/types/-/types-21.2.0.tgz",
+        "sha512": "ef3545083076ade32f247e5d99b2a73903e3644be37494c7f2373453f3c83d4d6bdfffaf7f9a43d4795f8ad576316b165ebbeeeeedfd898d65c8b50f39a3741b",
+        "dest-filename": "@commitlint__types-21.2.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@conventional-changelog/git-client/-/git-client-3.1.0.tgz",
+        "sha512": "4ea6bf807728d962566bbe343518ceadf295bf322ac6466979c6fc6de99a43cb0a3393d76f550ae2e4f24dbff5c08a8db8e55a0ce171c817614c84199fa81d8d",
+        "dest-filename": "@conventional-changelog__git-client-3.1.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@conventional-changelog/template/-/template-1.2.1.tgz",
+        "sha512": "4f395356928f8daa96eaa3988d0718503b86b0b08db2f1475415e46064c09dfe55dfb8c25ab13985a28d5f3cf459952d5478eba55efa2f56ee00d8f05cc7d3f3",
+        "dest-filename": "@conventional-changelog__template-1.2.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+        "sha512": "452bdb4261f374accdb0b61aff01eb6dcdca378b182ca01d3d9c6a88cd87013aaffd2064dbf10d487a6f5c668b38c72c032cf4a68106aa49a62981b739688911",
+        "dest-filename": "@emnapi__core-1.11.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+        "sha512": "be08fb477cb75a0c76e0841a18f03f47a6055cb1d530e674b951322103da5acfab7750337c43179400b6d856303b55e4291e8d3ecabb9946a7747f2821175917",
+        "dest-filename": "@emnapi__runtime-1.11.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+        "sha512": "73de6a39790777274d2a1b1c05379ba840b5095019a72a8e7d57c1cd0d6a833ca5de07de95d5232208036c86600cab072e09ec33e8a01fb4c9fde01ab1a56e30",
+        "dest-filename": "@emnapi__wasi-threads-1.2.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
+        "sha512": "d488785935b2c34fa52b214c7011c66dbe54e45b6e1c9bae8e8cb2af9cd36964b911831e4fa25bd80b8379fb6c0ac12e7213be98cda28f9faaf5cae1c9dccb85",
+        "dest-filename": "@floating-ui__core-1.7.5.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+        "sha512": "f60652008e57337ebcf343cf326ffff5d7e2127818a02e809b68b3112d45178d3a605b23bf204c99e2768384808eedf15b0b6eca735114bdacf61831a4b23949",
+        "dest-filename": "@floating-ui__dom-1.7.6.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.8.tgz",
+        "sha512": "702e766c7c0cfe7fc2c52f3b147d3259d9e0119ae376d2d6fea56bba8ebcaa0fa9acaed943860676eb761b20d5a6819e0187bf87cf7dad578e566e8e8b8d24d8",
+        "dest-filename": "@floating-ui__react-dom-2.1.8.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+        "sha512": "46207fc8887bf29708c65ea52cc1b40a0057019d98d1e547a8c3d8ba0bbef54d00793e9805e889a5fee56dd24d22e8053f94888f0351828e03851d50c62dba1a",
+        "dest-filename": "@floating-ui__utils-0.2.11.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+        "sha512": "da492dffb9e227a32010fc45d1b61d43a7ad65a03e7d0bc370b29c921cb5c8840ecdaa0a8c10634a3eb7fda2d58d8137aa146de5dbccfae5327c283a50a0816c",
+        "dest-filename": "@jridgewell__gen-mapping-0.3.13.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+        "sha512": "2c8f6effe95a606e03b354c3292256d983eb22571560ec22d9f502eb1078de5b9e0a383157895f7ce0990ad605887e9334e5feb50297c7ded3e082876e1c8711",
+        "dest-filename": "@jridgewell__remapping-2.3.5.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+        "sha512": "6d12128022233f6d3fb5b5923d63048b9e1054f45913192e0fd9492fe508c542adc15240f305b54eb6f58ccb354455e8d42053359ff98690bd42f98a59da292b",
+        "dest-filename": "@jridgewell__resolve-uri-3.1.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+        "sha512": "71843ddf5d20aeac6e7966e5f96b885086a251a0dc8fb58eab97d58449633558117ce52163d7f2db34ef7e8a96b2779b87c4a5ef45527056c80af2672ca0743a",
+        "dest-filename": "@jridgewell__sourcemap-codec-1.5.5.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+        "sha512": "cf3351f9275048327373c8e869e3fc410a0242bf0db98c76748232b65d507811191c9f6e5ba85e6ecad881bcfc849c1441aa374d608cb667d5f0dbb5b7038b03",
+        "dest-filename": "@jridgewell__trace-mapping-0.3.31.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+        "sha512": "64bbff25d51f92f3b2f5e0a79c16867e23be5e299b8de6c078ef8c450a83fc1f85475b6744dd2da4a4891d16c4f2c15f4ba6aab1767aed34237f07ecc542d56e",
+        "dest-filename": "@napi-rs__wasm-runtime-1.1.6.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@oxc-project/types/-/types-0.137.0.tgz",
+        "sha512": "593f866f6e22f219afa3ce4022fda8118a2e11791194a0254fd59a09add37cb80d08df8686b24e199b8894ca2e021dfc41ee103b1dba794395b2aef4a97af2c0",
+        "dest-filename": "@oxc-project__types-0.137.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@phosphor-icons/react/-/react-2.1.10.tgz",
+        "sha512": "bedf13beaf062e385e0196586be606fe95bb1c36e8bfc125fcc00d5bca4e033e1e1b1af08676dfad066ad02a78abccc112ef0d2211dd9ebfabf2d8677d148d60",
+        "dest-filename": "@phosphor-icons__react-2.1.10.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@radix-ui/number/-/number-1.1.2.tgz",
+        "sha512": "71e4f06b173823920e8bdec3802a2d977a6a8b2446bdf7dc734a0eb04d9d418689385203b03b785561bac446e0d5078fbfd4166aeb02108a69b9dfed275c0d8a",
+        "dest-filename": "@radix-ui__number-1.1.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.4.tgz",
+        "sha512": "ec07422bd3d0ca29632a80436cdf0eb9cb426ddfdeb1dc193d0f11b4e1374acc90b54a623dbf8d0fbe6ad231210b59b579c048d0c14d78b26fc0887d88a1d171",
+        "dest-filename": "@radix-ui__primitive-1.1.4.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@radix-ui/react-accessible-icon/-/react-accessible-icon-1.1.10.tgz",
+        "sha512": "4eb692c1952a4dc55b883576fd15f30170bb69e5555dc86ad1d68f15913bcc0c5815a3338ce52080b39f407f4a14b8118b3bb054a64efdcaef795d5e78edff65",
+        "dest-filename": "@radix-ui__react-accessible-icon-1.1.10.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@radix-ui/react-accordion/-/react-accordion-1.2.14.tgz",
+        "sha512": "884f1807d9e64c11fccddef7a1f048499f090b380ca0c9004c9afba83c1aeaee45d7eee64ccf3557a7daef58e067ae6ba6356979c0dfd6f4a7c0814ff4bcb5cf",
+        "dest-filename": "@radix-ui__react-accordion-1.2.14.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@radix-ui/react-alert-dialog/-/react-alert-dialog-1.1.17.tgz",
+        "sha512": "e7adf28067b258faf1c9508da7b395e2b1366885e114f927a45ca8e306c395cc8c30f67ac9287ecc2e564ef6346452e03d383f401ead03c3f20d0c89d9be1c3e",
+        "dest-filename": "@radix-ui__react-alert-dialog-1.1.17.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.10.tgz",
+        "sha512": "8f65530f3d6f802b26b86d24e6505f39c33c9f924f16a64170caf26ac1631d8321c3160be5245457994c494a5174db70dc3fd2bfca7326dae502092cb184ac41",
+        "dest-filename": "@radix-ui__react-arrow-1.1.10.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@radix-ui/react-aspect-ratio/-/react-aspect-ratio-1.1.10.tgz",
+        "sha512": "91b23b36baa10debb2b58aeaec98c0b285dccef2fcc208f6b5cd4cc9a6169bee746cc28708742d5560abcac971e1c0a99824d390173041c904e029a6195da169",
+        "dest-filename": "@radix-ui__react-aspect-ratio-1.1.10.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@radix-ui/react-avatar/-/react-avatar-1.2.0.tgz",
+        "sha512": "6a6fc2c25b57b66b5db4ffb915b61b9580e731aff3b8a70c24fd62dff4893035d77e3da61be053a8b1f6c2e72a7b2ca240cbabb14b60ff970af8d876a4269238",
+        "dest-filename": "@radix-ui__react-avatar-1.2.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@radix-ui/react-checkbox/-/react-checkbox-1.3.5.tgz",
+        "sha512": "a51133ae63675701af61a06833ae21b9344aec1de5ad346ec23f00f67c213e212d31bfb2b9d89687acd602a12d3f40f3779fa205ad4a8bb575a42c55f04c4c74",
+        "dest-filename": "@radix-ui__react-checkbox-1.3.5.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@radix-ui/react-collapsible/-/react-collapsible-1.1.14.tgz",
+        "sha512": "f5b4fe16f89f5f514ad8c8fa504b13772bb470ddc9680dca75f85a05aa3e38dad8172fe9c8ecb74d4d53370ee23a4d68fb484e12aebb4688e55149a8146c31c8",
+        "dest-filename": "@radix-ui__react-collapsible-1.1.14.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.10.tgz",
+        "sha512": "215573e04bc170a8ebcca8287fbd78a839f3fd2cd00242c0d849a1e5e7651db81c13a7cd777527e8224b95a61c9e6f0de09980b73420b1ee1d38ac5c0f6c9cf6",
+        "dest-filename": "@radix-ui__react-collection-1.1.10.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.3.tgz",
+        "sha512": "ad838ff0e327bae3cc405d6e84f56518d7020e592890aa86144dc97311558889005cfec4bc5594962240b2dadaa72a5a04b24d1db64bea31a16d50c64f099584",
+        "dest-filename": "@radix-ui__react-compose-refs-1.1.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@radix-ui/react-context-menu/-/react-context-menu-2.3.1.tgz",
+        "sha512": "5dbaf14baf16e5dca21387c06fdeb2bc9c12554e71eba076d00f7db03e4c937c5258afcba9e3a7c7a4d99e29b52a278c8d74bf09316af2b78e0235b16acd86f1",
+        "dest-filename": "@radix-ui__react-context-menu-2.3.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.4.tgz",
+        "sha512": "4301f83cee6eaeb6cef85686779020960f98260593cb2b99de0ffa98abecaab68b92094375c930f4969f80be4c70be55109e843cd76e3da4f7644f41b6d0c0aa",
+        "dest-filename": "@radix-ui__react-context-1.1.4.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.17.tgz",
+        "sha512": "4c34d89a976af1d236f9782f823f4027c1a1aaaf84a61fd345511d68540f0c8b4863ee904a453b30931e7afc35e7af18c3fd888f3f014e984f48fd977a32a987",
+        "dest-filename": "@radix-ui__react-dialog-1.1.17.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.2.tgz",
+        "sha512": "0b7bc585bca2e125b73e66c08ba030a6ee0ecc9b5dd0cc46babbd2b18b6bee9ee733c44d0775401770949a7a768f9d249e992b45c07bfb27155f380b805eb234",
+        "dest-filename": "@radix-ui__react-direction-1.1.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.13.tgz",
+        "sha512": "daffb33405967b4c92c600b40f4c9e5cc3d0db7c595605d94dead3cfe24a9667518fa81f4ea982711dbd8dbe9ddbdd037b35cf1a0aee1d60d7fef61479bb44ae",
+        "dest-filename": "@radix-ui__react-dismissable-layer-1.1.13.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@radix-ui/react-dropdown-menu/-/react-dropdown-menu-2.1.18.tgz",
+        "sha512": "3d9195f368059345a5b43448fff4ac1b6f19223968f403539a83588348cb3735d7883b00cb93e438e6106950f5a4fc58eadee0c5f7dbd50303eaa694bec05977",
+        "dest-filename": "@radix-ui__react-dropdown-menu-2.1.18.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.4.tgz",
+        "sha512": "728b7f681fe63a6d086156134e641c1042b5338f256568bc16561ee670cf410f0d6195255c41609dc27da762b37abdd1292ad8edc4d3a4430b64a368f50a0fe5",
+        "dest-filename": "@radix-ui__react-focus-guards-1.1.4.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.10.tgz",
+        "sha512": "15ab3f95742a855beac006fae2ce5115e1e21d812567a49441b65a35de8491f84ffc097bc13210f56211e10557e3be6d96ee7214211d0dc247ebf530b198cc5b",
+        "dest-filename": "@radix-ui__react-focus-scope-1.1.10.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@radix-ui/react-form/-/react-form-0.1.10.tgz",
+        "sha512": "d4d7eebdcb55b57e2c537326abf21dad1f14ba7c6208c89583703950434a845cf150178ec9a410fa599a41a57b4dcf1caaf04ab092f7fca181b22c4ad03f1616",
+        "dest-filename": "@radix-ui__react-form-0.1.10.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@radix-ui/react-hover-card/-/react-hover-card-1.1.17.tgz",
+        "sha512": "1a365020400d564bae59eced94acfa4041dedf5657da20df1f37133024156570b427242b81f296482f8b38e130e9a555eb8cf28f3a1b233480e0053878a5ab1c",
+        "dest-filename": "@radix-ui__react-hover-card-1.1.17.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.2.tgz",
+        "sha512": "a2b042f3c7eeb55a6a0a6857d69e1cbeab8d1ec10b43ec3ebc1267ba3ddfb444c8e5b25bd1b667dd3aaedd258dd8839c3f27139cc1a7870a1eae6bc84adef6b0",
+        "dest-filename": "@radix-ui__react-id-1.1.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@radix-ui/react-label/-/react-label-2.1.10.tgz",
+        "sha512": "89bd33bead99b00a8a9b9b519ea1899f7bcec52808b6ce53a31b174f4ab54bf19f2c3d598fb50e127930f2edb0eac4669f8edd8e9416b925350c22f5476f7fcb",
+        "dest-filename": "@radix-ui__react-label-2.1.10.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@radix-ui/react-menu/-/react-menu-2.1.18.tgz",
+        "sha512": "963f11c63b67eb326ad6849b13fb83b40c026c1f419f18070fef0cc0932e4e1eaed5d3da998856f62b842ebfd9f1dd03fd4cac15b9586077813f08bb4f893461",
+        "dest-filename": "@radix-ui__react-menu-2.1.18.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@radix-ui/react-menubar/-/react-menubar-1.1.18.tgz",
+        "sha512": "857ec41b1fe816ae833d8dbb190b8fff6c0fe3c1877f92c6eabd3a560349946fb39e60d2f0e7e8a59711706972dcbe25b01f45aa998bc7a250484f4fdc1529cb",
+        "dest-filename": "@radix-ui__react-menubar-1.1.18.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@radix-ui/react-navigation-menu/-/react-navigation-menu-1.2.16.tgz",
+        "sha512": "9c9d1292b49082e77262132261e1c0d5ac8b56e76e1090852da9f545964dedcf64ab3cc214b694f64bb2f35b8db6acf078cf586903e05b3c62f4cc10f63674e2",
+        "dest-filename": "@radix-ui__react-navigation-menu-1.2.16.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@radix-ui/react-one-time-password-field/-/react-one-time-password-field-0.1.10.tgz",
+        "sha512": "18791c27e5958fdd40b7e3af5154c3e11dd6d3fc31c3db7fb06e711540585da09bb568a8a195f931ddfbe908c9aa01f856c5725eb6d53473b63b83587268df56",
+        "dest-filename": "@radix-ui__react-one-time-password-field-0.1.10.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@radix-ui/react-password-toggle-field/-/react-password-toggle-field-0.1.5.tgz",
+        "sha512": "7d5b80f36bb46ff7c29696c426ff32a759d4f5e4afa1210e111b14fe185fdc55c63c8be4984ee811a1c4bbca68a30a173b7f7f55aef3ab61344d4718af574146",
+        "dest-filename": "@radix-ui__react-password-toggle-field-0.1.5.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@radix-ui/react-popover/-/react-popover-1.1.17.tgz",
+        "sha512": "fd848039d27b609bdd9fb6e7e6c752c767a05be48a63ebbb3b9472015b3de189ab8367e0e504d214f311933be11b216e138feab263c176bc18a1931987fe1ffa",
+        "dest-filename": "@radix-ui__react-popover-1.1.17.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.3.1.tgz",
+        "sha512": "6e19eaff40c43d38b696c383dc9e6b4cbeb9a942876ca6e1a87b2637d4cc89c9525e98a98bae75a2850a3cfa7a1b9945fd688705d9f5b345aeaac9fe9b2540bf",
+        "dest-filename": "@radix-ui__react-popper-1.3.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.12.tgz",
+        "sha512": "9b7d3d85abc6cec8cb1c76885f9d06e4f96f46cdf19203c2b0693fe4f4ef626f03e6adf7c86d09ef0ffbd763d33a189decd4da1444ed9d25e39e01d06afbe157",
+        "dest-filename": "@radix-ui__react-portal-1.1.12.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.6.tgz",
+        "sha512": "cdd4e4e0f9543b4135f079d9df061b5b42a4249c5609d88d629ea0e97d4fb4e345871564834d6f9624c9026c08b3353a9878b204ea16f4fd2b02e825e7f8542d",
+        "dest-filename": "@radix-ui__react-presence-1.1.6.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.6.tgz",
+        "sha512": "c1eb5dd1023bec36efacfa5302f1f54aa3b1b18176c197b94cdc6ac0e7794f2e170e9577769574b3c2bfd4c18c241798e68ee583cb9be5522dd546fec957a7ea",
+        "dest-filename": "@radix-ui__react-primitive-2.1.6.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@radix-ui/react-progress/-/react-progress-1.1.10.tgz",
+        "sha512": "258cc483ad2593bf4fc0a336ed667229decf5bc3b838ce6339a15f44f7cec9e5e6330eed2c98799128fe0848d54de86cceec2697f01d0b33c631705319fe0107",
+        "dest-filename": "@radix-ui__react-progress-1.1.10.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@radix-ui/react-radio-group/-/react-radio-group-1.4.1.tgz",
+        "sha512": "fd24b165d284a36128dbd14544a774e847c50d8a7c1ebc8a83459883b40b5dac9d3f3979d987d2bc21f66b740305176d72ec000aba094fc5158d0560389ecff4",
+        "dest-filename": "@radix-ui__react-radio-group-1.4.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.13.tgz",
+        "sha512": "f609309de23482e7fc2439ab1713e3245e8ecf3822a32c3efe5a2760d0b079f4bd647034e5eaf40551e25ebf8b6d6187c547dccef318e86d68899662d55ce347",
+        "dest-filename": "@radix-ui__react-roving-focus-1.1.13.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@radix-ui/react-scroll-area/-/react-scroll-area-1.2.12.tgz",
+        "sha512": "c6e69f5734224c22ecc848da928c13746dce8135ec98eec874288eefba2d21afb3e38c682cdb3d0e8e5e83b3ce16e9883828ed1ba7637e6e912942a951afdcb0",
+        "dest-filename": "@radix-ui__react-scroll-area-1.2.12.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@radix-ui/react-select/-/react-select-2.3.1.tgz",
+        "sha512": "c3a783bd8efc2c4f595223675c20354152bc45837b93d81a945bf4f648d5c9d26a04080777b63d03a874509ffa0c264d199319ac1da885c496d41a3d77cfb058",
+        "dest-filename": "@radix-ui__react-select-2.3.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@radix-ui/react-separator/-/react-separator-1.1.10.tgz",
+        "sha512": "63a2ba8cb40255f0a74cbd8c12d1b10cb7df92135f11f1ec120dd66bc254f8859d9f71166cb5dddceb8e7d044dee9fd6fdc51c7b55b24e4dd07ae0280c1ccdf6",
+        "dest-filename": "@radix-ui__react-separator-1.1.10.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@radix-ui/react-slider/-/react-slider-1.4.1.tgz",
+        "sha512": "afdd564a942e70d1852802314fc153d07d33ca3779b4996a39b2e9ecb38c578cf8f4aa030b08f2d35c37bc3394e1ed70c6117d2208d8728ed207a6f2396ec1bb",
+        "dest-filename": "@radix-ui__react-slider-1.4.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.3.0.tgz",
+        "sha512": "3288ca92ee14fe688ef00bf80e46fe72d300431ec9998f7a2e6b4342501aac246d77bacde764024b3045f9702faf94ba7284958fd1c43c180700728425593f58",
+        "dest-filename": "@radix-ui__react-slot-1.3.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@radix-ui/react-switch/-/react-switch-1.3.1.tgz",
+        "sha512": "e796d0b429ce0740688689921e2eaabd05e924412a5060e6ea146b334069879397c2149e82a91df08aa0040424335225814956648c69c517293847d12208a6cb",
+        "dest-filename": "@radix-ui__react-switch-1.3.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.1.15.tgz",
+        "sha512": "93173d808ebf1df714e277cc3154b702640ae35e246d4d4813a502266326c6384eddc44f5cec989e6bf2283f8e0edeeae7a9d1abd97b5a8be2eae686c0a80c96",
+        "dest-filename": "@radix-ui__react-tabs-1.1.15.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@radix-ui/react-toast/-/react-toast-1.2.17.tgz",
+        "sha512": "b8be24cb25b2d34d293cbe377c6182579a93e9972109611064e4a591888fc0fb7c1f2d625b7f118dea6d22fcf5fd265eb2b5ba567e7c0addec57bb5f11f8806f",
+        "dest-filename": "@radix-ui__react-toast-1.2.17.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@radix-ui/react-toggle-group/-/react-toggle-group-1.1.13.tgz",
+        "sha512": "5dbf4f2ed96f53ae85dfa2e229b6ba745b30bba57698392089d3b87cd49b407430999f4e6f13083b5ecc37f2c9e1a58979c56e4952c01cf663c9e33326b81e88",
+        "dest-filename": "@radix-ui__react-toggle-group-1.1.13.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@radix-ui/react-toggle/-/react-toggle-1.1.12.tgz",
+        "sha512": "02c015b18359225441b1c8bb06113e43241e29dd61e937df258b7e945d104247793a94379257c80723ec09be06d21fc5aba3c9c21d4560d96ecc1158ce1938fb",
+        "dest-filename": "@radix-ui__react-toggle-1.1.12.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@radix-ui/react-toolbar/-/react-toolbar-1.1.13.tgz",
+        "sha512": "65ad65e1fe9fcd3906833fe2ca700c37c89aaa229f7f6c26dbf43088b9873ed0d0ade58406bbd28a68101487a4c4c51d44f8482ccef17485f1b92fe8fc31996a",
+        "dest-filename": "@radix-ui__react-toolbar-1.1.13.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@radix-ui/react-tooltip/-/react-tooltip-1.2.10.tgz",
+        "sha512": "36535ef03d1d584a557d71658bdd083ba5f4ec9a2cc7f6f58aef7cb439f1f57bf41d3e302c82fe9b654e85e30784aeea6e9d87a1306a00b105cc6c99b3f95ebf",
+        "dest-filename": "@radix-ui__react-tooltip-1.2.10.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.2.tgz",
+        "sha512": "c42b28f63d7fbbcb0480fd513478c5ad724b0292fc2e2a8e908d51e32c2e374d2bc56758838a105eec0a2d2de2d23e4d58bae89940f6effe279718f650556f23",
+        "dest-filename": "@radix-ui__react-use-callback-ref-1.1.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.3.tgz",
+        "sha512": "3cbcc2f74312f917a8a2d9a30b9f7b76fa29a1e96967c43ad472640d76521318ad22aecf2f9e6f1cd9deb001f082e1cad1a3df067a5d37342dbf5ba589aa90ac",
+        "dest-filename": "@radix-ui__react-use-controllable-state-1.2.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.3.tgz",
+        "sha512": "e9cf19aaf3d35882c42a7c9590fe771064427299c988a4c2db5b12ffa475185e712b21c92564043df92a95c81491d4508af77ab5bdb769b5307b89e05a663424",
+        "dest-filename": "@radix-ui__react-use-effect-event-0.0.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.1.2.tgz",
+        "sha512": "dae54bbcb8e03bb359096c34d7f15da91c26038d89d017233cc50203e9281443806fece3a883fb4a2173ffbcd63eb2a75664aaafbe8e9aad802f20ae5f87612f",
+        "dest-filename": "@radix-ui__react-use-escape-keydown-1.1.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@radix-ui/react-use-is-hydrated/-/react-use-is-hydrated-0.1.1.tgz",
+        "sha512": "ab03a2cf84e3a3c08d9eb38b01850c5de6700f35e05e9bcae132903e658b10233d5e85af03afb4676ffb020dc0e22be34b8a2f6cb24f6ec924c62a05c8186bf0",
+        "dest-filename": "@radix-ui__react-use-is-hydrated-0.1.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.2.tgz",
+        "sha512": "8eb0563b16484ee19c9e3442336b7653964f9022f10fe626e838dfb2c4b985a4e3da289a93f0ce6fae0978de8e74b7cb829b5bebf7b690a47e66e4eb1a86533c",
+        "dest-filename": "@radix-ui__react-use-layout-effect-1.1.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.1.2.tgz",
+        "sha512": "2060503ed44576137a310f1d6de815981ab52d5665bb26b71758d663ea6e21c402dcc1dcb51c130d20560a42ffdd97273092d3309fbe67e92d9af83417cf620b",
+        "dest-filename": "@radix-ui__react-use-previous-1.1.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.1.2.tgz",
+        "sha512": "77c6be6c163f1718a434f960249a1a047657fb32956d61d82464cb9cbbef7908054939ed9067442afdc90ed1eb312d03358a65973da746c4cb18b298b6d6e99b",
+        "dest-filename": "@radix-ui__react-use-rect-1.1.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.2.tgz",
+        "sha512": "822590a7ee26c6304fb78299d0c9b2bb29053567db0f12ade31f9f3e44589a04452526c2645cd4825bcc6ff2a39f7f2d9b5d183f8b9f890643c77ce76b82d4eb",
+        "dest-filename": "@radix-ui__react-use-size-1.1.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.2.6.tgz",
+        "sha512": "8c21345a58d689f4c8e27888302965d3a906a6c25300f899554f47e1647537aa96ec0b7dcacb476cdedd0c1fb07b6c47e77e6ba051e3eea292f911a3d0530359",
+        "dest-filename": "@radix-ui__react-visually-hidden-1.2.6.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.2.tgz",
+        "sha512": "c675c4ef01b5dcf23e73189e56cb185e5409b98551847f4d068c6ddca370ce0843200ebd18c9bb778c17468b872188c4f8abd2e94fccb0c3bbdcd752d8c1fd64",
+        "dest-filename": "@radix-ui__rect-1.1.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.3.tgz",
+        "sha512": "0d3e99dcf86f8a878732fc68fb11dcdcab6a820ac8ec20935c2982da1ff9cd4969e63562b6fed7132fbdab9ffbbfc228961962a1ac29328f0a834104072ec9d2",
+        "dest-filename": "@rolldown__binding-android-arm64-1.1.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.3.tgz",
+        "sha512": "d0dc20c2c8ccecbaecb959d730ade4a13a5a80134e865a1cfc13632aa663bf8579cc8e6bd77ab1ebdb95851c7ea39674cb2e07ceafa5a72ed3020506fe872faf",
+        "dest-filename": "@rolldown__binding-darwin-arm64-1.1.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.3.tgz",
+        "sha512": "62d881a78762b2ee95e7ad25a13e8f8cc76245a5a656f0cdad4ba701a95b885c76820789c31740b2064c72818fd7bbb202c4f0023e55d678a4b319479d54354b",
+        "dest-filename": "@rolldown__binding-darwin-x64-1.1.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.3.tgz",
+        "sha512": "c83dc49047579362f2a4fc677ff9126478ab6abb08f2070fcdceb64ae92147d5494f2bd5f85f50fc6c5636e0a88dceec5f2b950b80f144685d0cae17f154ac6f",
+        "dest-filename": "@rolldown__binding-freebsd-x64-1.1.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.3.tgz",
+        "sha512": "73ef2f89e41bb03ec73401ca200df8c34189f4579d145b89183fbb13abf3ed0deea8022e80be69e397e196c8f851a02c1e972696aba0056321034fe3ee8d2c22",
+        "dest-filename": "@rolldown__binding-linux-arm-gnueabihf-1.1.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.3.tgz",
+        "sha512": "e748c3d2e5302efbabed9cfd2c7cf5ee46807533e39f9c0df77844823be6605459c2247b649628bd37798a9c962430275cabd9fb081cfbf2246ba770485e4e70",
+        "dest-filename": "@rolldown__binding-linux-arm64-gnu-1.1.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.3.tgz",
+        "sha512": "04ef7ea0f2fc2bda6864905f60fb1736d6233c4e6e337a9e7a14f7685716e0b2133a5fa24aa869d1a6f38d1da758150d8c865e2978c0116059eb85a33681ddeb",
+        "dest-filename": "@rolldown__binding-linux-arm64-musl-1.1.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.3.tgz",
+        "sha512": "7f75692c1d6f434128e9e72bffa71e90b9ef60c145e18045a151a47e4bcf2ead5b0246c0c076103d92a80261ba389c93731c680be02f7b31b1fd2d686cd0b433",
+        "dest-filename": "@rolldown__binding-linux-ppc64-gnu-1.1.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.3.tgz",
+        "sha512": "026bab676e8fab1fd123d37583310e0a496429797ddbbca37d7594512d0eecfba1f0044cfce6fca9fac3dea9d692c49c770e9c4ab5b93d21c4f43c8bbbbf8fb4",
+        "dest-filename": "@rolldown__binding-linux-s390x-gnu-1.1.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.3.tgz",
+        "sha512": "249a6ab3c6d11884c339d6e434a9e5a23cc169b6ce1ebaa34af0ebd0856c64e6c4d6505c3e3c48b54118f5e5880dbc5a277706ad73d619f1a42311628e0fd446",
+        "dest-filename": "@rolldown__binding-linux-x64-gnu-1.1.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.3.tgz",
+        "sha512": "ad225c7633f1cc0fdbcbfebfad8b3ebfe6d753b523be76d45b3f0c25bea487afa49ea075742aed1e0d2ebbb0bfe216aa26fa9d9181d0e481a7fad087f462d6fe",
+        "dest-filename": "@rolldown__binding-linux-x64-musl-1.1.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.3.tgz",
+        "sha512": "850dff3d89032480a07afbf235c56b8a155eaaaee4d4fa77559f6563e75ab8061424a3be6aea80a6f00d86f475027f41866a982af5b632ed45f6ee035d230bc5",
+        "dest-filename": "@rolldown__binding-openharmony-arm64-1.1.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.3.tgz",
+        "sha512": "12572ffc1b4c2fd957ad5e89b8a21373f82b37691857d823b10a56f097f0e22a0ad133a48c18f27b49e7caa40dcbd49335a236d255cd690051ac3e604a047462",
+        "dest-filename": "@rolldown__binding-wasm32-wasi-1.1.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.3.tgz",
+        "sha512": "d83ac47e196e1fdca189a140a66b23b23c2b4986cd718d68153cd848fd5ae77e630db57df330856a703ff7a4c151dd220c57311a6c3d411131c06097cf753efe",
+        "dest-filename": "@rolldown__binding-win32-arm64-msvc-1.1.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.3.tgz",
+        "sha512": "38be0e324ed43d739e54619ddeaa39cc9c8f2258dfe0016093940090f3d2f8ea0bb8e3a8ce1b9a4060b5f0cc554e7c3fd3aabdde04a1009ce5c2748263d62da8",
+        "dest-filename": "@rolldown__binding-win32-x64-msvc-1.1.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+        "sha512": "da3f5b1ade4987c863faf3ed8333ed97bda3d324711c0cae9a8a3a4cd7c08ec2c1d3852da52bcf6cf703701331cfb9fef42601d1cd46c501716118368e29aa1b",
+        "dest-filename": "@rolldown__pluginutils-1.0.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@simple-libs/child-process-utils/-/child-process-utils-2.0.0.tgz",
+        "sha512": "76f36844a2e28d79c3d17a09033f78a5b36e079190803af9e5486948f85f7c39134f40a672a87d8d208eb707d3d9de07e8c23d13b7384a0b4cb895d9e85ddce8",
+        "dest-filename": "@simple-libs__child-process-utils-2.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@simple-libs/stream-utils/-/stream-utils-2.0.0.tgz",
+        "sha512": "7c24ee64ae1005afb7f4ecfd9783867c97f3f86a700a9dc0a8eed9721deda3df711cf82cb55b11169790f0b35dda8d46bfcada2f698217089a1e1edb152a790d",
+        "dest-filename": "@simple-libs__stream-utils-2.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.1.tgz",
+        "sha512": "e8d0daa91a003125c3d66aff457bb41c1bcd13d6b69f9b473ecc6ef571cbc2cf28e13c1eb39ac1336db4e52514889f60a00b5a76b37ac53197d140c4c29fcde0",
+        "dest-filename": "@tailwindcss__node-4.3.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.3.1.tgz",
+        "sha512": "4959727fad60dfbe25e5c1f283cc7d91fe7198b70e6b1bce4ec6eca839d2b0325a28e10567b182be2f38540546a71a2360eb35fb72ba3345235dfa8f53cbe639",
+        "dest-filename": "@tailwindcss__oxide-android-arm64-4.3.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.1.tgz",
+        "sha512": "8559d62f0bfe7bf97b73858ac95b4756b20fbd876a5878d107730322a011ca7cc5b67420f399264041426d5f496b4555c78c574c8883598eb463b8b3fe23680c",
+        "dest-filename": "@tailwindcss__oxide-darwin-arm64-4.3.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.3.1.tgz",
+        "sha512": "09feda6eed165606e153b00d80f527480be6ee70af3307aeb076fc16768794b7effc26aae0661a11983b6489b3ce68f1e252007ee4bcabe78b212ec0ec8cf122",
+        "dest-filename": "@tailwindcss__oxide-darwin-x64-4.3.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.3.1.tgz",
+        "sha512": "659ab35f663e197b575dfa927e92610e6eb43a865fbcb1cb0a09be27b355aa01c72631bf9bdba0648efb4704ec55de1f9c126e0853fa01eea44c96fbd54752f2",
+        "dest-filename": "@tailwindcss__oxide-freebsd-x64-4.3.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.3.1.tgz",
+        "sha512": "fc087fc629342da3187eff436744bfb78a4194135839caad470bac8e0a2f1e4bd3f22c6e79608bc898ec685e644087248dbe084fc43a2baa7f88f999322c5882",
+        "dest-filename": "@tailwindcss__oxide-linux-arm-gnueabihf-4.3.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.3.1.tgz",
+        "sha512": "82a745a15265c38e381afa6785e64b1e6bd3cd2c48fdc394521d8a48d7a34234dc6245b4eb64950fe127d2b5200fe415f756f3d571881adb751c9778f315066d",
+        "dest-filename": "@tailwindcss__oxide-linux-arm64-gnu-4.3.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.3.1.tgz",
+        "sha512": "070bfd2b03af13454a6bceb13c589ff5bf5cdd8d4dc4e5753f480bb62fc861a584b106195c39717c612d03c99d0d9ed21b7c32357016613e52227de088be7ba0",
+        "dest-filename": "@tailwindcss__oxide-linux-arm64-musl-4.3.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.3.1.tgz",
+        "sha512": "6268bc3bc4f5e4761074e51652d4c8ea574dd277873fce450be433df6c53719ee2257b5e9bfc7c2137afd28d5ef5ee6b92a8f894e3597d344bbe49a29f5fad2a",
+        "dest-filename": "@tailwindcss__oxide-linux-x64-gnu-4.3.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.3.1.tgz",
+        "sha512": "33e3fff75a89eae20b2f0e24d86f7718c0d10178fad5232f15062ddfd02abd4a98804c57a4b2f969ea5f9eceec8f81e20107a8962ad017d13497346f75fe333d",
+        "dest-filename": "@tailwindcss__oxide-linux-x64-musl-4.3.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.1.tgz",
+        "sha512": "cec33cb8e7aabd5187b005ec271b13dbcb6da2c15a84b24a08b393501a9102d2a7560192462b5db3d4f8df64224fc6fbed881aec920192e9484519493ed62144",
+        "dest-filename": "@tailwindcss__oxide-wasm32-wasi-4.3.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.1.tgz",
+        "sha512": "6a236f4aaf41b1593c579d779432a5ac214081ff2a04c3d94e98048489cbf8dc10aacf7b9989aea5532b3eb8010522fc3efff4cd7bbd32b305f6b32e9f565e36",
+        "dest-filename": "@tailwindcss__oxide-win32-arm64-msvc-4.3.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.3.1.tgz",
+        "sha512": "c43132bb5ae0dbdd38ef614419a2879f3c83ca1e501fe0255afb14e6132832d3e9ce62a5448d236982828121c362d6905993986cc69db92c82c05c18e27d4798",
+        "dest-filename": "@tailwindcss__oxide-win32-x64-msvc-4.3.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.3.1.tgz",
+        "sha512": "c953f2a3c44d91a6d5af73b61211c413445ec2eed82b37350e122a7cbe3a2cabde16b9aef576c36b334e258eff191bafc3587abb7bad5a7476f47fe9e493e580",
+        "dest-filename": "@tailwindcss__oxide-4.3.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@tailwindcss/postcss/-/postcss-4.3.1.tgz",
+        "sha512": "74d26e35b744253fd2591b974d83f55926a67a5b33df3b6452c76d5903e3adec72b2b4e96843cce343ffef59275e25cb604a23a8f3841a2b552cba4f312e53e8",
+        "dest-filename": "@tailwindcss__postcss-4.3.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.101.2.tgz",
+        "sha512": "847e4c2e826117b29a20677bab7c535c65efb2523e19894cd59ff7e5a4871d668225607b5ef4d21d8b95dde33bb70f9a134993ff132ba3833843dac21874f497",
+        "dest-filename": "@tanstack__query-core-5.101.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.101.2.tgz",
+        "sha512": "b1e0e4afa9331b35f5a2469a4ed64fb6003af3c0833e55d4cf50bac52834112aa7d3856e73cb65ad89acd6cddd7bece706a84f5711517e901f51ffba5ef7cf5a",
+        "dest-filename": "@tanstack__react-query-5.101.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@tauri-apps/api/-/api-2.10.1.tgz",
+        "sha512": "84a2ff8d67f6f77503494374f6b47af61ad3a3221705bf028c66960bb81f8a7be742b055be72ebd3c15e162dfc831b6e80057255c4dae7f143fd79e46f5b2207",
+        "dest-filename": "@tauri-apps__api-2.10.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@tauri-apps/api/-/api-2.11.1.tgz",
+        "sha512": "33614fb98343da6fb087985f5bd66949dc4c3dd109a2f3c15b0a07266c14a72b1360d1da3a4545378d7d9bf2b42c88236ffeca536bc182c51ea495ae8100af00",
+        "dest-filename": "@tauri-apps__api-2.11.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@tauri-apps/cli-darwin-arm64/-/cli-darwin-arm64-2.10.1.tgz",
+        "sha512": "6763a3097899f9f6d8672ecf98fdd64673a933df85cbea289ca0c499413a330378206698aa071e4e3c07b9c73f904118668b391880af7b7e5fed98a2ce0a849d",
+        "dest-filename": "@tauri-apps__cli-darwin-arm64-2.10.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@tauri-apps/cli-darwin-x64/-/cli-darwin-x64-2.10.1.tgz",
+        "sha512": "57f8ab415be33cc18e4d0a8d8f9e4f9d03d5b87e1524ff2f64237b6a39e3f994bc2a89b5b44336851dea6db211a12ddd04ab3999b1bcca0d560bef7b76ad7b3f",
+        "dest-filename": "@tauri-apps__cli-darwin-x64-2.10.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm-gnueabihf/-/cli-linux-arm-gnueabihf-2.10.1.tgz",
+        "sha512": "1f2cf0b1be159c258a19f4f0fb04add79676a4bc367f425d1417eadaf1c138186f83ba22eae84a885f3b8666d73815d465a1a4c910e4087b1dcc97087e8242db",
+        "dest-filename": "@tauri-apps__cli-linux-arm-gnueabihf-2.10.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-gnu/-/cli-linux-arm64-gnu-2.10.1.tgz",
+        "sha512": "3b2398b36b791a4048bf25a3035fa1e026714dc773d4e64f09600fcf90d811f0747275871114e743f48b6b24339dcad3d24c11a127d2cfd2b17a79322684de94",
+        "dest-filename": "@tauri-apps__cli-linux-arm64-gnu-2.10.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.10.1.tgz",
+        "sha512": "3088fbf0f0c31a3920dcda86a6d0ce1a07d792ced2609c2188c87c481a194bebdf773ef23f98cdd7c6cd68b9c386c5483c045c0211354e5b197bff18c68db3aa",
+        "dest-filename": "@tauri-apps__cli-linux-arm64-musl-2.10.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@tauri-apps/cli-linux-riscv64-gnu/-/cli-linux-riscv64-gnu-2.10.1.tgz",
+        "sha512": "5f496f395520f0f0956a812d1009e9c669e4c2513581c3034ea7e16de7c808a0e739327912cb77a8bd12ad6c62cc369c90838a05cbeda5e8eb4a2569b8923593",
+        "dest-filename": "@tauri-apps__cli-linux-riscv64-gnu-2.10.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@tauri-apps/cli-linux-x64-gnu/-/cli-linux-x64-gnu-2.10.1.tgz",
+        "sha512": "dbfd766c4cec252f5f00ac9bc6089c083171603d56108f643beb650f05f9ce7586d86c0c05a896726846959f1f8be0cc7bd09795c55aacc4d87342f7444211c7",
+        "dest-filename": "@tauri-apps__cli-linux-x64-gnu-2.10.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@tauri-apps/cli-linux-x64-musl/-/cli-linux-x64-musl-2.10.1.tgz",
+        "sha512": "63c274673b303f3e7451c18e16e5c610caf16e3c0a48f8177edc79aa792e32cdab9b0401e6cb2f2dbead9f9e300d26317bb4babe52e86fdbedd152ae34e68221",
+        "dest-filename": "@tauri-apps__cli-linux-x64-musl-2.10.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@tauri-apps/cli-win32-arm64-msvc/-/cli-win32-arm64-msvc-2.10.1.tgz",
+        "sha512": "892b7907cea31d800f25afc8958c3ef925ed14f1a75ad149ae21e7ed7d0d14156e9c5eb3bbdfbfcce9fc3a0a8859297c460ce12c65d0104b4605d478c33a5582",
+        "dest-filename": "@tauri-apps__cli-win32-arm64-msvc-2.10.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@tauri-apps/cli-win32-ia32-msvc/-/cli-win32-ia32-msvc-2.10.1.tgz",
+        "sha512": "817cb1804cec15e8269d6cb0614e6910151191c14dfcea38e44030bd9ac7321fb3512100bcee44f135ec80f003626df5775bbb3905373b71ec61f5417f69a81f",
+        "dest-filename": "@tauri-apps__cli-win32-ia32-msvc-2.10.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@tauri-apps/cli-win32-x64-msvc/-/cli-win32-x64-msvc-2.10.1.tgz",
+        "sha512": "e829fb6293c5c330a1cb4111cfa7632849947a15ab62533ec5368dcc63e0668730dc10fb39fc1f5872955b15f3763116d8a7ca90775d7ddc4ad575d362a0512e",
+        "dest-filename": "@tauri-apps__cli-win32-x64-msvc-2.10.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@tauri-apps/cli/-/cli-2.10.1.tgz",
+        "sha512": "8d034617fe6abb03917594922ed4e5bb2290fa8e9231afc050809f85fe1e80218574c1ea5acb00a5581849b83e8e6ad9a1cf1ed43b1c36f8d39d7b651cb4b5d6",
+        "dest-filename": "@tauri-apps__cli-2.10.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@tauri-apps/plugin-deep-link/-/plugin-deep-link-2.4.6.tgz",
+        "sha512": "514392b745398ee2b6d2e84ed8ca07657fc83db964ae1521f953ed21ebb7470b7323447d126dc0bb37e0fcfc1c67d3eff262e77b7710e29f421570fa5b1a8264",
+        "dest-filename": "@tauri-apps__plugin-deep-link-2.4.6.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@tauri-apps/plugin-dialog/-/plugin-dialog-2.7.1.tgz",
+        "sha512": "38ad5405762dfa88dc9b1324b73ceeca89d8205b5af02980012a57f8203e0d318adb82a51e385823ac7688e27f4e3645e0deff0022b5a059843a3218f4887339",
+        "dest-filename": "@tauri-apps__plugin-dialog-2.7.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@tauri-apps/plugin-notification/-/plugin-notification-2.3.3.tgz",
+        "sha512": "670f991f5f1125be351b836b7c7808ba87c98b29aeb2a37eabc7c6508215eefc821fee6c4a7e5ca2a46ffcc581f6a113b14b3deef994d38e6aececac78257742",
+        "dest-filename": "@tauri-apps__plugin-notification-2.3.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@tauri-apps/plugin-opener/-/plugin-opener-2.5.4.tgz",
+        "sha512": "d479cf91bf809a03b6f4705ace6e2e3cb281fabef3cdc4c15b57747f2629d6e3fe8f0b69a2234318a30ccf3e7c485a78f67388af1744dda509b53e7b95f3bd09",
+        "dest-filename": "@tauri-apps__plugin-opener-2.5.4.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@tauri-apps/plugin-os/-/plugin-os-2.3.2.tgz",
+        "sha512": "9fe9d759eb92785f70704b123e64670441ab4603b2ea38e4494f94542395f1850629bd9eae10cec62b3b22a457891547858f1730a92cd34049d0e01d9297faf8",
+        "dest-filename": "@tauri-apps__plugin-os-2.3.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@tauri-apps/plugin-process/-/plugin-process-2.3.1.tgz",
+        "sha512": "9c26b87c655a0cbfc1f5a8b4dd5c8f3a37c01d11d2073e6fe85fce6ec07bdebfdd0373071e166d95d68330873457fa67530f5e873af68841be5e4484c82d0924",
+        "dest-filename": "@tauri-apps__plugin-process-2.3.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@tauri-apps/plugin-store/-/plugin-store-2.4.3.tgz",
+        "sha512": "f4b58f8fdc8ca61462f5ccc4b54bfced71db9756fac6077d117a4fad49eaea71bbfa76eda05f387782b0cfdc6102ffc77f7d2caf9f29abb10e97223ddfacbcab",
+        "dest-filename": "@tauri-apps__plugin-store-2.4.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@tauri-apps/plugin-updater/-/plugin-updater-2.10.1.tgz",
+        "sha512": "34560c83eb563993c977313f3e9163daa7eac005b0352de45eb6f5b66d609c127d998cd9e160d1af0cbcb9dcd6a009df1821cbb9e3cd2d8d565423479e1dde44",
+        "dest-filename": "@tauri-apps__plugin-updater-2.10.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+        "sha512": "1777e8d4c62b44960bdf3111d0e50e9a4bad8ebd55a76de6eceb12829ee7ab848fe8ea97e82ff9e971483c09796eddf3681463996ed21b3deeffa2f016961c3a",
+        "dest-filename": "@tybys__wasm-util-0.10.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+        "sha512": "ea8601022e62920e0f97e906b2862d6b050c053db364c0af3cd17ba552e71d97ddd737f7f034625a7fe04f4d51602754aa4bfb161afe0bda2de3fb5bfb6b15bc",
+        "dest-filename": "@types__node-20.19.43.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+        "sha512": "17a6c4c9a995f632860050449a54277ac44f18e42a4b6f94c22d049b5e717a73b11da7f686fe8bf180959f7acf74f24e8897cf8829cb211cafc156aa318dcc23",
+        "dest-filename": "@types__prop-types-15.7.15.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+        "sha512": "3047b751ea043585455f3a17116b2f72983a66f96b14d94e43b10eb2f848dc27c05f0ccf7cef10c2ec5de349dea6c60aab2c954274dd11fbfaf2af75c8b70aad",
+        "dest-filename": "@types__react-dom-18.3.7.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@types/react/-/react-18.3.31.tgz",
+        "sha512": "bdf12aa574efc13f75ca19b075fa2e4ad3768522b04efc91b3caa92df003cababf9310f0d2164ced693d520d4510b8fc8486f2f92ffe910092445177da7bf643",
+        "dest-filename": "@types__react-18.3.31.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.3.tgz",
+        "sha512": "be616f728e7f42e0b67fd3a3fb04e4d3ef577831641f149a9b064a61ceccc58c0a2027ef52f94c86a288d15b8808f96d1aa8759dea81283bcee247acd726bcbe",
+        "dest-filename": "@vitejs__plugin-react-6.0.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+        "sha512": "4e16e58be3a53a3fa230f60505505f2773a60809da4b2367e0cd6fcfd4fa1a46b926df5b6bf1c8479ea3a32eb9b58ea4c7f142179557341f35f58eff194ac118",
+        "dest-filename": "ajv-8.20.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+        "sha512": "06add2992a721476968cf93c21ff7273ab2f33c739e9d079040b56e106f0e631d3c305d77132e844c9290c9a7a54bd17ce559a0874d7ae415444c6260f4b0baa",
+        "dest-filename": "ansi-regex-6.2.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+        "sha512": "e038fa336f0907ea001fc9059132d4a3e6b68f038592ea9bdf2b9c53408035c45151bc52d1c3f49d96021a371cdc1357c1122c5159831a0cdac267bbcef247be",
+        "dest-filename": "ansi-styles-6.2.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+        "sha512": "f3ef56a9e6db173a57f4e47e59ae8edbd6ac22881e44ccdc1ad00835da4c1c7c80835d1fd3969215505b704a867ff3d7c35123019faadbf6c4060dc3beeacadd",
+        "dest-filename": "argparse-2.0.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/argue-cli/-/argue-cli-3.1.0.tgz",
+        "sha512": "0e106905f5cbe124b6b82d0df76d8c31a8ca47709dad31b4bb6a2bd4f35881732cad2cd5889adbb6f4f49c22e52c6508d2995a9bf6590aceda01ab87b56f6d87",
+        "dest-filename": "argue-cli-3.1.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
+        "sha512": "8a4dd9802f5d63f95855533ef8e212b1a6037a0d6d6f456d3f9b8bde8ba1d64a0639a50c0cfa5b1487a2e099058a659414f9fdd2c6cc34c5d000854e96760a24",
+        "dest-filename": "aria-hidden-1.2.6.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/attr-accept/-/attr-accept-2.2.5.tgz",
+        "sha512": "d1b0cd9d8feeea93f01c3328174162794df9e28062d1af2b0fd15cb0bc3370659b73c292f0a3c88bbcbeb35dce95563e80c59cffdc4431480d13a426f1996561",
+        "dest-filename": "attr-accept-2.2.5.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+        "sha512": "3fc06302c5ef652f95203508d7584709012fef8613ebb6148b924914d588a8bdb7e6c0668d7e3eab1f4cbaf96ce62bf234435cb71e3ac502d0dda4ee13bb2c69",
+        "dest-filename": "callsites-3.1.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz",
+        "sha512": "29afbd4ebbadbfb1bc33a593e927a2456cfbf762b9a84a881841b35ca84013ac4e58063aa4f1fc53ef48637a0232fea4a9398bb2fed787fdb0d918a091e3ccb2",
+        "dest-filename": "class-variance-authority-0.7.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+        "sha512": "93b9dd80a870a10bde04bfbfd6da86258373d3dec8ed63afc1b9a6536011e7e99a82d6e33d64134b50b9bf31a4042f189bc5164737ca533514a852f2a58e10fb",
+        "dest-filename": "cliui-9.0.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+        "sha512": "7989b441606d52b0566561b4777f3a386030d7a67df793e2395a3607b6e35926c779d1a5e5ed1959aabae6438681448d7ac1080e407d2126d383f24af5d84264",
+        "dest-filename": "clsx-2.1.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-9.2.1.tgz",
+        "sha512": "a1648be998675db62b68e1532b73e0440409f1f0030c012fe4ae8075ec903cbbe3166846f3e7a32f48d9669fd1eef4e6189681bd9104fac13b741e1b0afeec03",
+        "dest-filename": "conventional-changelog-angular-9.2.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-10.2.1.tgz",
+        "sha512": "9f82abd4714c4dfde231b112d13331288718b5452fe2b2aac90429d89c1f3847c508e7c64f74eae260b227c4bdfd83f25a1c9d8df2abaef9f297e8028c0fa625",
+        "dest-filename": "conventional-changelog-conventionalcommits-10.2.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-7.1.1.tgz",
+        "sha512": "0747f8da323ef95e556fba8af830f0ebcaf474dc73e6193e45d294931d8d3a2dfd7a673d86c1dadeed8cddda05ed0421445cc2ac08fbb8cf74b5e1be4414da61",
+        "dest-filename": "conventional-commits-parser-7.1.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+        "sha512": "7a2f00a2cee36b4c1e469173267100f541c9ffb5d09aa8256d1c277f60138dc07d5aaf3be15287f647e38e2acce94854dbf1397c561a77297284595d72a4a275",
+        "dest-filename": "cookie-1.1.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-6.3.0.tgz",
+        "sha512": "024afcd961f559fa9ab728aaa63f070e43b6a362a6251bb516129f48d24fdcae08757c077c4c8becc39beb68b50064152ed21033e88213d0863adadf851fa698",
+        "dest-filename": "cosmiconfig-typescript-loader-6.3.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.2.tgz",
+        "sha512": "82d4d9c530dabb5c0bed8ef389f73675df231d22bf93a053c7fd97a7f06976501d9e5616155b7baa126a8308bbeb7ef2470450dea2f866275b07823cb40e553a",
+        "dest-filename": "cosmiconfig-9.0.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/country-flag-icons/-/country-flag-icons-1.6.20.tgz",
+        "sha512": "a72f098842b38e1630e873c9d0bed2c4b8026229b7e943d14d95f8dff92a1ae7940992d2be7aea022c16f07b5089bbabee67641505248ce81d2bea3ff4506d6b",
+        "dest-filename": "country-flag-icons-1.6.20.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+        "sha512": "cf51c629c632db103c00641fc2b9f43c0cbe3c1ed7fc64a3dd45495bda8aca7e37c566be825e675e6538aaa2cc4735952c50bc2aeb145fc4ffd240a2398a4021",
+        "dest-filename": "csstype-3.2.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+        "sha512": "06d8f604e38ef37a375b21f9f5ef0c817b3111055c6ab9143a9118aee6c1d2eaf09cdd74c90dfae2bb22072535d67665a966199b4e62fe87fb8a8e26ce2841b5",
+        "dest-filename": "detect-libc-2.1.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+        "sha512": "ca9766254fd36c16f2d83c626eebfb64b5b706cd5012633b9c78c400d7e88492ef1345d5ba38ac9f5a8f25c67183ea83b9cb2bf9b3fa7cb0f5acf4b702127b11",
+        "dest-filename": "detect-node-es-1.1.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+        "sha512": "b68508f38612e589b15b6d7d7ab9e2583d022153a8e3ac46282a2578d41180ecc3a2b8018b5bf80fbd7f385ce00fd18ed9418a22fd42dd2a7c0c09f4fa3e70ec",
+        "dest-filename": "emoji-regex-10.6.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.6.tgz",
+        "sha512": "68d9c60af6c9fd12325a8d48ba135d5639cd17e1231fdc29ce9347b7e722fe6f477bd2c9bd437cc2b09c5e3a7d716b06340baf4a95454f1fefada00543ca868d",
+        "dest-filename": "enhanced-resolve-5.21.6.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+        "sha512": "fa1d6590b2a164c4d88e8835544a49346ecd64959cb9cd830e4feab2a49345108e5e22e3790d5dd7fb9dad41a1a8cc5480097028d67471fdaea9a9f918bb92d8",
+        "dest-filename": "env-paths-2.2.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+        "sha512": "b2a41a9809d1d785600abd40eb5f00dec1abca07292be1c46de9c0fc7884024914c1c648201fed816a871715a03b20e1e270782424629a1efd751e58c1cf4c0d",
+        "dest-filename": "error-ex-1.3.4.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.50.0.tgz",
+        "sha512": "3b264a85456f11ea7d213122c079fc18a9cc450215aa84885fb5a745b916809925942ba38a5a8fdab0f4bbdefdb6497cc2ac9cf080b095cd54055bff4a5d46eb",
+        "dest-filename": "es-toolkit-1.50.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+        "sha512": "5948f6aa5c5a42d3b883a3eae5cdbd193716183c9df22b4bf334e58a98040b3dc97ac02288e2a8b5df0953aa2d0773c00a01bac64254c9585ba0c4be6e37bf8c",
+        "dest-filename": "escalade-3.2.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+        "sha512": "7f7a90f68432f63d808417bf1fd542f75c0b98a042094fe00ce9ca340606e61b303bb04b2a3d3d1dce4760dcfd70623efb19690c22200da8ad56cd3701347ce1",
+        "dest-filename": "fast-deep-equal-3.1.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+        "sha512": "f099db910e23b83caf62ce26805190aa0e32098b450ed52d9a9d90210ab5d5965ee42150e7072a9b5aea0e0021fd074cc92b819cfccc5222543591b937f02243",
+        "dest-filename": "fast-uri-3.1.4.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+        "sha512": "b486d8b596ee70eb340511aa3c992c84951874bf920c7edd54cf208f2f84469dd60148cb105244fb4da46a7c87b708d63a7c2b298062c0098cd29e242c90275e",
+        "dest-filename": "fdir-6.5.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/file-selector/-/file-selector-2.1.2.tgz",
+        "sha512": "4205e8fa65d37bc9637aa505697dd0547739a2c488b49fca9bec69a1cc74692a9618c4827faa98b3f567cd9812f3ae0f8e7e6271e31116281e015ec07d395a8a",
+        "dest-filename": "file-selector-2.1.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.42.0.tgz",
+        "sha512": "c29ec42677d669a112715ca02afddedb4b9da11cfe2dbb7149cb2e4e46a40317d79adf91782e96c8f5b69c8351006bddfa11bda1dc1c8c12f23933e31f9a4144",
+        "dest-filename": "framer-motion-12.42.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+        "sha512": "e71a037d7f9f2fb7da0139da82658fa5b16dc21fd1efb5a630caaa1c64bae42defbc1d181eb805f81d58999df8e35b4c8f99fade4d36d765cda09c339617df43",
+        "dest-filename": "fsevents-2.3.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+        "sha512": "0f214fdc133fdd81d340e0942ffc343991d1d25a4a786af1a2d70759ca8d11d9e5b6a1705d57e110143de1e228df801f429a34ac6922e1cc8889fb58d3a87616",
+        "dest-filename": "get-caller-file-2.0.5.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+        "sha512": "4116ef0c86f1e9892551ee91c5e4de95e311d32bf77181fa3ec3d91dc9d59fbc6fef33b504737caf45c44eef27e987b743e6a1b526ab7375a0b4d5a67a12017c",
+        "dest-filename": "get-east-asian-width-1.6.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
+        "sha512": "1498584680da89ab5f12450af072a589c9aeff7486143e75ab78ad2831a8493cac4090677ce7315391b19e113513ab2807be8c6d3d0c06d9ca26e5f2031fbde9",
+        "dest-filename": "get-nonce-1.0.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/global-directory/-/global-directory-5.0.0.tgz",
+        "sha512": "d698057612b72762de33e7557f63dde36e321f1da8bb7dfc942d04acd3f684fc788fc796d52a745ea4a3371b64e937382abe70956b52bf3f1c9f6c9beff486ff",
+        "dest-filename": "global-directory-5.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+        "sha512": "45b279fe398570d342703579a3d7939c12c9fc7b33595d0fef76dcf857f89d2feb263f98692e881b288e2f45680585fe9755ab97793ade1fcaac7fa7849d17bd",
+        "dest-filename": "graceful-fs-4.2.11.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+        "sha512": "e60b39cad68d8c1ae1e4ec37cebbdd51463ed15c48b9654be22f62aede9fae257e06a7427e6575d4241358c8816161db5e1728f89d641df4ce52478f8420ef30",
+        "dest-filename": "husky-9.1.7.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+        "sha512": "4d1dca7eb4d94d82cf07a8d48dfc7a305f56716ac72fdb2ee5339b2b866462005d58a3ce1684a8408744b93b91f36a66b711f6b29586f61e9eb707ebd692c1a9",
+        "dest-filename": "import-fresh-3.3.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/ini/-/ini-6.0.0.tgz",
+        "sha512": "2014dd224cd934ea6a9bbab7751a89bcc6a57578c31d69040dfaf0184413b3979a40c595f9d8c0851fb06a1c8d34c01afaaa5b0d4841315b7864a370a4f9bbc5",
+        "dest-filename": "ini-6.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+        "sha512": "cf3d3a4bcb74a33a035cc1beb9b7b6eb37824cd5dc2883c96498bc841ac5e227422e6b38086f50b4aeea065d5ba22e4e0f31698ecc1be493e61c26cca63698ce",
+        "dest-filename": "is-arrayish-0.2.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+        "sha512": "f8f822faf32e50d909c84c62301b792251683322a7af9ce127852ca73e7c58e841179428219905c8d1c86c102d1f0cd502093946d9dd54db0344deb5fe6983aa",
+        "dest-filename": "is-plain-obj-4.1.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
+        "sha512": "7a48a50923758f046f21b81e83fe7b60587ca900cd6f00dbf714ffaaed830076c5159522708978ca055a02fcef78c84c56bdcb9e948a4cd9f0b7c3e839f98a85",
+        "dest-filename": "jiti-2.6.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+        "sha512": "002ffb2687c9bd91abae779635a12725e38b531f89946b7bb4d6b4c198913d3e0c635c267ca8eddbee8eda9daecf6fac92597c39966624c36a7a47bb90a6cd81",
+        "dest-filename": "jiti-2.7.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+        "sha512": "45d2547e5704ddc5332a232a420b02bb4e853eef5474824ed1b7986cf84737893a6a9809b627dca02b53f5b7313a9601b690f690233a49bce0e026aeb16fcf29",
+        "dest-filename": "js-tokens-4.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+        "sha512": "d6d77bf3c6809e7679aaced5d90211975a308ed6296cab7be3d637c5abaa420c0820617fc575b3d70313101c793b72cade55cb56ea973dd3f18f6068147696f5",
+        "dest-filename": "js-yaml-4.3.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+        "sha512": "c72170ca1ae8fc91287fa1a17b68b3d8d717a23dac96836c5abfd7b044432bfa223c27da36197938d7e9fa341d01945043420958dcc7f7321917b962f75921db",
+        "dest-filename": "json-parse-even-better-errors-2.3.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+        "sha512": "34cf3f3fd9f75e35e12199f594b86415a0024ce5114178d6855e0103f4673aff31be0aadaa9017f483b89914314b1d51968e2dab37aa6f4b0e96bb9a3b2dddba",
+        "dest-filename": "json-schema-traverse-1.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+        "sha512": "60aeff0a54ede2400ad2fa3ac375fe3e79b40f671fdaf3c76e139776836d8b519ad1a9753f84c1661c23013be33702c40429cabe325cda34201d71f4344c2502",
+        "dest-filename": "lightningcss-android-arm64-1.32.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+        "sha512": "473786f49bb96da83606fd7f97095526f044deae93b57b247592cb0b27e0e69b7e1cbcfd06a94808eecb64ced51cd4d39ffe4f4611c50528e4e65738726b1c3d",
+        "dest-filename": "lightningcss-darwin-arm64-1.32.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+        "sha512": "53e42c069da6fecdb0aa95184ffeb09e56a07596ed65d9dd4a6badfcd26a94270c2d35a9e66b82ac80fe2b9509ea3a83d8116c85e8c26179e23c36cd87bdd5f3",
+        "dest-filename": "lightningcss-darwin-x64-1.32.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+        "sha512": "2424e281e74492c664ded1d34ed86731d55f19feb5164cbc262d84e188d44c4417d78c62cbf953cd79eed6fc2265eddb61ed2af92a6c487fc24de0d72ba5878a",
+        "dest-filename": "lightningcss-freebsd-x64-1.32.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+        "sha512": "c7aae79e945ad862f4cd03a4b7aaedb376033f376e2e95afc0017a10c8571556570f8b4fac190416acc6a30cc2b085ac3e3a922beb723443835015de7951d293",
+        "dest-filename": "lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+        "sha512": "d279ccca8c8e2d12577db30e8a569245c2c7dc9c39cfd1c33467d3fe0c023e06838e7c748bcc3bbc1cc52c54757fa08c2ca17c8156de6e69143777dafe4409a5",
+        "dest-filename": "lightningcss-linux-arm64-gnu-1.32.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+        "sha512": "529424a1e9ebe14244ce054862923cd250c5bd198f560ea8a9ba0d1dfa07e024087cd03e1cead9ecca3b2993f4d9d0ba2e38213d025e06cbd7849a1dff09c806",
+        "dest-filename": "lightningcss-linux-arm64-musl-1.32.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+        "sha512": "57b42be7622166674a3d5afe56dc3ca3e58bb1025809377c96821fa4368c45619465f04e60425ec89224a862033193f03f1db8a5431fc12c7123ca61aff31b38",
+        "dest-filename": "lightningcss-linux-x64-gnu-1.32.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+        "sha512": "6d870ba7e55bd1ac2c89783ff34b8245ecc2607360d7f9779add20cc79d657d5cfd56e6c29ae7f4c274659a47fcc13363de17f1dbb10bff8f651134e895bb15a",
+        "dest-filename": "lightningcss-linux-x64-musl-1.32.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+        "sha512": "f126c2f01478d294ba6da08cf2c6ed6034b011541de099454ce95a0f78161877d385370006734305d6ba79365ea9ba1f6a5209845c74a8ace01c999c3d39c677",
+        "dest-filename": "lightningcss-win32-arm64-msvc-1.32.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+        "sha512": "026abd07f4a86587438b5905ae88e7a2a3cbc58850e16a395e22fc11526b56c07c011a02d4f596e951ad4f458a09e9a3cbc682fa5a2e2678d2ed4d7cc776f4e9",
+        "dest-filename": "lightningcss-win32-x64-msvc-1.32.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+        "sha512": "357601ce29cdadb95fada3c6cab6cfa03d7d0b587d95f23fd66ce0598bd75137b8d781b3fd7d450f65c165264ceeb453acc03c24bdceb4068689fac82a1439c9",
+        "dest-filename": "lightningcss-1.32.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+        "sha512": "ef297295eb1943f3d5dbd8e110397751f8e8e995fb802a89af917b3caaea73ddefedfcd2ca6b75069c0453c9c0517b3cab3cefaa16e384ae50660e8cb7f1e406",
+        "dest-filename": "lines-and-columns-1.2.4.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+        "sha512": "972bb13c6aff59f86b95e9b608bfd472751cd7372a280226043cee918ed8e45ff242235d928ebe7d12debe5c351e03324b0edfeb5d54218e34f04b71452a0add",
+        "dest-filename": "loose-envify-1.4.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/lottie-react/-/lottie-react-2.4.1.tgz",
+        "sha512": "2d0ac7ee39648a0208bfefb0232ace6052c748a429118e337a13e270bf5b42caedd6b9e8291602620a4251ee666aaca536d69ccb9f3fb100d94e4c0c71347167",
+        "dest-filename": "lottie-react-2.4.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/lottie-web/-/lottie-web-5.13.0.tgz",
+        "sha512": "fa07c15e5eacc5730f7bcb4a426eeaccb9d4cb90d43c93ca232447c2da42a725046231d84490bfe608d4bdd92e3b673726596b3ed1d71f950924af0b458979c9",
+        "dest-filename": "lottie-web-5.13.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.292.0.tgz",
+        "sha512": "ad18149291075a96b95424fae98b1c227090990b8f081d51151ce49313318386fe8da2f4575d84deb896591d92879388894842c065bf644c6e10ee00cf7d84e9",
+        "dest-filename": "lucide-react-0.292.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+        "sha512": "bddd85e1853211728670b1e8abe4c4c828f1b9e49e1e7171cb28cda7cd328345d5e2f5219c37abfe5bef96a33f6ab0796d740de4adbfde88a7c82472c7c4f609",
+        "dest-filename": "magic-string-0.30.21.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.42.0.tgz",
+        "sha512": "33ade1e27f11faab8974d841c2e2e583133e38b61af7e23f4f6a730d16e807d7cb5d175ba2ef86c3b66eaf2f92929682c8008fd491d28c7819d44813901af7d3",
+        "dest-filename": "motion-dom-12.42.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.39.0.tgz",
+        "sha512": "f2769d2402634eda91926445dfa168253af2c0af679c59a73f09d2332c5a38253b1838cdf514cc248c71f437bc12b33ebe93e131c72bffa7e8e56722c902e731",
+        "dest-filename": "motion-utils-12.39.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/motion/-/motion-12.42.0.tgz",
+        "sha512": "421c2fbbdb15979fd4452ab908dcf0302a5228af14867af06fa54ef7bee46728ffc0e092ee659e6c95270681f1e5c654d59bfc6bd043e4248809628096b2c980",
+        "dest-filename": "motion-12.42.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+        "sha512": "cbb5b282fffb9843afc53b8440307c4ad5dd3110567f5911fed961033051505901da37dc2ce0313bf48798e3b6ce0cf5a5580adbdfe4caea67d39f7f6c21dd8c",
+        "dest-filename": "nanoid-3.3.15.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+        "sha512": "ac98134279149c7d6c170f324fa552537cc3dec5a6bbab19848b1e63c557f8646edcfe85ec5bbe24d0e85df9251256cb2529dcdc55101d57b8714e618fe05c52",
+        "dest-filename": "object-assign-4.1.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+        "sha512": "190d84591a5057cfe8f80c3c62ab5f6593df3515996246e2744f64e6ba65fe10b7bed1c705f1a6d887e2eaa595f9ca031a4ad42990311372e8b7991cb11961fa",
+        "dest-filename": "parent-module-1.0.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+        "sha512": "6b208abe6fe98421b13a461148233cda20f072df3f1289d2120092c56c43eef7ba8c7820b059787d955004f44d810a0a8ae57fa1d845ac6cd05d9c1b89f0bc46",
+        "dest-filename": "parse-json-5.2.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+        "sha512": "c5c787dac9e1b5be4cf658aa0ec984c39ea57b7efa993664117fe311bfd1c4d1727a036e97b78db250973fd1438ff2dcbb45fc284c8c71e3f69eda5a1eb0c454",
+        "dest-filename": "picocolors-1.1.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+        "sha512": "40ff3c0402af31a9bfdcdc47eaf8f6a36d51e8c8f165401dea7970012fe99c6bcdf4854ba1c2c7c46608cc5860e9f510fb9b61e8fe1dbf8796f635f70d2223ec",
+        "dest-filename": "picomatch-4.0.4.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+        "sha512": "15f47cb237787a6d93e9f6f723633000953b1d654cafdcdb6be7a799079e5857c26e6f94382ff45f80d2f17b6951333058c19b8ca60fef18df35e933c86981dc",
+        "dest-filename": "postcss-8.5.15.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+        "sha512": "a23f3b0a064809dba5528868815011ec08e50b4df6ed4e1e9782fa780bcea827ae74c0d553435384d695f9bf437f87578123f58173139cf7617deff6a831f972",
+        "dest-filename": "prop-types-15.8.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/radix-ui/-/radix-ui-1.6.0.tgz",
+        "sha512": "114102ef43b4dc483158c3f96a8a9f059ea22c2e5b73315a806cbbce149846df28e433fb2163623f7cb07adb1edcbf5bf3ce37131074386599be06d8549b8d7a",
+        "dest-filename": "radix-ui-1.6.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+        "sha512": "e66e2740aa7ead945bd3d2cd1f9f463380714e1f76e75ff295b2886e97bb4e91b17c9fbd92fe812e42c15c88e3b296e06e720136a948db7b519d3593d2c9d423",
+        "dest-filename": "react-dom-18.3.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/react-dropzone/-/react-dropzone-14.4.1.tgz",
+        "sha512": "403b95efabf7b8a6c7887df84a9c227d9fa038b8b5f9176c08ed64979bf1313e305bc47cdbeb2d863bc1c38b61dcd1c5fd75fa141b2a0d865534dfa99e16b0d2",
+        "dest-filename": "react-dropzone-14.4.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+        "sha512": "db87baca71361fe38ab7892ab0ebcd77c901a55eb9ce8c5b038055b04381dc0455590922fc31f3694a02e4ab8e37f06271c0da0824d906e39c7d9b3bd2447c6d",
+        "dest-filename": "react-is-16.13.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz",
+        "sha512": "f6bfb28bdfa6814df700a723e886d3f684423bbf16ae24a3eadfdc17c0d605927d68e18f393103bdd503cf51702a29bb4175b0987aad7479d125f840c441b8e9",
+        "dest-filename": "react-remove-scroll-bar-2.3.8.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.2.tgz",
+        "sha512": "22a6fd3630824ede877febce74d21919d4e21f5412aabdbb1ff124f6cbff6bdee07ee788ff9875b37c918b59e783331468e393a229f9748d5d5ca757885faed1",
+        "dest-filename": "react-remove-scroll-2.7.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.0.tgz",
+        "sha512": "162d3263a920b4a69efd3876c626dd58ad0a49d619e01e771b27fac11b6898e296829366ec7efe0f27c386771dcfd14a6e94bed63983860dc5e16a0627ec8538",
+        "dest-filename": "react-router-dom-7.18.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/react-router/-/react-router-7.18.0.tgz",
+        "sha512": "a534c6b7c27e8e2d4d3a66278f34fe6c0272ff5cc3f89a78ce23ba70bed3dd92ef5cab6eb0eec1a45aa54578adaa970f56a965b085c51d132dfb6fe4dd79fa1d",
+        "dest-filename": "react-router-7.18.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
+        "sha512": "6fa8d2bf1bd59f2a6d0222e36e458b13f94e9d1e257d3b43025f9e502ed1672f9041673ac11cc8576084eb106e3260f1736a888a1b430990f934f38597b7d105",
+        "dest-filename": "react-style-singleton-2.2.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+        "sha512": "c12fa1020252851d0a844bcf240adfb8f54dd7e1f3d6dd18ea7e632eb1906e46f8bab80f13fd11bdefb590c075bffa16807826e1621c57e8bb176a53563fb689",
+        "dest-filename": "react-18.3.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+        "sha512": "5dfd2759ee91b1ece214cbbe029f5b8a251b9a996ae92f7fa7eef0ed85cffc904786b5030d48706bebc0372b9bbaa7d9593bde53ffc36151ac0c6ed128bfef13",
+        "dest-filename": "require-from-string-2.0.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/reselect/-/reselect-5.2.0.tgz",
+        "sha512": "02067750e666dd89dd7eb2783988e0ad3edb9829bfd62aa48ef11f1ffa188f387a3c3daac3842e4f78e39d722ba5db78313a4c5dc94c4f79576e6458f9745a93",
+        "dest-filename": "reselect-5.2.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+        "sha512": "a5bfcc6265ecb40932b11171f2988d235b4614d408140def904dc6ab812e035745ea01e9ffebe066ab021896a9bf2f0ddd0fb8a3b170beab8f25c9d9ed1632e2",
+        "dest-filename": "resolve-from-4.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+        "sha512": "a9883d28fdb8743e6a91af49e3b774695932d0df9be1f4d4f3d2cdf620e78c1e706a4b220b8f6bbcc0743eb509406a13987e745cf8aa3af0230df6a28c6c5867",
+        "dest-filename": "resolve-from-5.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.3.tgz",
+        "sha512": "d45d5e12d501b45bdc1a6d4743d4e25085073d01bb99200e0eb848ce3c6850416ea3c39c6eb18b8952e47af3608fce131389671ef9ee9b01638493b912ed77e6",
+        "dest-filename": "rolldown-1.1.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+        "sha512": "50e4a1b0fc33ecdacc52a851eadd215a315dbaf3b36edbfbb680c7d7f848adf44d2030679c159dd02c094c6bd3a67815966c0609d3fdfd997fb55ac3a9cb98cd",
+        "dest-filename": "scheduler-0.23.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+        "sha512": "63bfca0ec6fc2e3a28669c1aa86cae94ee8342592c8029dc7211c693eb19218e1206f52870c044147e54af57c8e1d57e26f974c3a723bee71a222e34a6e462a0",
+        "dest-filename": "semver-7.8.5.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+        "sha512": "a1e33596953f52f853c70fa0ddc21fc571f225173fba275ddf22b53f6e368331ddb34b9d401633b37cbc8f8802096f9927b69dd3272d95df1160ef9b76eae5bf",
+        "dest-filename": "set-cookie-parser-2.7.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+        "sha512": "51758c2a12cec1529bef6f0852d40f5f17d853ebac7726ed52b2bff2e184f0240cbeb84ea70bf30c1c23d108522fb31073bbc8b084811bc550f3e203431a5f40",
+        "dest-filename": "source-map-js-1.2.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+        "sha512": "b6c693224296f5be0df80123f92540f96849cd5effccc85c4aeefc98b2964a4edc5cc3921ec04a15652cd1f5b0abc4322b73202414115fa19b8b89186ddbc691",
+        "dest-filename": "string-width-7.2.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/string-width/-/string-width-8.2.2.tgz",
+        "sha512": "19a3d487981f76b633a9e54d66f51f4f6def618c57cca62275472732d260ff7af1455eb7105672de4eb17ca9667de243d35efa967515fd4b2bdd77304af173a6",
+        "dest-filename": "string-width-8.2.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+        "sha512": "c833cc363a785b27d80641e78c844b7dc6b58ba28cc860adb1582829eff3d7eeafba481a10d76018166df9998a3dce206afbc46793a01df1ddadace180dc86ef",
+        "dest-filename": "strip-ansi-7.2.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.6.0.tgz",
+        "sha512": "bb12fba80550ae2a9140f0322b7a63eba56ab245aaa19dfb3d6f788f0393c0d7eaff3f68caed55f9eaab66ab51dbe7c28977583997bf32876df06b6fa8dceefb",
+        "dest-filename": "tailwind-merge-3.6.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.1.tgz",
+        "sha512": "864f930759be2bc09836b3faae341aabf63ee19ca5c296bcee62d804a0ae9f09e743da7e7c76fb92649f1aac84268c45fcee820f200159514469f35260a965f9",
+        "dest-filename": "tailwindcss-4.3.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+        "sha512": "bb173fce9a8583ac7b0bcbce13b961e8b6dd6bc7842fdce6566fcf2de4cf051861d710a0756690f89d42522786a487e6d8776db14a51bfe1ec8626ac04c71ce8",
+        "dest-filename": "tapable-2.3.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+        "sha512": "4877ffaf8f1beef3ab8ef7bd3f1268dcc379bf9caeca31ef75472b41f7d3dd65cc51f9c69870d56c2e24dec1c96894e0642c29529948680a3900db4cca9dd81e",
+        "dest-filename": "tinyexec-1.2.4.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+        "sha512": "c1747f758a5ca8a99f5a911d66388a24ec023459dd0f40cc9eb5bf7188d51adb449017d581c2c51e836b963e3b9a339589cf72c8dbbae5a96c805e0d4324dada",
+        "dest-filename": "tinyglobby-0.2.17.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+        "sha512": "a0916ef781d06fe29576e49440bef09e99aa9df98bb0e03f9c087a6fa107d30084a0ad3f98f79753a737c0a0d5f373243ae1cf447b525ca294f7d2016b34bfdb",
+        "dest-filename": "tslib-2.8.1.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/tw-animate-css/-/tw-animate-css-1.4.0.tgz",
+        "sha512": "edbce23a546a1f4849c7cd21ff799b89c2d6ee8f2a2ec1f9f9168b476b7e3873370f426558638340a4387316caed696f994c69723e8a82ee842aa8eb1857b741",
+        "dest-filename": "tw-animate-css-1.4.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+        "sha512": "8e5d6f6733c38a72ebf5e52ddc9feded5e8580d130f508ef04f772b33f4a7d00c3e357d0ac2d98e2f290762694a454f86d795bd511e12e9a7cc2d9ba3394e04b",
+        "dest-filename": "typescript-5.9.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+        "sha512": "8b00d9aa0d10006ae0f516afe47e27d0ceb87379a4479f5c27ac10a7eec2e2723482c984c5a79d6982cd3b8e1e4f802d041c236d38863cc96dd8c7744fd1fd25",
+        "dest-filename": "undici-types-6.21.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
+        "sha512": "8d02f79519e871a16dbb7574d094e8633ff8424356b30c628c368254d6518914cedc74032ec76ed59b66214bd5e323e9fabbd69b98f4cb44c6fd2eb572e8a34e",
+        "dest-filename": "use-callback-ref-1.3.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz",
+        "sha512": "15e770d1a66f921ca7a0f625039597acc080326fa7496759b7a973250ece93c4ba43e56c1e61e94569dd55127c05ed196e47cf7392d1607fb95ebcd770478b45",
+        "dest-filename": "use-sidecar-1.1.3.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+        "sha512": "3e9e864b018ffcdacf22bc551402243907b2c3c9457a73878a34169144eb0efac5e002eaca53f60bf28291e4bd76950cdcabd84508676b9bedec82fde7e650f7",
+        "dest-filename": "use-sync-external-store-1.6.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/vite/-/vite-8.1.0.tgz",
+        "sha512": "06e25c40aff9e8d4135831a7e0005e6b7ab849205d34f5b035929392452970c3e72e8aae4981fc96546d494220a0bd4a482a47b797a084b4a19f9d261f7eb2ed",
+        "dest-filename": "vite-8.1.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+        "sha512": "e3602d9a0aa357e5f556974e7f24c6398462d3fceca0baad5d07244e6a937b26d3f810c86ccfc6bb1a3bc77a44dafb69af5a24eb146a33d3a905ef89ca8ab2c3",
+        "dest-filename": "wrap-ansi-9.0.2.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+        "sha512": "d297c5cde81e0d62472480264cb44fd83c078dd179b3b8e8f6dbb3b5d43102120d09dbd2fb79c620da8f774d00a61a8947fd0b8403544baffeed209bf7c60e7c",
+        "dest-filename": "y18n-5.0.8.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+        "sha512": "d80be1357de66fccdde99cbb20d4ed4a9975175e475ba5a7aa3d2cad696428b729625fe03083098b2b86ab629e236605c543e376507edcb735d2c78c2ed2f870",
+        "dest-filename": "yaml-2.9.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+        "sha512": "af0bbf0a535d48ca644ab51bf9de8146c4a42d4ab57e67ec63a4cea58cd3c2fc24835fcd446f39281cb792afbe03c2ca4305fa96cbbe69669dfb6921bee5ebab",
+        "dest-filename": "yargs-parser-22.0.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/yargs/-/yargs-18.1.0.tgz",
+        "sha512": "dab02044abb9e15b0792a234fed6249a5b865c70f8296ef2668c9cbaa0d0d7940e4e77365557f2d2737fd5e3219d02ced3403e770b4adb4c6e0a7735606794ca",
+        "dest-filename": "yargs-18.1.0.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/zustand/-/zustand-5.0.14.tgz",
+        "sha512": "ffcb40b293392cc3ebdbc6f77f02d8aed763efb102a5f66f89a3fbe423139f03bc212c9a138183206ffdac30d8abf707f43d97c360364578252c89e6541401fe",
+        "dest-filename": "zustand-5.0.14.tgz",
+        "dest": "flatpak-node/pnpm-tarballs"
+    },
+    {
+        "type": "inline",
+        "contents": "from __future__ import annotations\n\nimport base64\nimport contextlib\nimport hashlib\nimport json\nimport os\nimport re\nimport sqlite3\nimport struct\nimport sys\nimport tarfile\nimport time\nfrom collections.abc import Mapping\n\n_SANITIZE_RE = re.compile(r'[\\\\/:*?\"<>|]')\n_MAX_LENGTH_WITHOUT_HASH = 120\n\n\ndef _msgpack_pack(obj: object) -> bytes:\n    \"\"\"Minimal msgpack packer matching msgpackr with useRecords: true.\n\n    msgpackr reserves the byte range 0x40-0x7F for record IDs when useRecords\n    is enabled (pnpm's config).  Standard msgpack uses 0x00-0x7F for positive\n    fixints, but this packer caps them at 0x3F and emits a uint 8 prefix (0xcc)\n    for 64-255 to avoid aliasing with record ID bytes.\n    \"\"\"\n\n    def _pack_int(val: int) -> bytes:\n        # Positive fixint capped at 0x3F \u2014 0x40-0x7F are msgpackr record IDs\n        if 0 <= val <= 0x3F:\n            return val.to_bytes(1, 'big')\n        if -32 <= val < 0:\n            return val.to_bytes(1, 'big', signed=True)\n        if val >= 0:\n            if val <= 0xFF:\n                return b'\\xcc' + val.to_bytes(1, 'big')\n            if val <= 0xFFFF:\n                return b'\\xcd' + val.to_bytes(2, 'big')\n            if val <= 0xFFFFFFFF:\n                return b'\\xce' + val.to_bytes(4, 'big')\n            return b'\\xcf' + val.to_bytes(8, 'big')\n        if val >= -0x80:\n            return b'\\xd0' + val.to_bytes(1, 'big', signed=True)\n        if val >= -0x8000:\n            return b'\\xd1' + val.to_bytes(2, 'big', signed=True)\n        if val >= -0x80000000:\n            return b'\\xd2' + val.to_bytes(4, 'big', signed=True)\n        return b'\\xd3' + val.to_bytes(8, 'big', signed=True)\n\n    def _pack_str(val: str) -> bytes:\n        data = val.encode('utf-8')\n        length = len(data)\n        if length <= 0x1F:\n            return (0xA0 | length).to_bytes(1, 'big') + data\n        if length <= 0xFF:\n            return b'\\xd9' + length.to_bytes(1, 'big') + data\n        if length <= 0xFFFF:\n            return b'\\xda' + length.to_bytes(2, 'big') + data\n        return b'\\xdb' + length.to_bytes(4, 'big') + data\n\n    if obj is None:\n        return b'\\xc0'\n    if isinstance(obj, bool):\n        return b'\\xc3' if obj else b'\\xc2'\n    if isinstance(obj, int):\n        return _pack_int(obj)\n    if isinstance(obj, float):\n        return b'\\xcb' + struct.pack('>d', obj)\n    if isinstance(obj, str):\n        return _pack_str(obj)\n    if isinstance(obj, dict):\n        length = len(obj)\n        if length <= 0x0F:\n            result = (0x80 | length).to_bytes(1, 'big')\n        elif length <= 0xFFFF:\n            result = b'\\xde' + length.to_bytes(2, 'big')\n        else:\n            result = b'\\xdf' + length.to_bytes(4, 'big')\n        for key, val in obj.items():\n            result += _msgpack_pack(key) + _msgpack_pack(val)\n        return result\n    if isinstance(obj, (list, tuple)):\n        length = len(obj)\n        if length <= 0x0F:\n            result = (0x90 | length).to_bytes(1, 'big')\n        elif length <= 0xFFFF:\n            result = b'\\xdc' + length.to_bytes(2, 'big')\n        else:\n            result = b'\\xdd' + length.to_bytes(4, 'big')\n        for item in obj:\n            result += _msgpack_pack(item)\n        return result\n    raise TypeError(f'Unsupported type for msgpack: {type(obj)}')\n\n\nRECORD_HEADER = b'\\xd4\\x72'\n\n\ndef _pack_v11_store_entry(\n    files: dict[str, dict[str, object]],\n    manifest: dict[str, str] | None = None,\n) -> bytes:\n    \"\"\"Encode a store v11 entry using msgpackr-compatible record extensions.\n\n    msgpackr with ``useRecords: true, moreTypes: true`` decodes:\n\n    - standard msgpack maps (0x80/0xde/0xdf) as JavaScript ``Map`` objects\n      (iterable, supports ``for..of``)\n    - record extensions (0x72) as plain objects (dot-notation access)\n\n    The ``files`` field must be a Map so pnpm can iterate it with ``for..of``.\n    Everything else must use record extensions so dot-notation works\n    (e.g. ``pkgIndex.algo``, ``info.digest``, ``manifest.name``).\n    \"\"\"\n\n    def _record(obj: Mapping[str, object], struct_id: int) -> bytes:\n        keys = list(obj.keys())\n        result = RECORD_HEADER + struct_id.to_bytes(1, 'big')\n        result += _msgpack_pack(keys)\n        for k in keys:\n            result += _msgpack_pack(obj[k])\n        return result\n\n    def _fixmap(length: int) -> bytes:\n        if length <= 0x0F:\n            return (0x80 | length).to_bytes(1, 'big')\n        if length <= 0xFFFF:\n            return b'\\xde' + length.to_bytes(2, 'big')\n        return b'\\xdf' + length.to_bytes(4, 'big')\n\n    # Pack file entries as records, build files map as standard msgpack map\n    files_map_bytes = _fixmap(len(files))\n    for fname, finfo in files.items():\n        files_map_bytes += _msgpack_pack(fname) + _record(finfo, 0x41)\n\n    # Outer store_entry as record (struct_id 0x40)\n    store_entry_keys = ['algo', 'requiresBuild', 'files']\n    if manifest is not None:\n        store_entry_keys.append('manifest')\n\n    # Record with fixed entries\n    result = RECORD_HEADER + b'\\x40' + _msgpack_pack(store_entry_keys)\n    # This is hardcoded to use sha512 per pnpm's behavior, see @pnpm/store.cafs/index and\n    # file digest logic below\n    result += _msgpack_pack('sha512')  # algo\n    result += _msgpack_pack(False)  # requiresBuild\n    result += files_map_bytes  # files (standard map \u2192 iterable Map in JS)\n\n    if manifest is not None:\n        result += _record(manifest, 0x42)\n    return result\n\n\ndef populate_store(manifest_path: str, tarball_dir: str, store_dir: str) -> None:\n    with open(manifest_path, encoding='utf-8') as f:\n        manifest = json.load(f)\n\n    store_version = manifest['store_version']\n    packages = manifest['packages']\n\n    index_db: sqlite3.Connection | None = None\n\n    store = os.path.join(store_dir, store_version)\n    os.makedirs(os.path.join(store, 'files'), exist_ok=True)\n    if store_version == 'v11':\n        index_db = sqlite3.connect(os.path.join(store, 'index.db'))\n        index_db.execute('PRAGMA busy_timeout=5000')\n        index_db.execute('PRAGMA journal_mode=WAL')\n        index_db.execute('PRAGMA synchronous=NORMAL')\n        index_db.execute('PRAGMA temp_store=MEMORY')\n        index_db.execute(\n            'CREATE TABLE IF NOT EXISTS package_index ('\n            '  key TEXT PRIMARY KEY,'\n            '  data BLOB NOT NULL'\n            ') WITHOUT ROWID'\n        )\n    else:\n        os.makedirs(os.path.join(store, 'index'), exist_ok=True)\n\n    now = int(time.time() * 1000)\n\n    for tarball_name, info in packages.items():\n        tarball_path = os.path.join(tarball_dir, tarball_name)\n        if not os.path.isfile(tarball_path):\n            raise FileNotFoundError(tarball_path)\n\n        _process_tarball(\n            tarball_path=tarball_path,\n            pkg_name=info['name'],\n            pkg_version=info['version'],\n            integrity=info['integrity'],\n            integrity_digest=info['integrity_digest'],\n            integrity_algo=info['integrity_algo'],\n            store=store,\n            now=now,\n            tarball_url=info.get('tarball_url'),\n            store_version=store_version,\n            index_db=index_db,\n        )\n\n    if index_db is not None:\n        index_db.commit()\n        index_db.close()\n\n\ndef _process_tarball(\n    *,\n    tarball_path: str,\n    pkg_name: str,\n    pkg_version: str,\n    integrity: str,\n    integrity_digest: str,\n    integrity_algo: str,\n    store: str,\n    now: int,\n    tarball_url: str | None = None,\n    store_version: str = 'v3',\n    index_db: sqlite3.Connection | None = None,\n) -> None:\n    index_files: dict[str, dict[str, object]] = {}\n    file_digests: dict[str, str] = {}\n    real_pkg_name = pkg_name\n    real_pkg_version = pkg_version\n\n    with tarfile.open(tarball_path, 'r:gz') as tf:\n        for member in tf.getmembers():\n            if not member.isfile():\n                continue\n            fobj = tf.extractfile(member)\n            if fobj is None:\n                continue\n            data = fobj.read()\n\n            if member.name.endswith('package.json') and member.name.count('/') <= 1:\n                with contextlib.suppress(ValueError, TypeError, UnicodeDecodeError):\n                    pkg_data = json.loads(data.decode('utf-8'))\n                    if isinstance(pkg_data, dict):\n                        if 'name' in pkg_data and isinstance(pkg_data['name'], str):\n                            real_pkg_name = pkg_data['name']\n                        if 'version' in pkg_data and isinstance(\n                            pkg_data['version'], str\n                        ):\n                            real_pkg_version = pkg_data['version']\n\n            digest = hashlib.sha512(data).digest()\n            file_hex = digest.hex()\n            is_exec = bool(member.mode & 0o111)\n\n            cas_dir = os.path.join(store, 'files', file_hex[:2])\n            cas_name = file_hex[2:] + ('-exec' if is_exec else '')\n            cas_path = os.path.join(cas_dir, cas_name)\n            if not os.path.exists(cas_path):\n                os.makedirs(cas_dir, exist_ok=True)\n                with open(cas_path, 'wb') as out:\n                    out.write(data)\n                if is_exec:\n                    os.chmod(cas_path, 0o755)\n\n            rel_name = member.name\n            if '/' in rel_name:\n                rel_name = rel_name.split('/', 1)[1]\n\n            b64 = base64.b64encode(digest).decode()\n            index_files[rel_name] = {\n                'checkedAt': now,\n                'integrity': f'sha512-{b64}',\n                'mode': member.mode,\n                'size': len(data),\n            }\n            file_digests[rel_name] = file_hex\n\n    if store_version == 'v11':\n        assert index_db is not None\n        # pnpm v11 store index keys use the raw package name (e.g. @scope/pkg),\n        # not the filesystem-sanitized form (@scope+pkg), since keys are stored\n        # in SQLite, not as filenames.\n        raw_pkg_id = f'{pkg_name}@{pkg_version}'\n        key = f'{integrity_algo}-{integrity}\\t{raw_pkg_id}'\n\n        v11_files: dict[str, dict[str, object]] = {}\n        for rel_name, finfo in index_files.items():\n            checked_at = finfo['checkedAt']\n            assert isinstance(checked_at, int)\n            v11_files[rel_name] = {\n                'checkedAt': float(checked_at),  # float64 avoids msgpackr BigInt\n                'digest': file_digests[rel_name],\n                'mode': finfo['mode'],\n                'size': finfo['size'],\n            }\n\n        manifest = None\n        if real_pkg_name or real_pkg_version:\n            manifest = {\n                'name': real_pkg_name,\n                'version': real_pkg_version,\n            }\n\n        entry_bytes = _pack_v11_store_entry(v11_files, manifest)\n\n        # It's currently not possible to fully determine which store key pnpm will use,\n        # so we insert multiple keys to ensure pnpm can find the entry it wants.\n\n        index_db.execute(\n            'INSERT OR REPLACE INTO package_index (key, data) VALUES (?, ?)',\n            (key, entry_bytes),\n        )\n\n        if tarball_url:\n            url_key = f'{tarball_url}\\t{raw_pkg_id}'\n            index_db.execute(\n                'INSERT OR REPLACE INTO package_index (key, data) VALUES (?, ?)',\n                (url_key, entry_bytes),\n            )\n\n            # pnpm looks up git-hosted tarballs (codeload.github.com,\n            # bitbucket.org, gitlab.com) and tarballs without integrity by\n            # {tarball_url}\\tbuilt(not-built) \u2014 see pickStoreIndexKey in @pnpm/store.index.\n            pkgid_key = f'{tarball_url}\\t'\n            index_db.execute(\n                'INSERT OR REPLACE INTO package_index (key, data) VALUES (?, ?)',\n                (pkgid_key + 'built', entry_bytes),\n            )\n            index_db.execute(\n                'INSERT OR REPLACE INTO package_index (key, data) VALUES (?, ?)',\n                (pkgid_key + 'not-built', entry_bytes),\n            )\n    else:\n        pkg_id = _SANITIZE_RE.sub('+', f'{pkg_name}@{pkg_version}')\n\n        index_data = {\n            'name': real_pkg_name,\n            'version': real_pkg_version,\n            'requiresBuild': False,\n            'files': index_files,\n        }\n\n        idx_prefix = integrity_digest[:2]\n        idx_rest = integrity_digest[2:64]\n        idx_dir = os.path.join(store, 'index', idx_prefix)\n        os.makedirs(idx_dir, exist_ok=True)\n        idx_path = os.path.join(idx_dir, f'{idx_rest}-{pkg_id}.json')\n        with open(idx_path, 'w', encoding='utf-8') as out:\n            json.dump(index_data, out)\n\n        # For tarball-URL packages, also create an index entry keyed by the URL hash\n        # this is how pnpm looks up tarball deps without integrity\n        if tarball_url:\n            if store_version == 'v3':\n                url_hash = hashlib.sha256(tarball_url.encode()).hexdigest()\n                url_idx_prefix = url_hash[:2]\n                url_idx_rest = url_hash[2:64]\n                url_idx_dir = os.path.join(store, 'index', url_idx_prefix)\n                os.makedirs(url_idx_dir, exist_ok=True)\n                url_idx_path = os.path.join(\n                    url_idx_dir, f'{url_idx_rest}-{pkg_id}.json'\n                )\n                with open(url_idx_path, 'w', encoding='utf-8') as out:\n                    json.dump(index_data, out)\n            else:\n                url_dir_name = re.sub(r'[:/]', '+', tarball_url)\n                if (\n                    len(url_dir_name) > _MAX_LENGTH_WITHOUT_HASH\n                    or url_dir_name != url_dir_name.lower()\n                ):\n                    url_dir_name = f'{url_dir_name[: _MAX_LENGTH_WITHOUT_HASH - 33]}_{hashlib.sha256(url_dir_name.encode()).hexdigest()[:32]}'\n                url_idx_dir = os.path.join(store, url_dir_name)\n                os.makedirs(url_idx_dir, exist_ok=True)\n                url_idx_path = os.path.join(url_idx_dir, 'integrity.json')\n                with open(url_idx_path, 'w', encoding='utf-8') as out:\n                    json.dump(index_data, out)\n\n\nif __name__ == '__main__':\n    if len(sys.argv) != 4:\n        print(\n            f'Usage: {sys.argv[0]} <manifest.json> <tarball-dir> <store-dir>',\n            file=sys.stderr,\n        )\n        sys.exit(1)\n    populate_store(sys.argv[1], sys.argv[2], sys.argv[3])\n",
+        "dest-filename": "populate_pnpm_store.py",
+        "dest": "flatpak-node"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"packages\":{\"@alloc__quick-lru-5.2.0.tgz\":{\"integrity\":\"UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"52b700041fb86d4ac5001c1b96e4c8044ad7c2f6ec53f57b4d959f99b8097db930881bb3892f60c5d383532ba279c7dd190f398e094c5ba8ee4b7fb3e53b0a2f\",\"name\":\"@alloc/quick-lru\",\"version\":\"5.2.0\"},\"@babel__code-frame-7.29.7.tgz\":{\"integrity\":\"Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"02ea7b69439fa5b01483644e38937a230e5ff43301973bb4988926fe66a52d014dfd84203b8f300a3d0ac5adec10726f3d5160eec891faa4489f05dddaa8502b\",\"name\":\"@babel/code-frame\",\"version\":\"7.29.7\"},\"@babel__helper-validator-identifier-7.29.7.tgz\":{\"integrity\":\"qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"a9e8711a4463e7987f7dff0431a27e71887268a947231a980e7ebcdb0403ed1369f54ba3390b07a20dae4b4af6bf3af8a56fac5dff7435e79aca370d697ddf16\",\"name\":\"@babel/helper-validator-identifier\",\"version\":\"7.29.7\"},\"@babel__runtime-7.29.7.tgz\":{\"integrity\":\"Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"36af0e8465a264864657a84b1e8c8028b2dc26284fff115e04c189a14af14d7da9b08f1d0a27f32e16484856fe5564b7c053110e6086c3947e74ec920aa3cb87\",\"name\":\"@babel/runtime\",\"version\":\"7.29.7\"},\"@base-ui__react-1.6.0.tgz\":{\"integrity\":\"/jzjTWJYXhRFO45Bev9lc3cHbmjzCMpUqbMZ2AgKy/z25mY9B6shGSNcXcjQar9n5doM0KYW1W8fcFv2jZBuMw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"fe3ce34d62585e14453b8e417aff657377076e68f308ca54a9b319d8080acbfcf6e6663d07ab2119235c5dc8d06abf67e5da0cd0a616d56f1f705bf68d906e33\",\"name\":\"@base-ui/react\",\"version\":\"1.6.0\"},\"@base-ui__utils-0.3.1.tgz\":{\"integrity\":\"gFFiltORVmW/N6IILTGxizP3PBpVpysqML1ALY5Vk0mH+7faVkCknOU31goYHN5Aoek2dkjxva1XOD2Ce9WuIg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"80516296d3915665bf37a2082d31b18b33f73c1a55a72b2a30bd402d8e55934987fbb7da5640a49ce537d60a181cde40a1e9367648f1bdad57383d827bd5ae22\",\"name\":\"@base-ui/utils\",\"version\":\"0.3.1\"},\"@biomejs__biome-2.5.1.tgz\":{\"integrity\":\"IXWLCxKmae+rI7LOHS1B3EbVisQ6GRAWbhN9msa6KjNCyFWrvKZWR4oUdinaNssrV852OrSHuSPa95h1GPJc7Q==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"21758b0b12a669efab23b2ce1d2d41dc46d58ac43a1910166e137d9ac6ba2a3342c855abbca656478a147629da36cb2b57ce763ab487b923daf7987518f25ced\",\"name\":\"@biomejs/biome\",\"version\":\"2.5.1\"},\"@biomejs__cli-darwin-arm64-2.5.1.tgz\":{\"integrity\":\"npqDzvqv7vFaWRiNN1Te71siRgPaqS9MpqgYCdP/CrUbkJ7ApezaeaKjueKHRN/JH/6lRjJQAHi8acQDCAz22w==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"9e9a83cefaafeef15a59188d3754deef5b224603daa92f4ca6a81809d3ff0ab51b909ec0a5ecda79a2a3b9e28744dfc91ffea54632500078bc69c403080cf6db\",\"name\":\"@biomejs/cli-darwin-arm64\",\"version\":\"2.5.1\"},\"@biomejs__cli-darwin-x64-2.5.1.tgz\":{\"integrity\":\"RgwTqPAM8g2tn1j+b5oRjF/DbSBX8a4gwojtuG9XuhfK7GgomvZ9+T+tqjXiVbjLEeGJOoL6VEk8mvRTVeSybw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"460c13a8f00cf20dad9f58fe6f9a118c5fc36d2057f1ae20c288edb86f57ba17caec68289af67df93fadaa35e255b8cb11e1893a82fa54493c9af45355e4b26f\",\"name\":\"@biomejs/cli-darwin-x64\",\"version\":\"2.5.1\"},\"@biomejs__cli-linux-arm64-2.5.1.tgz\":{\"integrity\":\"yhV35CzZh38VyMvTEXi3JTjxZBs++oCKK9KG8vB6VI5+uvQvZNR3BFWEKKzuOmx9DJJj7sQpZ4LQJcmbGTs3+Q==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"ca1577e42cd9877f15c8cbd31178b72538f1641b3efa808a2bd286f2f07a548e7ebaf42f64d47704558428acee3a6c7d0c9263eec4296782d025c99b193b37f9\",\"name\":\"@biomejs/cli-linux-arm64\",\"version\":\"2.5.1\"},\"@biomejs__cli-linux-arm64-musl-2.5.1.tgz\":{\"integrity\":\"WMcvMLgByyTqVxGlq918NBBYliq9FRR9GAQVETHb+VjGVqXCZFfHlZHC1FX4ibuYY/Hg6TJE3rHU0xVrdJXNRw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"58c72f30b801cb24ea5711a5abdd7c341058962abd15147d1804151131dbf958c656a5c26457c79591c2d455f889bb9863f1e0e93244deb1d4d3156b7495cd47\",\"name\":\"@biomejs/cli-linux-arm64-musl\",\"version\":\"2.5.1\"},\"@biomejs__cli-linux-x64-2.5.1.tgz\":{\"integrity\":\"J/7uHSX7NfoYDI7HijAkd8lnQIOrRb2W7j3X+tw4R+N5ExvXGsyXFiGdQcfcxfOmNQmZVSQOCDk757fwpzqQcg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"27feee1d25fb35fa180c8ec78a302477c9674083ab45bd96ee3dd7fadc3847e379131bd71acc9716219d41c7dcc5f3a635099955240e08393be7b7f0a73a9072\",\"name\":\"@biomejs/cli-linux-x64\",\"version\":\"2.5.1\"},\"@biomejs__cli-linux-x64-musl-2.5.1.tgz\":{\"integrity\":\"ANTowtlLmPYm5yeMckWY8Xzb9Ix+JJP3tgHR/n6xRj1VWyIzzWtfRfih9hv9VmClwadpBvZduISZIbBsIlYG3A==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"00d4e8c2d94b98f626e7278c724598f17cdbf48c7e2493f7b601d1fe7eb1463d555b2233cd6b5f45f8a1f61bfd5660a5c1a76906f65db8849921b06c225606dc\",\"name\":\"@biomejs/cli-linux-x64-musl\",\"version\":\"2.5.1\"},\"@biomejs__cli-win32-arm64-2.5.1.tgz\":{\"integrity\":\"zgXnKNgWPC4iPF7Y1lR3STUeCUuZRpD6IiOrC7TZTlh0Lx6FiVUT05myuMQHQ9D+1cc7uyMldi4forE6lp0ivQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"ce05e728d8163c2e223c5ed8d6547749351e094b994690fa2223ab0bb4d94e58742f1e85895513d399b2b8c40743d0fed5c73bbb2325762e1fa2b13a969d22bd\",\"name\":\"@biomejs/cli-win32-arm64\",\"version\":\"2.5.1\"},\"@biomejs__cli-win32-x64-2.5.1.tgz\":{\"integrity\":\"6uxpR9hvaglANkZemeSiN/FhYgkGasrEGn267eXIWvjrjJ2LhDlk251IhjVJq6MXzkV2/bcXwLwSroLyPtqRZg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"eaec6947d86f6a094036465e99e4a237f1616209066acac41a7dbaede5c85af8eb8c9d8b843964db9d48863549aba317ce4576fdb717c0bc12ae82f23eda9166\",\"name\":\"@biomejs/cli-win32-x64\",\"version\":\"2.5.1\"},\"@commitlint__cli-21.2.1.tgz\":{\"integrity\":\"blsZGe29hJ72VGEFVl72IVYX+1vsfINpjA9yWQA6i7OKD/McGEOXg08sKIRKjFk4JvzhV/9n0l3i6NooPLTNfg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"6e5b1919edbd849ef6546105565ef6215617fb5bec7c83698c0f7259003a8bb38a0ff31c184397834f2c28844a8c593826fce157ff67d25de2e8da283cb4cd7e\",\"name\":\"@commitlint/cli\",\"version\":\"21.2.1\"},\"@commitlint__config-conventional-21.2.0.tgz\":{\"integrity\":\"Qf8WRDVcyVd14if6VTWenebxFbKnVnbzPUJjlzjkyJGeHK2xCGd63Dr1XZzj0plXKQb9P0BfOxoc1HVeCo2BWQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"41ff1644355cc95775e227fa55359e9de6f115b2a75676f33d42639738e4c8919e1cadb108677adc3af55d9ce3d299572906fd3f405f3b1a1cd4755e0a8d8159\",\"name\":\"@commitlint/config-conventional\",\"version\":\"21.2.0\"},\"@commitlint__config-validator-21.2.0.tgz\":{\"integrity\":\"t7AzNHAKeIdo/3NRGwzpufKHsKkPHmFs/56N2Fnsh0/r0rGtnQzTxk6vnFgjaGr4hdSQKNB50/KAhR9Yk4LJKA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"b7b03334700a788768ff73511b0ce9b9f287b0a90f1e616cff9e8dd859ec874febd2b1ad9d0cd3c64eaf9c5823686af885d49028d079d3f280851f589382c928\",\"name\":\"@commitlint/config-validator\",\"version\":\"21.2.0\"},\"@commitlint__ensure-21.2.0.tgz\":{\"integrity\":\"76IF9vDNS13lAzEEik9eKwzt8f9hYhWiwVXZ2AnyLCz5/f511FsEQ3pw1X3/zSQpdRLQU7i5qDMVKyXi1GWjSg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"efa205f6f0cd4b5de50331048a4f5e2b0cedf1ff616215a2c155d9d809f22c2cf9fdfe75d45b04437a70d57dffcd24297512d053b8b9a833152b25e2d465a34a\",\"name\":\"@commitlint/ensure\",\"version\":\"21.2.0\"},\"@commitlint__execute-rule-21.0.1.tgz\":{\"integrity\":\"RifH+FmImozKBE6mozhF4K3r2RRKP7SMi/Q/zLCmExtp5e05lhHOUYqGBlFBAGNHaZxU/WYw1XuugYK9jQzqnA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"4627c7f859889a8cca044ea6a33845e0adebd9144a3fb48c8bf43fccb0a6131b69e5ed399611ce518a86065141006347699c54fd6630d57bae8182bd8d0cea9c\",\"name\":\"@commitlint/execute-rule\",\"version\":\"21.0.1\"},\"@commitlint__format-21.2.0.tgz\":{\"integrity\":\"c4q64xaav2U83t7k7RyzJerBZurPer7FxUOY0RL5L/6CZijZ7K+s6HIBGIghj0ey1P2+seRX0J9XQYtDued6tg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"738abae3169abf653cdedee4ed1cb325eac166eacf7abec5c54398d112f92ffe826628d9ecaface872011888218f47b2d4fdbeb1e457d09f57418b43b9e77ab6\",\"name\":\"@commitlint/format\",\"version\":\"21.2.0\"},\"@commitlint__is-ignored-21.2.0.tgz\":{\"integrity\":\"4/eB0vBN7L88O/oC4ajAEqi7j2ZfNgxl/+11RfAV9YosejZgDXhY2C9VcHnHJhOzPLoSy5P3Mg/46kqeyJfXKw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"e3f781d2f04decbf3c3bfa02e1a8c012a8bb8f665f360c65ffed7545f015f58a2c7a36600d7858d82f557079c72613b33cba12cb93f7320ff8ea4a9ec897d72b\",\"name\":\"@commitlint/is-ignored\",\"version\":\"21.2.0\"},\"@commitlint__lint-21.2.0.tgz\":{\"integrity\":\"ceO5dp9pLjEZ6y6qbq/uXWXDPykqqlTsyzoQ0NzecpisSJhK3kTy9qzQoPeJuWG/IMNdV1lO0RgmzqoAlSi1uw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"71e3b9769f692e3119eb2eaa6eafee5d65c33f292aaa54eccb3a10d0dcde7298ac48984ade44f2f6acd0a0f789b961bf20c35d57594ed11826ceaa009528b5bb\",\"name\":\"@commitlint/lint\",\"version\":\"21.2.0\"},\"@commitlint__load-21.2.0.tgz\":{\"integrity\":\"RjlzWQqruRwIenJEfZtq7kG97co97nKoHpflE5YnF61tDLXxHPrdWImgzw6VL6MlFyaOcVlk74eBV8ZQmc3oIA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"463973590aabb91c087a72447d9b6aee41bdedca3dee72a81e97e513962717ad6d0cb5f11cfadd5889a0cf0e952fa32517268e715964ef878157c65099cde820\",\"name\":\"@commitlint/load\",\"version\":\"21.2.0\"},\"@commitlint__message-21.2.0.tgz\":{\"integrity\":\"YxGoiXD/HXNXLJPrQwE5poXa+XH0CBEm+mdvbHQP0g6MV/dmJyUFCzPNzZbxL93GvZ70TmtTK0Z0/IBpAqHv8g==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"6311a88970ff1d73572c93eb430139a685daf971f4081126fa676f6c740fd20e8c57f7662725050b33cdcd96f12fddc6bd9ef44e6b532b4674fc806902a1eff2\",\"name\":\"@commitlint/message\",\"version\":\"21.2.0\"},\"@commitlint__parse-21.2.0.tgz\":{\"integrity\":\"QHWxG4d0PLTF634/AdyZ0MQS+CLn5YOuJlCFhMMlSGKFxzYGUetkHBj18xgBD+6fVzUrA2lrCdi/vlS2f/oYXg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"4075b11b87743cb4c5eb7e3f01dc99d0c412f822e7e583ae26508584c325486285c7360651eb641c18f5f318010fee9f57352b03696b09d8bfbe54b67ffa185e\",\"name\":\"@commitlint/parse\",\"version\":\"21.2.0\"},\"@commitlint__read-21.2.1.tgz\":{\"integrity\":\"hUW7EJQnNTL0vPOmVMNK4CrnrNBN0nN+JJHReFkdHO5y4iyHeEmTBwuC15OCqUTjxWo7idnH1LftfpWVIaPWIA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"8545bb1094273532f4bcf3a654c34ae02ae7acd04dd2737e2491d178591d1cee72e22c87784993070b82d79382a944e3c56a3b89d9c7d4b7ed7e959521a3d620\",\"name\":\"@commitlint/read\",\"version\":\"21.2.1\"},\"@commitlint__resolve-extends-21.2.0.tgz\":{\"integrity\":\"4O/1j51+79Wth9s/MGxt/5gs0XYLDgNlYpltQfhAvLE0itusLKs9zruxbiNg1oOkmkb9L9L4USYGjEj7n87NxA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"e0eff58f9d7eefd5ad87db3f306c6dff982cd1760b0e036562996d41f840bcb1348adbac2cab3dcebbb16e2360d683a49a46fd2fd2f85126068c48fb9fcecdc4\",\"name\":\"@commitlint/resolve-extends\",\"version\":\"21.2.0\"},\"@commitlint__rules-21.2.0.tgz\":{\"integrity\":\"C2yXMNpiB8ETZKfx5JD8+ExgF8vTU1VQMKPSUUYwqKpw9oJWQBrlXBpdU038mj2WPjof7o9UzFpmTyBeGMZwZg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"0b6c9730da6207c11364a7f1e490fcf84c6017cbd353555030a3d2514630a8aa70f68256401ae55c1a5d534dfc9a3d963e3a1fee8f54cc5a664f205e18c67066\",\"name\":\"@commitlint/rules\",\"version\":\"21.2.0\"},\"@commitlint__to-lines-21.0.1.tgz\":{\"integrity\":\"bd1BFII7p1EQZre9Kaj+kKaMFP3cFCdt21K7DItVux9XP5WjLgJ0/Uy1pJJh9aPwVJ6SKg62PxqlZaHI8hQAXw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"6ddd4114823ba7511066b7bd29a8fe90a68c14fddc14276ddb52bb0c8b55bb1f573f95a32e0274fd4cb5a49261f5a3f0549e922a0eb63f1aa565a1c8f214005f\",\"name\":\"@commitlint/to-lines\",\"version\":\"21.0.1\"},\"@commitlint__top-level-21.2.0.tgz\":{\"integrity\":\"Y5gmQ+KxzqCrBFJfLvFEPvvwD3LDiNZoTT2yeFBm96M8qhmqSzQc5DvX3rheAaAMjyIvMXOCLS/mWfdpONsjyQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"63982643e2b1cea0ab04525f2ef1443efbf00f72c388d6684d3db2785066f7a33caa19aa4b341ce43bd7deb85e01a00c8f222f3173822d2fe659f76938db23c9\",\"name\":\"@commitlint/top-level\",\"version\":\"21.2.0\"},\"@commitlint__types-21.2.0.tgz\":{\"integrity\":\"7zVFCDB2reMvJH5dmbKnOQPjZEvjdJTH8jc0U/PIPU1r3/+vf5pD1HlfitV2MWsWXrvu7u39iY1lyLUPOaN0Gw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"ef3545083076ade32f247e5d99b2a73903e3644be37494c7f2373453f3c83d4d6bdfffaf7f9a43d4795f8ad576316b165ebbeeeeedfd898d65c8b50f39a3741b\",\"name\":\"@commitlint/types\",\"version\":\"21.2.0\"},\"@conventional-changelog__git-client-3.1.0.tgz\":{\"integrity\":\"Tqa/gHco2WJWa740NRjOrfKVvzIqxkZpecb8bemaQ8sKM5PXb1UK4uTyTb/1wIqNuOVaDOFxyBdhTIQZn6gdjQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"4ea6bf807728d962566bbe343518ceadf295bf322ac6466979c6fc6de99a43cb0a3393d76f550ae2e4f24dbff5c08a8db8e55a0ce171c817614c84199fa81d8d\",\"name\":\"@conventional-changelog/git-client\",\"version\":\"3.1.0\"},\"@conventional-changelog__template-1.2.1.tgz\":{\"integrity\":\"TzlTVpKPjaqW6qOYjQcYUDuGsLCNsvFHVBXkYGTAnf5V37jCWrE5haKNXzz0WZUtVHjrpV76L1buANjwXMfT8w==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"4f395356928f8daa96eaa3988d0718503b86b0b08db2f1475415e46064c09dfe55dfb8c25ab13985a28d5f3cf459952d5478eba55efa2f56ee00d8f05cc7d3f3\",\"name\":\"@conventional-changelog/template\",\"version\":\"1.2.1\"},\"@emnapi__core-1.11.1.tgz\":{\"integrity\":\"RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"452bdb4261f374accdb0b61aff01eb6dcdca378b182ca01d3d9c6a88cd87013aaffd2064dbf10d487a6f5c668b38c72c032cf4a68106aa49a62981b739688911\",\"name\":\"@emnapi/core\",\"version\":\"1.11.1\"},\"@emnapi__runtime-1.11.1.tgz\":{\"integrity\":\"vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"be08fb477cb75a0c76e0841a18f03f47a6055cb1d530e674b951322103da5acfab7750337c43179400b6d856303b55e4291e8d3ecabb9946a7747f2821175917\",\"name\":\"@emnapi/runtime\",\"version\":\"1.11.1\"},\"@emnapi__wasi-threads-1.2.2.tgz\":{\"integrity\":\"c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"73de6a39790777274d2a1b1c05379ba840b5095019a72a8e7d57c1cd0d6a833ca5de07de95d5232208036c86600cab072e09ec33e8a01fb4c9fde01ab1a56e30\",\"name\":\"@emnapi/wasi-threads\",\"version\":\"1.2.2\"},\"@floating-ui__core-1.7.5.tgz\":{\"integrity\":\"1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"d488785935b2c34fa52b214c7011c66dbe54e45b6e1c9bae8e8cb2af9cd36964b911831e4fa25bd80b8379fb6c0ac12e7213be98cda28f9faaf5cae1c9dccb85\",\"name\":\"@floating-ui/core\",\"version\":\"1.7.5\"},\"@floating-ui__dom-1.7.6.tgz\":{\"integrity\":\"9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"f60652008e57337ebcf343cf326ffff5d7e2127818a02e809b68b3112d45178d3a605b23bf204c99e2768384808eedf15b0b6eca735114bdacf61831a4b23949\",\"name\":\"@floating-ui/dom\",\"version\":\"1.7.6\"},\"@floating-ui__react-dom-2.1.8.tgz\":{\"integrity\":\"cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"702e766c7c0cfe7fc2c52f3b147d3259d9e0119ae376d2d6fea56bba8ebcaa0fa9acaed943860676eb761b20d5a6819e0187bf87cf7dad578e566e8e8b8d24d8\",\"name\":\"@floating-ui/react-dom\",\"version\":\"2.1.8\"},\"@floating-ui__utils-0.2.11.tgz\":{\"integrity\":\"RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"46207fc8887bf29708c65ea52cc1b40a0057019d98d1e547a8c3d8ba0bbef54d00793e9805e889a5fee56dd24d22e8053f94888f0351828e03851d50c62dba1a\",\"name\":\"@floating-ui/utils\",\"version\":\"0.2.11\"},\"@jridgewell__gen-mapping-0.3.13.tgz\":{\"integrity\":\"2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"da492dffb9e227a32010fc45d1b61d43a7ad65a03e7d0bc370b29c921cb5c8840ecdaa0a8c10634a3eb7fda2d58d8137aa146de5dbccfae5327c283a50a0816c\",\"name\":\"@jridgewell/gen-mapping\",\"version\":\"0.3.13\"},\"@jridgewell__remapping-2.3.5.tgz\":{\"integrity\":\"LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"2c8f6effe95a606e03b354c3292256d983eb22571560ec22d9f502eb1078de5b9e0a383157895f7ce0990ad605887e9334e5feb50297c7ded3e082876e1c8711\",\"name\":\"@jridgewell/remapping\",\"version\":\"2.3.5\"},\"@jridgewell__resolve-uri-3.1.2.tgz\":{\"integrity\":\"bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"6d12128022233f6d3fb5b5923d63048b9e1054f45913192e0fd9492fe508c542adc15240f305b54eb6f58ccb354455e8d42053359ff98690bd42f98a59da292b\",\"name\":\"@jridgewell/resolve-uri\",\"version\":\"3.1.2\"},\"@jridgewell__sourcemap-codec-1.5.5.tgz\":{\"integrity\":\"cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"71843ddf5d20aeac6e7966e5f96b885086a251a0dc8fb58eab97d58449633558117ce52163d7f2db34ef7e8a96b2779b87c4a5ef45527056c80af2672ca0743a\",\"name\":\"@jridgewell/sourcemap-codec\",\"version\":\"1.5.5\"},\"@jridgewell__trace-mapping-0.3.31.tgz\":{\"integrity\":\"zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"cf3351f9275048327373c8e869e3fc410a0242bf0db98c76748232b65d507811191c9f6e5ba85e6ecad881bcfc849c1441aa374d608cb667d5f0dbb5b7038b03\",\"name\":\"@jridgewell/trace-mapping\",\"version\":\"0.3.31\"},\"@napi-rs__wasm-runtime-1.1.6.tgz\":{\"integrity\":\"ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"64bbff25d51f92f3b2f5e0a79c16867e23be5e299b8de6c078ef8c450a83fc1f85475b6744dd2da4a4891d16c4f2c15f4ba6aab1767aed34237f07ecc542d56e\",\"name\":\"@napi-rs/wasm-runtime\",\"version\":\"1.1.6\"},\"@oxc-project__types-0.137.0.tgz\":{\"integrity\":\"WT+Gb24i8hmvo85AIv2oEYouEXkRlKAlT9WaCa3TfLgNCN+GhrJOGZuIlMouAh38Qe4QOx26eUOVsq70qXrywA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"593f866f6e22f219afa3ce4022fda8118a2e11791194a0254fd59a09add37cb80d08df8686b24e199b8894ca2e021dfc41ee103b1dba794395b2aef4a97af2c0\",\"name\":\"@oxc-project/types\",\"version\":\"0.137.0\"},\"@phosphor-icons__react-2.1.10.tgz\":{\"integrity\":\"vt8Tvq8GLjheAZZYa+YG/pW7HDbov8El/MANW8pOAz4eGxrwhnbfrQZq0Cp4q8zBEu8NIhHdnr+r8thnfRSNYA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"bedf13beaf062e385e0196586be606fe95bb1c36e8bfc125fcc00d5bca4e033e1e1b1af08676dfad066ad02a78abccc112ef0d2211dd9ebfabf2d8677d148d60\",\"name\":\"@phosphor-icons/react\",\"version\":\"2.1.10\"},\"@radix-ui__number-1.1.2.tgz\":{\"integrity\":\"ceTwaxc4I5IOi97DgCotl3pqiyRGvffcc0oOsE2dQYaJOFIDsDt4VWG6xEbg1QePv9QWausCEIppud/tJ1wNig==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"71e4f06b173823920e8bdec3802a2d977a6a8b2446bdf7dc734a0eb04d9d418689385203b03b785561bac446e0d5078fbfd4166aeb02108a69b9dfed275c0d8a\",\"name\":\"@radix-ui/number\",\"version\":\"1.1.2\"},\"@radix-ui__primitive-1.1.4.tgz\":{\"integrity\":\"7AdCK9PQyiljKoBDbN8OuctCbd/esdwZPQ8RtOE3SsyQtUpiPb+ND75q0jEhC1m1ecBI0MFNeLJvwIh9iKHRcQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"ec07422bd3d0ca29632a80436cdf0eb9cb426ddfdeb1dc193d0f11b4e1374acc90b54a623dbf8d0fbe6ad231210b59b579c048d0c14d78b26fc0887d88a1d171\",\"name\":\"@radix-ui/primitive\",\"version\":\"1.1.4\"},\"@radix-ui__react-accessible-icon-1.1.10.tgz\":{\"integrity\":\"TraSwZUqTcVbiDV2/RXzAXC7aeVVXchq0daPFZE7zAxYFaMzjOUggLOfQH9KFLgRizuwVKZO/crveV1eeO3/ZQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"4eb692c1952a4dc55b883576fd15f30170bb69e5555dc86ad1d68f15913bcc0c5815a3338ce52080b39f407f4a14b8118b3bb054a64efdcaef795d5e78edff65\",\"name\":\"@radix-ui/react-accessible-icon\",\"version\":\"1.1.10\"},\"@radix-ui__react-accordion-1.2.14.tgz\":{\"integrity\":\"iE8YB9nmTBH8zd73ofBISZ8JCzgMoMkATJr7qDwa6u5F1+7mTM81V6fa71jgZ65rpjVpecDf1vSnwIFP9Ly1zw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"884f1807d9e64c11fccddef7a1f048499f090b380ca0c9004c9afba83c1aeaee45d7eee64ccf3557a7daef58e067ae6ba6356979c0dfd6f4a7c0814ff4bcb5cf\",\"name\":\"@radix-ui/react-accordion\",\"version\":\"1.2.14\"},\"@radix-ui__react-alert-dialog-1.1.17.tgz\":{\"integrity\":\"563ygGeyWPrxyVCNp7OV4rE2aIXhFPknpFyo4wbDlcyMMPZ6ySh+zC5WTvY0ZFLgPTg/QB6tA8PyDQyJ2b4cPg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"e7adf28067b258faf1c9508da7b395e2b1366885e114f927a45ca8e306c395cc8c30f67ac9287ecc2e564ef6346452e03d383f401ead03c3f20d0c89d9be1c3e\",\"name\":\"@radix-ui/react-alert-dialog\",\"version\":\"1.1.17\"},\"@radix-ui__react-arrow-1.1.10.tgz\":{\"integrity\":\"j2VTDz1vgCsmuG0k5lBfOcM8n5JPFqZBcMryasFjHYMhwxYL5SRUV5lMSUpRdNtw3D/Sv8pzJtrlAgkssYSsQQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"8f65530f3d6f802b26b86d24e6505f39c33c9f924f16a64170caf26ac1631d8321c3160be5245457994c494a5174db70dc3fd2bfca7326dae502092cb184ac41\",\"name\":\"@radix-ui/react-arrow\",\"version\":\"1.1.10\"},\"@radix-ui__react-aspect-ratio-1.1.10.tgz\":{\"integrity\":\"kbI7NrqhDeuytYrq7JjAsoXczvL8wgj2tc1MyaYWm+50bMKHCHQtVWCryslx4cCpmCTTkBcwQckE4CmmGV2haQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"91b23b36baa10debb2b58aeaec98c0b285dccef2fcc208f6b5cd4cc9a6169bee746cc28708742d5560abcac971e1c0a99824d390173041c904e029a6195da169\",\"name\":\"@radix-ui/react-aspect-ratio\",\"version\":\"1.1.10\"},\"@radix-ui__react-avatar-1.2.0.tgz\":{\"integrity\":\"am/CwltXtmtdtP+5FbYblYDnMa/zuKcMJP1i3/SJMDXXfj2mG+BTqLH2wucqeyyiQMursUtg/5cK+Nh2pCaSOA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"6a6fc2c25b57b66b5db4ffb915b61b9580e731aff3b8a70c24fd62dff4893035d77e3da61be053a8b1f6c2e72a7b2ca240cbabb14b60ff970af8d876a4269238\",\"name\":\"@radix-ui/react-avatar\",\"version\":\"1.2.0\"},\"@radix-ui__react-checkbox-1.3.5.tgz\":{\"integrity\":\"pREzrmNnVwGvYaBoM64huTRK7B3lrTRuwj8A9nwhPiEtMb+yudiWh6zWAqEtP0Dzd5+iBa1Ki7V1pCxV8ExMdA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"a51133ae63675701af61a06833ae21b9344aec1de5ad346ec23f00f67c213e212d31bfb2b9d89687acd602a12d3f40f3779fa205ad4a8bb575a42c55f04c4c74\",\"name\":\"@radix-ui/react-checkbox\",\"version\":\"1.3.5\"},\"@radix-ui__react-collapsible-1.1.14.tgz\":{\"integrity\":\"9bT+FvifX1FK2Mj6UEsTdyu0cN3JaA3KdfhaBao+ONrYFy/pyOy3TU1TNw7iOk1o+0hOEq67RojlUUmoFGwxyA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"f5b4fe16f89f5f514ad8c8fa504b13772bb470ddc9680dca75f85a05aa3e38dad8172fe9c8ecb74d4d53370ee23a4d68fb484e12aebb4688e55149a8146c31c8\",\"name\":\"@radix-ui/react-collapsible\",\"version\":\"1.1.14\"},\"@radix-ui__react-collection-1.1.10.tgz\":{\"integrity\":\"IVVz4EvBcKjrzKgof714qDnz/SzQAkLA2Emh5edlHbgcE6fNd3Un6CJLlaYcnm8N4JmAtzQgse4dOKxcD2yc9g==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"215573e04bc170a8ebcca8287fbd78a839f3fd2cd00242c0d849a1e5e7651db81c13a7cd777527e8224b95a61c9e6f0de09980b73420b1ee1d38ac5c0f6c9cf6\",\"name\":\"@radix-ui/react-collection\",\"version\":\"1.1.10\"},\"@radix-ui__react-compose-refs-1.1.3.tgz\":{\"integrity\":\"rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"ad838ff0e327bae3cc405d6e84f56518d7020e592890aa86144dc97311558889005cfec4bc5594962240b2dadaa72a5a04b24d1db64bea31a16d50c64f099584\",\"name\":\"@radix-ui/react-compose-refs\",\"version\":\"1.1.3\"},\"@radix-ui__react-context-1.1.4.tgz\":{\"integrity\":\"QwH4PO5urrbO+FaGd5Aglg+YJgWTyyuZ3g/6mKvsqraLkglDdckw9JafgL5McL5VEJ6EPNduPaT3ZE9BttDAqg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"4301f83cee6eaeb6cef85686779020960f98260593cb2b99de0ffa98abecaab68b92094375c930f4969f80be4c70be55109e843cd76e3da4f7644f41b6d0c0aa\",\"name\":\"@radix-ui/react-context\",\"version\":\"1.1.4\"},\"@radix-ui__react-context-menu-2.3.1.tgz\":{\"integrity\":\"XbrxS68W5dyiE4fAb96yvJwSVU5x66B20A99sD5Mk3xSWK/LqeOnx6TZnim1KieMjXS/CTFq8reOAjWxas2G8Q==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"5dbaf14baf16e5dca21387c06fdeb2bc9c12554e71eba076d00f7db03e4c937c5258afcba9e3a7c7a4d99e29b52a278c8d74bf09316af2b78e0235b16acd86f1\",\"name\":\"@radix-ui/react-context-menu\",\"version\":\"2.3.1\"},\"@radix-ui__react-dialog-1.1.17.tgz\":{\"integrity\":\"TDTYmpdq8dI2+Xgvgj9AJ8Ghqq+Eph/TRVEdaFQPDItIY+6QSkU7MJMeevw1568Yw/2Ijz8BTphPSP2XejKphw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"4c34d89a976af1d236f9782f823f4027c1a1aaaf84a61fd345511d68540f0c8b4863ee904a453b30931e7afc35e7af18c3fd888f3f014e984f48fd977a32a987\",\"name\":\"@radix-ui/react-dialog\",\"version\":\"1.1.17\"},\"@radix-ui__react-direction-1.1.2.tgz\":{\"integrity\":\"C3vFhbyi4SW3PmbAi6Awpu4OzJtd0MxGurvSsYtr7p7nM8RNB3VAF3CUmnp2j50knpkrRcB7+ycVXzgLgF6yNA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"0b7bc585bca2e125b73e66c08ba030a6ee0ecc9b5dd0cc46babbd2b18b6bee9ee733c44d0775401770949a7a768f9d249e992b45c07bfb27155f380b805eb234\",\"name\":\"@radix-ui/react-direction\",\"version\":\"1.1.2\"},\"@radix-ui__react-dismissable-layer-1.1.13.tgz\":{\"integrity\":\"2v+zNAWWe0ySxgC0D0yeXMPQ23xZVgXZTerTz+JKlmdRj6gfTqmCcR29jb6d290DezXPGgruHWDX/vYUebtErg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"daffb33405967b4c92c600b40f4c9e5cc3d0db7c595605d94dead3cfe24a9667518fa81f4ea982711dbd8dbe9ddbdd037b35cf1a0aee1d60d7fef61479bb44ae\",\"name\":\"@radix-ui/react-dismissable-layer\",\"version\":\"1.1.13\"},\"@radix-ui__react-dropdown-menu-2.1.18.tgz\":{\"integrity\":\"PZGV82gFk0WltDRI//SsG28ZIjlo9ANTmoNYg0jLNzXXiDsAy5PkOOYQaVD1pPxY6t7gxffb1QMD6qaUvsBZdw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"3d9195f368059345a5b43448fff4ac1b6f19223968f403539a83588348cb3735d7883b00cb93e438e6106950f5a4fc58eadee0c5f7dbd50303eaa694bec05977\",\"name\":\"@radix-ui/react-dropdown-menu\",\"version\":\"2.1.18\"},\"@radix-ui__react-focus-guards-1.1.4.tgz\":{\"integrity\":\"cot/aB/mOm0IYVYTTmQcEEK1M48lZWi8FlYe5nDPQQ8NYZUlXEFgncJ9p2Kzer3RKSrY7cTTpEMLZKNo9QoP5Q==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"728b7f681fe63a6d086156134e641c1042b5338f256568bc16561ee670cf410f0d6195255c41609dc27da762b37abdd1292ad8edc4d3a4430b64a368f50a0fe5\",\"name\":\"@radix-ui/react-focus-guards\",\"version\":\"1.1.4\"},\"@radix-ui__react-focus-scope-1.1.10.tgz\":{\"integrity\":\"Fas/lXQqhVvqwAb64s5RFeHiHYElZ6SUQbZaNd6EkfhP/Al7wTIQ9WIR4QVX475tlu5yFCEdDcJH6/UwsZjMWw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"15ab3f95742a855beac006fae2ce5115e1e21d812567a49441b65a35de8491f84ffc097bc13210f56211e10557e3be6d96ee7214211d0dc247ebf530b198cc5b\",\"name\":\"@radix-ui/react-focus-scope\",\"version\":\"1.1.10\"},\"@radix-ui__react-form-0.1.10.tgz\":{\"integrity\":\"1NfuvctVtX4sU3Mmq/IdrR8UunxiCMiVg3A5UENKhFzxUBeOyaQQ+lmaQaV7Tc8cqvBKsJL3/KGBsixK0D8WFg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"d4d7eebdcb55b57e2c537326abf21dad1f14ba7c6208c89583703950434a845cf150178ec9a410fa599a41a57b4dcf1caaf04ab092f7fca181b22c4ad03f1616\",\"name\":\"@radix-ui/react-form\",\"version\":\"0.1.10\"},\"@radix-ui__react-hover-card-1.1.17.tgz\":{\"integrity\":\"GjZQIEANVkuuWeztlKz6QEHe31ZX2iDfHzcTMCQVZXC0JyQrgfKWSC+LOOEw6aVV64zyjzobIzSA4AU4eKWrHA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"1a365020400d564bae59eced94acfa4041dedf5657da20df1f37133024156570b427242b81f296482f8b38e130e9a555eb8cf28f3a1b233480e0053878a5ab1c\",\"name\":\"@radix-ui/react-hover-card\",\"version\":\"1.1.17\"},\"@radix-ui__react-id-1.1.2.tgz\":{\"integrity\":\"orBC88futVpqCmhX1p4cvquNHsELQ+w+vBJnuj3ftETI5bJb0bZn3Tqu3SWN2IOcPycTnMGnhwoermvISt72sA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"a2b042f3c7eeb55a6a0a6857d69e1cbeab8d1ec10b43ec3ebc1267ba3ddfb444c8e5b25bd1b667dd3aaedd258dd8839c3f27139cc1a7870a1eae6bc84adef6b0\",\"name\":\"@radix-ui/react-id\",\"version\":\"1.1.2\"},\"@radix-ui__react-label-2.1.10.tgz\":{\"integrity\":\"ib0zvq2ZsAqKm5tRnqGJn3vOxSgIts5ToxsXT0q1S/GfLD1Zj7UOEnkw8u2w6sRmn47djpQWuSU1DCL1R29/yw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"89bd33bead99b00a8a9b9b519ea1899f7bcec52808b6ce53a31b174f4ab54bf19f2c3d598fb50e127930f2edb0eac4669f8edd8e9416b925350c22f5476f7fcb\",\"name\":\"@radix-ui/react-label\",\"version\":\"2.1.10\"},\"@radix-ui__react-menu-2.1.18.tgz\":{\"integrity\":\"lj8Rxjtn6zJq1oSbE/uDtAwCbB9BnxgHD+8MwJMuTh6u1dPamYhW9iuELr/Z8d0D/UysFblYYHeBPwi7T4k0YQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"963f11c63b67eb326ad6849b13fb83b40c026c1f419f18070fef0cc0932e4e1eaed5d3da998856f62b842ebfd9f1dd03fd4cac15b9586077813f08bb4f893461\",\"name\":\"@radix-ui/react-menu\",\"version\":\"2.1.18\"},\"@radix-ui__react-menubar-1.1.18.tgz\":{\"integrity\":\"hX7EGx/oFq6DPY27GQuP/2wP48GHf5LG6r06VgNJlG+znmDS8OfopZcRcGly3L4lsB9FqpmLx6JQSE9P3BUpyw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"857ec41b1fe816ae833d8dbb190b8fff6c0fe3c1877f92c6eabd3a560349946fb39e60d2f0e7e8a59711706972dcbe25b01f45aa998bc7a250484f4fdc1529cb\",\"name\":\"@radix-ui/react-menubar\",\"version\":\"1.1.18\"},\"@radix-ui__react-navigation-menu-1.2.16.tgz\":{\"integrity\":\"nJ0SkrSQgudyYhMiYeHA1ayLVuduEJCFLan1RZZN7c9kqzzCFLaU9kuy81uNtqzweM9YaQPgWzxi9MwQ9jZ04g==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"9c9d1292b49082e77262132261e1c0d5ac8b56e76e1090852da9f545964dedcf64ab3cc214b694f64bb2f35b8db6acf078cf586903e05b3c62f4cc10f63674e2\",\"name\":\"@radix-ui/react-navigation-menu\",\"version\":\"1.2.16\"},\"@radix-ui__react-one-time-password-field-0.1.10.tgz\":{\"integrity\":\"GHkcJ+WVj91At+OvUVTD4R3W0/wxw9t/sG5xFUBYXaCbtWiooZX5Md376QjJqgH4VsVyXrbVNHO2O4NYcmjfVg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"18791c27e5958fdd40b7e3af5154c3e11dd6d3fc31c3db7fb06e711540585da09bb568a8a195f931ddfbe908c9aa01f856c5725eb6d53473b63b83587268df56\",\"name\":\"@radix-ui/react-one-time-password-field\",\"version\":\"0.1.10\"},\"@radix-ui__react-password-toggle-field-0.1.5.tgz\":{\"integrity\":\"fVuA82u0b/fClpbEJv8yp1nU9eSvoSEOERsU/hhf3FXGPIvkmE7oEaHEu8poowoXO39/Va7zq2E0TUcYr1dBRg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"7d5b80f36bb46ff7c29696c426ff32a759d4f5e4afa1210e111b14fe185fdc55c63c8be4984ee811a1c4bbca68a30a173b7f7f55aef3ab61344d4718af574146\",\"name\":\"@radix-ui/react-password-toggle-field\",\"version\":\"0.1.5\"},\"@radix-ui__react-popover-1.1.17.tgz\":{\"integrity\":\"/YSAOdJ7YJvdn7bn5sdSx2egW+SKY+u7O5RyAVs94Ymrg2fg5QTSFPMRkzvhGyFuE4/qsmPBdrwYoZMZh/4f+g==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"fd848039d27b609bdd9fb6e7e6c752c767a05be48a63ebbb3b9472015b3de189ab8367e0e504d214f311933be11b216e138feab263c176bc18a1931987fe1ffa\",\"name\":\"@radix-ui/react-popover\",\"version\":\"1.1.17\"},\"@radix-ui__react-popper-1.3.1.tgz\":{\"integrity\":\"bhnq/0DEPTi2lsOD3J5rTL65qUKHbKbhqHsmN9TMiclSXpipi651ooUKPPp6G5lF/WiHBdn1s0Wuqsn+myVAvw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"6e19eaff40c43d38b696c383dc9e6b4cbeb9a942876ca6e1a87b2637d4cc89c9525e98a98bae75a2850a3cfa7a1b9945fd688705d9f5b345aeaac9fe9b2540bf\",\"name\":\"@radix-ui/react-popper\",\"version\":\"1.3.1\"},\"@radix-ui__react-portal-1.1.12.tgz\":{\"integrity\":\"m309havGzsjLHHaIX50G5PlvRs3xkgPCsGk/5PTvYm8D5q33yG0J7w/712PTOhid7NTaFETtnSXjngHQavvhVw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"9b7d3d85abc6cec8cb1c76885f9d06e4f96f46cdf19203c2b0693fe4f4ef626f03e6adf7c86d09ef0ffbd763d33a189decd4da1444ed9d25e39e01d06afbe157\",\"name\":\"@radix-ui/react-portal\",\"version\":\"1.1.12\"},\"@radix-ui__react-presence-1.1.6.tgz\":{\"integrity\":\"zdTk4PlUO0E18HnZ3wYbW0KkJJxWCdiNYp6g6X1PtONFhxVkg01vliTJAmwIszU6mHiyBOoW9P0rAugl5/hULQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"cdd4e4e0f9543b4135f079d9df061b5b42a4249c5609d88d629ea0e97d4fb4e345871564834d6f9624c9026c08b3353a9878b204ea16f4fd2b02e825e7f8542d\",\"name\":\"@radix-ui/react-presence\",\"version\":\"1.1.6\"},\"@radix-ui__react-primitive-2.1.6.tgz\":{\"integrity\":\"wetd0QI77DbvrPpTAvH1SqOxsYF2wZe5TNxqwOd5Ty4XDpV3dpV0s8K/1MGMJBeY5o7lg8ub5VIt1Ub+yVen6g==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"c1eb5dd1023bec36efacfa5302f1f54aa3b1b18176c197b94cdc6ac0e7794f2e170e9577769574b3c2bfd4c18c241798e68ee583cb9be5522dd546fec957a7ea\",\"name\":\"@radix-ui/react-primitive\",\"version\":\"2.1.6\"},\"@radix-ui__react-progress-1.1.10.tgz\":{\"integrity\":\"JYzEg60lk79PwKM27WZyKd7PW8O4OM5jOaFfRPfOyeXmMw7tLJh5kSj+CEjVTehszuwml/AdCzPGMXBTGf4BBw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"258cc483ad2593bf4fc0a336ed667229decf5bc3b838ce6339a15f44f7cec9e5e6330eed2c98799128fe0848d54de86cceec2697f01d0b33c631705319fe0107\",\"name\":\"@radix-ui/react-progress\",\"version\":\"1.1.10\"},\"@radix-ui__react-radio-group-1.4.1.tgz\":{\"integrity\":\"/SSxZdKEo2Eo29FFRKd06EfFDYp8HryKg0WYg7QLXaydPzl52YfSvCH2a3QDBRdtcuwACroJT8UVjQVgOJ7P9A==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"fd24b165d284a36128dbd14544a774e847c50d8a7c1ebc8a83459883b40b5dac9d3f3979d987d2bc21f66b740305176d72ec000aba094fc5158d0560389ecff4\",\"name\":\"@radix-ui/react-radio-group\",\"version\":\"1.4.1\"},\"@radix-ui__react-roving-focus-1.1.13.tgz\":{\"integrity\":\"9gkwneI0guf8JDmrFxPjJF6Ozzgioyw+/lonYNCwefS9ZHA05er0BVHiXr+LbWGHxUfczvMY6G1oiZZi1VzjRw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"f609309de23482e7fc2439ab1713e3245e8ecf3822a32c3efe5a2760d0b079f4bd647034e5eaf40551e25ebf8b6d6187c547dccef318e86d68899662d55ce347\",\"name\":\"@radix-ui/react-roving-focus\",\"version\":\"1.1.13\"},\"@radix-ui__react-scroll-area-1.2.12.tgz\":{\"integrity\":\"xuafVzQiTCLsyEjakowTdG3OgTXsmO7IdCiO77otIa+z44xoLNs9Do5eg7POFumIOCjtG6djfm6RKUKpUa/csA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"c6e69f5734224c22ecc848da928c13746dce8135ec98eec874288eefba2d21afb3e38c682cdb3d0e8e5e83b3ce16e9883828ed1ba7637e6e912942a951afdcb0\",\"name\":\"@radix-ui/react-scroll-area\",\"version\":\"1.2.12\"},\"@radix-ui__react-select-2.3.1.tgz\":{\"integrity\":\"w6eDvY78LE9ZUiNnXCA1QVK8RYN7k9galFv09kjVydJqBAgHd7Y9A6h0UJ/6DCZNGZMZrB2ohcSW1Bo9d8+wWA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"c3a783bd8efc2c4f595223675c20354152bc45837b93d81a945bf4f648d5c9d26a04080777b63d03a874509ffa0c264d199319ac1da885c496d41a3d77cfb058\",\"name\":\"@radix-ui/react-select\",\"version\":\"2.3.1\"},\"@radix-ui__react-separator-1.1.10.tgz\":{\"integrity\":\"Y6K6jLQCVfCnTL2MEtGxDLffkhNfEfHsEg3Wa8JU+IWdn3EWbLXd3OuOfQRN7p/W/cUce1WyTk3QeuAoDBzN9g==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"63a2ba8cb40255f0a74cbd8c12d1b10cb7df92135f11f1ec120dd66bc254f8859d9f71166cb5dddceb8e7d044dee9fd6fdc51c7b55b24e4dd07ae0280c1ccdf6\",\"name\":\"@radix-ui/react-separator\",\"version\":\"1.1.10\"},\"@radix-ui__react-slider-1.4.1.tgz\":{\"integrity\":\"r91WSpQucNGFKAIxT8FT0H0zyjd5tJlqObLp7LOMV4z49KoDCwjy01w3vDOU4e1wxhF9IgjYco7SB6byOW7Buw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"afdd564a942e70d1852802314fc153d07d33ca3779b4996a39b2e9ecb38c578cf8f4aa030b08f2d35c37bc3394e1ed70c6117d2208d8728ed207a6f2396ec1bb\",\"name\":\"@radix-ui/react-slider\",\"version\":\"1.4.1\"},\"@radix-ui__react-slot-1.3.0.tgz\":{\"integrity\":\"MojKku4U/miO8Av4Dkb+ctMAQx7JmY96LmtDQlAarCRtd7rN52QCSzBF+XAvr5S6coSVj9HEPBgHAHKEJVk/WA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"3288ca92ee14fe688ef00bf80e46fe72d300431ec9998f7a2e6b4342501aac246d77bacde764024b3045f9702faf94ba7284958fd1c43c180700728425593f58\",\"name\":\"@radix-ui/react-slot\",\"version\":\"1.3.0\"},\"@radix-ui__react-switch-1.3.1.tgz\":{\"integrity\":\"55bQtCnOB0BohomSHi6qvQXpJEEqUGDm6hRrM0Bph5OXwhSegqkd8IqgBAQkM1IlgUlWZIxpxRcpOEfRIgimyw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"e796d0b429ce0740688689921e2eaabd05e924412a5060e6ea146b334069879397c2149e82a91df08aa0040424335225814956648c69c517293847d12208a6cb\",\"name\":\"@radix-ui/react-switch\",\"version\":\"1.3.1\"},\"@radix-ui__react-tabs-1.1.15.tgz\":{\"integrity\":\"kxc9gI6/HfcU4nfMMVS3AmQK414kbU1IE6UCJmMmxjhO3cRPXOyYnmvyKD+ODt7q56nRq9l7Wovi6uaGwKgMlg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"93173d808ebf1df714e277cc3154b702640ae35e246d4d4813a502266326c6384eddc44f5cec989e6bf2283f8e0edeeae7a9d1abd97b5a8be2eae686c0a80c96\",\"name\":\"@radix-ui/react-tabs\",\"version\":\"1.1.15\"},\"@radix-ui__react-toast-1.2.17.tgz\":{\"integrity\":\"uL4kyyWy000pPL43fGGCV5qT6ZchCWEQZOSlkYiPwPt8Hy1iW38RjeptIvz1/SZesrW6Vn58Ct3sV7tfEfiAbw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"b8be24cb25b2d34d293cbe377c6182579a93e9972109611064e4a591888fc0fb7c1f2d625b7f118dea6d22fcf5fd265eb2b5ba567e7c0addec57bb5f11f8806f\",\"name\":\"@radix-ui/react-toast\",\"version\":\"1.2.17\"},\"@radix-ui__react-toggle-1.1.12.tgz\":{\"integrity\":\"AsAVsYNZIlRBsci7BhE+QyQeKd1h6TffJYt+lF0QQkd5OpQ3klfIByPsCb4G0h/Fq6PJwh1FYNluzBFYzhk4+w==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"02c015b18359225441b1c8bb06113e43241e29dd61e937df258b7e945d104247793a94379257c80723ec09be06d21fc5aba3c9c21d4560d96ecc1158ce1938fb\",\"name\":\"@radix-ui/react-toggle\",\"version\":\"1.1.12\"},\"@radix-ui__react-toggle-group-1.1.13.tgz\":{\"integrity\":\"Xb9PLtlvU66F36LiKba6dFswu6V2mDkgidO4fNSbQHQwmZ9ObxMIO17MN/LJ4aWJecVuSVLAHPZjyeMzJrgeiA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"5dbf4f2ed96f53ae85dfa2e229b6ba745b30bba57698392089d3b87cd49b407430999f4e6f13083b5ecc37f2c9e1a58979c56e4952c01cf663c9e33326b81e88\",\"name\":\"@radix-ui/react-toggle-group\",\"version\":\"1.1.13\"},\"@radix-ui__react-toolbar-1.1.13.tgz\":{\"integrity\":\"Za1l4f6fzTkGgz/iynAMN8iaqiKff2wm2/QwiLmHPtDQreWEBrvSimgQFIekxMUdRPhILM7xdIXxuS/o/DGZag==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"65ad65e1fe9fcd3906833fe2ca700c37c89aaa229f7f6c26dbf43088b9873ed0d0ade58406bbd28a68101487a4c4c51d44f8482ccef17485f1b92fe8fc31996a\",\"name\":\"@radix-ui/react-toolbar\",\"version\":\"1.1.13\"},\"@radix-ui__react-tooltip-1.2.10.tgz\":{\"integrity\":\"NlNe8D0dWEpVfXFli90IO6X07Josx/b1iu98tDnx9Xv0HT4wLIL+m2VOheMHhK7qbp2HoTBqALEFzGyZs/levw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"36535ef03d1d584a557d71658bdd083ba5f4ec9a2cc7f6f58aef7cb439f1f57bf41d3e302c82fe9b654e85e30784aeea6e9d87a1306a00b105cc6c99b3f95ebf\",\"name\":\"@radix-ui/react-tooltip\",\"version\":\"1.2.10\"},\"@radix-ui__react-use-callback-ref-1.1.2.tgz\":{\"integrity\":\"xCso9j1/u8sEgP1RNHjFrXJLApL8LiqOkI1R4ywuN00rxWdYg4oQXuwKLS3i0j5NWLromUD27/4nlxj2UFVvIw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"c42b28f63d7fbbcb0480fd513478c5ad724b0292fc2e2a8e908d51e32c2e374d2bc56758838a105eec0a2d2de2d23e4d58bae89940f6effe279718f650556f23\",\"name\":\"@radix-ui/react-use-callback-ref\",\"version\":\"1.1.2\"},\"@radix-ui__react-use-controllable-state-1.2.3.tgz\":{\"integrity\":\"PLzC90MS+ReootmjC597dvopoelpZ8Q61HJkDXZSExitIq7PL55vHNnesAHwguHK0aPfBnpdNzQtv1uliaqQrA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"3cbcc2f74312f917a8a2d9a30b9f7b76fa29a1e96967c43ad472640d76521318ad22aecf2f9e6f1cd9deb001f082e1cad1a3df067a5d37342dbf5ba589aa90ac\",\"name\":\"@radix-ui/react-use-controllable-state\",\"version\":\"1.2.3\"},\"@radix-ui__react-use-effect-event-0.0.3.tgz\":{\"integrity\":\"6c8ZqvPTWILEKnyVkP53EGRCcpnJiKTC21sS/6R1GF5xKyHJJWQEPfkqlcgUkdRQivd6tb23abUwe4ngWmY0JA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"e9cf19aaf3d35882c42a7c9590fe771064427299c988a4c2db5b12ffa475185e712b21c92564043df92a95c81491d4508af77ab5bdb769b5307b89e05a663424\",\"name\":\"@radix-ui/react-use-effect-event\",\"version\":\"0.0.3\"},\"@radix-ui__react-use-escape-keydown-1.1.2.tgz\":{\"integrity\":\"2uVLvLjgO7NZCWw01/FdqRwmA42J0BcjPMUCA+koFEOAb+zjqIP7SiFz/7zWPrKnVmSqr76Omq2ALyCuX4dhLw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"dae54bbcb8e03bb359096c34d7f15da91c26038d89d017233cc50203e9281443806fece3a883fb4a2173ffbcd63eb2a75664aaafbe8e9aad802f20ae5f87612f\",\"name\":\"@radix-ui/react-use-escape-keydown\",\"version\":\"1.1.2\"},\"@radix-ui__react-use-is-hydrated-0.1.1.tgz\":{\"integrity\":\"qwOiz4Tjo8CNnrOLAYUMXeZwDzXgXpvK4TKQPmWLECM9XoWvA6+0Z2/7Ag3A4ivjS4ovbLJPbskkxioFyBhr8A==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"ab03a2cf84e3a3c08d9eb38b01850c5de6700f35e05e9bcae132903e658b10233d5e85af03afb4676ffb020dc0e22be34b8a2f6cb24f6ec924c62a05c8186bf0\",\"name\":\"@radix-ui/react-use-is-hydrated\",\"version\":\"0.1.1\"},\"@radix-ui__react-use-layout-effect-1.1.2.tgz\":{\"integrity\":\"jrBWOxZITuGcnjRCM2t2U5ZPkCLxD+Ym6DjfssS5haTj2iiak/DOb64JeN6OdLfLgptb6/e2kKR+ZuTrGoZTPA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"8eb0563b16484ee19c9e3442336b7653964f9022f10fe626e838dfb2c4b985a4e3da289a93f0ce6fae0978de8e74b7cb829b5bebf7b690a47e66e4eb1a86533c\",\"name\":\"@radix-ui/react-use-layout-effect\",\"version\":\"1.1.2\"},\"@radix-ui__react-use-previous-1.1.2.tgz\":{\"integrity\":\"IGBQPtRFdhN6MQ8dbegVmBq1LVZluya3F1jWY+puIcQC3MHctRwTDSBWCkL/3ZcnMJLTMJ++Z+ktmvg0F89iCw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"2060503ed44576137a310f1d6de815981ab52d5665bb26b71758d663ea6e21c402dcc1dcb51c130d20560a42ffdd97273092d3309fbe67e92d9af83417cf620b\",\"name\":\"@radix-ui/react-use-previous\",\"version\":\"1.1.2\"},\"@radix-ui__react-use-rect-1.1.2.tgz\":{\"integrity\":\"d8a+bBY/FxikNPlgJJoaBHZX+zKVbWHYJGTLnLvveQgFSTntkGdEKv3JDtHrMS0DNYpllz2nRsTLGLKYttbpmw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"77c6be6c163f1718a434f960249a1a047657fb32956d61d82464cb9cbbef7908054939ed9067442afdc90ed1eb312d03358a65973da746c4cb18b298b6d6e99b\",\"name\":\"@radix-ui/react-use-rect\",\"version\":\"1.1.2\"},\"@radix-ui__react-use-size-1.1.2.tgz\":{\"integrity\":\"giWQp+4mxjBPt4KZ0MmyuykFNWfbDxKt4x+fPkRYmgRFJSbCZFzUglvMb/Kjn38tm10YP4ufiQZDx3zna4LU6w==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"822590a7ee26c6304fb78299d0c9b2bb29053567db0f12ade31f9f3e44589a04452526c2645cd4825bcc6ff2a39f7f2d9b5d183f8b9f890643c77ce76b82d4eb\",\"name\":\"@radix-ui/react-use-size\",\"version\":\"1.1.2\"},\"@radix-ui__react-visually-hidden-1.2.6.tgz\":{\"integrity\":\"jCE0WljWifTI4niIMCll06kGpsJTAPiZVU9H4WR1N6qW7At9ystHbN7dDB+we2xH535roFHj7qKS+RGj0FMDWQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"8c21345a58d689f4c8e27888302965d3a906a6c25300f899554f47e1647537aa96ec0b7dcacb476cdedd0c1fb07b6c47e77e6ba051e3eea292f911a3d0530359\",\"name\":\"@radix-ui/react-visually-hidden\",\"version\":\"1.2.6\"},\"@radix-ui__rect-1.1.2.tgz\":{\"integrity\":\"xnXE7wG13PI+cxieVssYXlQJuYVRhH9NBoxt3KNwzghDIA69GMm7d4wXRouHIYjE+KvS6U/MsMO73NdS2MH9ZA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"c675c4ef01b5dcf23e73189e56cb185e5409b98551847f4d068c6ddca370ce0843200ebd18c9bb778c17468b872188c4f8abd2e94fccb0c3bbdcd752d8c1fd64\",\"name\":\"@radix-ui/rect\",\"version\":\"1.1.2\"},\"@rolldown__binding-android-arm64-1.1.3.tgz\":{\"integrity\":\"DT6Z3PhvioeHMvxo+xHc3KtqggrI7CCTXCmC2h/5zUlp5jVitv7XEy+9q5/7v8IolhlioawpMo8Kg0EEBy7J0g==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"0d3e99dcf86f8a878732fc68fb11dcdcab6a820ac8ec20935c2982da1ff9cd4969e63562b6fed7132fbdab9ffbbfc228961962a1ac29328f0a834104072ec9d2\",\"name\":\"@rolldown/binding-android-arm64\",\"version\":\"1.1.3\"},\"@rolldown__binding-darwin-arm64-1.1.3.tgz\":{\"integrity\":\"0NwgwsjM7LrsuVnXMK3koTpagBNOhloc/BNjKqZjv4V5zI5r13qx69uVhRx+o5Z0yy4Hzq+lpy7TAgUG/ocvrw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"d0dc20c2c8ccecbaecb959d730ade4a13a5a80134e865a1cfc13632aa663bf8579cc8e6bd77ab1ebdb95851c7ea39674cb2e07ceafa5a72ed3020506fe872faf\",\"name\":\"@rolldown/binding-darwin-arm64\",\"version\":\"1.1.3\"},\"@rolldown__binding-darwin-x64-1.1.3.tgz\":{\"integrity\":\"YtiBp4disu6V560loT6PjMdiRaWmVvDNrUunAalbiFx2ggeJwxdAsgZMcoGP17uyAsTwAj5V1niksxlHnVQ1Sw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"62d881a78762b2ee95e7ad25a13e8f8cc76245a5a656f0cdad4ba701a95b885c76820789c31740b2064c72818fd7bbb202c4f0023e55d678a4b319479d54354b\",\"name\":\"@rolldown/binding-darwin-x64\",\"version\":\"1.1.3\"},\"@rolldown__binding-freebsd-x64-1.1.3.tgz\":{\"integrity\":\"yD3EkEdXk2LypPxnf/kSZHirarsI8gcPzc62SukhR9VJTyvV+F9Q/GxWNuCojc7sXyuVC4DxRGhdDK4X8VSsbw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"c83dc49047579362f2a4fc677ff9126478ab6abb08f2070fcdceb64ae92147d5494f2bd5f85f50fc6c5636e0a88dceec5f2b950b80f144685d0cae17f154ac6f\",\"name\":\"@rolldown/binding-freebsd-x64\",\"version\":\"1.1.3\"},\"@rolldown__binding-linux-arm-gnueabihf-1.1.3.tgz\":{\"integrity\":\"c+8vieQbsD7HNAHKIA34w0GJ9FedFFuJGD+7E6vz7Q3uqAIugL5p45fhlsj4UaAsHpcmlqugBWMhA0/j7o0sIg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"73ef2f89e41bb03ec73401ca200df8c34189f4579d145b89183fbb13abf3ed0deea8022e80be69e397e196c8f851a02c1e972696aba0056321034fe3ee8d2c22\",\"name\":\"@rolldown/binding-linux-arm-gnueabihf\",\"version\":\"1.1.3\"},\"@rolldown__binding-linux-arm64-gnu-1.1.3.tgz\":{\"integrity\":\"50jD0uUwLvur7Zz9LHz17kaAdTPjn5wN93hEgjvmYFRZwiR7ZJYovTd5ipyWJDAnXKvZ+wgc+/Ika6dwSF5OcA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"e748c3d2e5302efbabed9cfd2c7cf5ee46807533e39f9c0df77844823be6605459c2247b649628bd37798a9c962430275cabd9fb081cfbf2246ba770485e4e70\",\"name\":\"@rolldown/binding-linux-arm64-gnu\",\"version\":\"1.1.3\"},\"@rolldown__binding-linux-arm64-musl-1.1.3.tgz\":{\"integrity\":\"BO9+oPL8K9poZJBfYPsXNtYjPE5uM3qeehT3aFcW4LITOl+iSqhp0abzjR2nWBUNjIZeKXjAEWBZ64WjNoHd6w==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"04ef7ea0f2fc2bda6864905f60fb1736d6233c4e6e337a9e7a14f7685716e0b2133a5fa24aa869d1a6f38d1da758150d8c865e2978c0116059eb85a33681ddeb\",\"name\":\"@rolldown/binding-linux-arm64-musl\",\"version\":\"1.1.3\"},\"@rolldown__binding-linux-ppc64-gnu-1.1.3.tgz\":{\"integrity\":\"f3VpLB1vQ0Eo6ecr/6cekLnvYMFF4YBFoVGkfkvPLq1bAkbAwHYQPZKoAmG6OJyTcxxoC+AvezGx/S1obNC0Mw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"7f75692c1d6f434128e9e72bffa71e90b9ef60c145e18045a151a47e4bcf2ead5b0246c0c076103d92a80261ba389c93731c680be02f7b31b1fd2d686cd0b433\",\"name\":\"@rolldown/binding-linux-ppc64-gnu\",\"version\":\"1.1.3\"},\"@rolldown__binding-linux-s390x-gnu-1.1.3.tgz\":{\"integrity\":\"AmurZ26Pqx/RI9N1gzEOCklkKXl927yjfXWUUS0O7Puh8ARM/Ob8qfrD3qnWksScdw6cSrW5PSHE9DyLu7+PtA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"026bab676e8fab1fd123d37583310e0a496429797ddbbca37d7594512d0eecfba1f0044cfce6fca9fac3dea9d692c49c770e9c4ab5b93d21c4f43c8bbbbf8fb4\",\"name\":\"@rolldown/binding-linux-s390x-gnu\",\"version\":\"1.1.3\"},\"@rolldown__binding-linux-x64-gnu-1.1.3.tgz\":{\"integrity\":\"JJpqs8bRGITDOdbkNKnlojzBabbOHrqjSvDr0IVsZObE1lBcPjxItUEY9eWIDbxaJ3cGrXPWGfGkIxFijg/URg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"249a6ab3c6d11884c339d6e434a9e5a23cc169b6ce1ebaa34af0ebd0856c64e6c4d6505c3e3c48b54118f5e5880dbc5a277706ad73d619f1a42311628e0fd446\",\"name\":\"@rolldown/binding-linux-x64-gnu\",\"version\":\"1.1.3\"},\"@rolldown__binding-linux-x64-musl-1.1.3.tgz\":{\"integrity\":\"rSJcdjPxzA/by/6/rYs+v+bXU7UjvnbUWz8MJb6kh6+knqB1dCrtHg0uu7C/4haqJvqdkYHQ5IGn+tCH9GLW/g==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"ad225c7633f1cc0fdbcbfebfad8b3ebfe6d753b523be76d45b3f0c25bea487afa49ea075742aed1e0d2ebbb0bfe216aa26fa9d9181d0e481a7fad087f462d6fe\",\"name\":\"@rolldown/binding-linux-x64-musl\",\"version\":\"1.1.3\"},\"@rolldown__binding-openharmony-arm64-1.1.3.tgz\":{\"integrity\":\"hQ3/PYkDJICgevvyNcVrihVeqq7k1Pp3VZ9lY+dauAYUJKO+auqApvANhvR1An9BhmqYKvW2Mu1F9u4DXSMLxQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"850dff3d89032480a07afbf235c56b8a155eaaaee4d4fa77559f6563e75ab8061424a3be6aea80a6f00d86f475027f41866a982af5b632ed45f6ee035d230bc5\",\"name\":\"@rolldown/binding-openharmony-arm64\",\"version\":\"1.1.3\"},\"@rolldown__binding-wasm32-wasi-1.1.3.tgz\":{\"integrity\":\"Elcv/BtML9lXrV6JuKITc/grN2kYV9gjsQpW8Jfw4ioK0TOkjBjye0nnyqQNy9STNaI20lXNaQBRrD5gSgR0Yg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"12572ffc1b4c2fd957ad5e89b8a21373f82b37691857d823b10a56f097f0e22a0ad133a48c18f27b49e7caa40dcbd49335a236d255cd690051ac3e604a047462\",\"name\":\"@rolldown/binding-wasm32-wasi\",\"version\":\"1.1.3\"},\"@rolldown__binding-win32-arm64-msvc-1.1.3.tgz\":{\"integrity\":\"2DrEfhluH9yhiaFApmsjsjwrSYbNcY1oFTzYSP1a535jDbV98zCFanA/96TBUd0iDFcxGmw9QRExwGCXz3U+/g==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"d83ac47e196e1fdca189a140a66b23b23c2b4986cd718d68153cd848fd5ae77e630db57df330856a703ff7a4c151dd220c57311a6c3d411131c06097cf753efe\",\"name\":\"@rolldown/binding-win32-arm64-msvc\",\"version\":\"1.1.3\"},\"@rolldown__binding-win32-x64-msvc-1.1.3.tgz\":{\"integrity\":\"OL4OMk7UPXOeVGGd3qo5zJyPIljf4AFgk5QAkPPS+OoLuOOozhuaQGC18MxVTnw/06q93gShAJzlwnSCY9YtqA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"38be0e324ed43d739e54619ddeaa39cc9c8f2258dfe0016093940090f3d2f8ea0bb8e3a8ce1b9a4060b5f0cc554e7c3fd3aabdde04a1009ce5c2748263d62da8\",\"name\":\"@rolldown/binding-win32-x64-msvc\",\"version\":\"1.1.3\"},\"@rolldown__pluginutils-1.0.1.tgz\":{\"integrity\":\"2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"da3f5b1ade4987c863faf3ed8333ed97bda3d324711c0cae9a8a3a4cd7c08ec2c1d3852da52bcf6cf703701331cfb9fef42601d1cd46c501716118368e29aa1b\",\"name\":\"@rolldown/pluginutils\",\"version\":\"1.0.1\"},\"@simple-libs__child-process-utils-2.0.0.tgz\":{\"integrity\":\"dvNoRKLijXnD0XoJAz94pbNuB5GQgDr55UhpSPhffDkTT0Cmcqh9jSCOtwfT2d4H6MI9E7c4SgtMuJXZ6F3c6A==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"76f36844a2e28d79c3d17a09033f78a5b36e079190803af9e5486948f85f7c39134f40a672a87d8d208eb707d3d9de07e8c23d13b7384a0b4cb895d9e85ddce8\",\"name\":\"@simple-libs/child-process-utils\",\"version\":\"2.0.0\"},\"@simple-libs__stream-utils-2.0.0.tgz\":{\"integrity\":\"fCTuZK4QBa+39Oz9l4OGfJfz+GpwCp3AqO7Zch3to99xHPgstVsRFpeQ8LNd2o1Gv8raL2mCFwiaHh7bFSp5DQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"7c24ee64ae1005afb7f4ecfd9783867c97f3f86a700a9dc0a8eed9721deda3df711cf82cb55b11169790f0b35dda8d46bfcada2f698217089a1e1edb152a790d\",\"name\":\"@simple-libs/stream-utils\",\"version\":\"2.0.0\"},\"@tailwindcss__node-4.3.1.tgz\":{\"integrity\":\"6NDaqRoAMSXD1mr/RXu0HBvNE9a2n5tHPsxu9XHLws8o4Twes5rBM2205SUUiJ9goAtadrN6xTGX0UDEwp/N4A==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"e8d0daa91a003125c3d66aff457bb41c1bcd13d6b69f9b473ecc6ef571cbc2cf28e13c1eb39ac1336db4e52514889f60a00b5a76b37ac53197d140c4c29fcde0\",\"name\":\"@tailwindcss/node\",\"version\":\"4.3.1\"},\"@tailwindcss__oxide-4.3.1.tgz\":{\"integrity\":\"yVPyo8RNkabVr3O2EhHEE0Rewu7YKzc1DhIqfL46LKveFrmu9XbDazNOJY7/GRuvw1h6u3utWnR29H/p5JPlgA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"c953f2a3c44d91a6d5af73b61211c413445ec2eed82b37350e122a7cbe3a2cabde16b9aef576c36b334e258eff191bafc3587abb7bad5a7476f47fe9e493e580\",\"name\":\"@tailwindcss/oxide\",\"version\":\"4.3.1\"},\"@tailwindcss__oxide-android-arm64-4.3.1.tgz\":{\"integrity\":\"SVlyf61g374l5cHyg8x9kf5xmLcOaxvOTsbsqDnSsDJaKOEFZ7GCvi84VAVGpxojYOs1+3K6M0UjXfqPU8vmOQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"4959727fad60dfbe25e5c1f283cc7d91fe7198b70e6b1bce4ec6eca839d2b0325a28e10567b182be2f38540546a71a2360eb35fb72ba3345235dfa8f53cbe639\",\"name\":\"@tailwindcss/oxide-android-arm64\",\"version\":\"4.3.1\"},\"@tailwindcss__oxide-darwin-arm64-4.3.1.tgz\":{\"integrity\":\"hVnWLwv+e/l7c4WKyVtHVrIPvYdqWHjRB3MDIqARynzFtnQg85kmQEFCbV9Ja0VVx4xXTIiDWY60Y7iz/iNoDA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"8559d62f0bfe7bf97b73858ac95b4756b20fbd876a5878d107730322a011ca7cc5b67420f399264041426d5f496b4555c78c574c8883598eb463b8b3fe23680c\",\"name\":\"@tailwindcss/oxide-darwin-arm64\",\"version\":\"4.3.1\"},\"@tailwindcss__oxide-darwin-x64-4.3.1.tgz\":{\"integrity\":\"Cf7abu0WVgbhU7ANgPUnSAvm7nCvMweusHb8FnaHlLfv/Caq4GYaEZg7ZImzzmjx4lIAfuS8q+eLIS7A7IzxIg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"09feda6eed165606e153b00d80f527480be6ee70af3307aeb076fc16768794b7effc26aae0661a11983b6489b3ce68f1e252007ee4bcabe78b212ec0ec8cf122\",\"name\":\"@tailwindcss/oxide-darwin-x64\",\"version\":\"4.3.1\"},\"@tailwindcss__oxide-freebsd-x64-4.3.1.tgz\":{\"integrity\":\"ZZqzX2Y+GXtXXfqSfpJhDm60OoZfvLHLCgm+J7NVqgHHJjG/m9ugZI77RwTsVd4fnBJuCFP6Ae6kTJb71UdS8g==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"659ab35f663e197b575dfa927e92610e6eb43a865fbcb1cb0a09be27b355aa01c72631bf9bdba0648efb4704ec55de1f9c126e0853fa01eea44c96fbd54752f2\",\"name\":\"@tailwindcss/oxide-freebsd-x64\",\"version\":\"4.3.1\"},\"@tailwindcss__oxide-linux-arm-gnueabihf-4.3.1.tgz\":{\"integrity\":\"/Ah/xik0LaMYfv9DZ0S/t4pBlBNYOcqtRwusjgovHkvT8ixueWCLyJjsaF5kQIckjb4IT8Q6K6p/iPmZMixYgg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"fc087fc629342da3187eff436744bfb78a4194135839caad470bac8e0a2f1e4bd3f22c6e79608bc898ec685e644087248dbe084fc43a2baa7f88f999322c5882\",\"name\":\"@tailwindcss/oxide-linux-arm-gnueabihf\",\"version\":\"4.3.1\"},\"@tailwindcss__oxide-linux-arm64-gnu-4.3.1.tgz\":{\"integrity\":\"gqdFoVJlw444GvpnheZLHmvTzSxI/cOUUh2KSNejQjTcYkW062SVD+En0rUgD+QV91bz1XGIGtt1HJd48xUGbQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"82a745a15265c38e381afa6785e64b1e6bd3cd2c48fdc394521d8a48d7a34234dc6245b4eb64950fe127d2b5200fe415f756f3d571881adb751c9778f315066d\",\"name\":\"@tailwindcss/oxide-linux-arm64-gnu\",\"version\":\"4.3.1\"},\"@tailwindcss__oxide-linux-arm64-musl-4.3.1.tgz\":{\"integrity\":\"Bwv9KwOvE0VKa86xPFif9b9c3Y1NxOV1P0gLti/IYaWEsQYZXDlxfGEtA8mdDZ7SG3wyNXAWYT5SIn3giL57oA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"070bfd2b03af13454a6bceb13c589ff5bf5cdd8d4dc4e5753f480bb62fc861a584b106195c39717c612d03c99d0d9ed21b7c32357016613e52227de088be7ba0\",\"name\":\"@tailwindcss/oxide-linux-arm64-musl\",\"version\":\"4.3.1\"},\"@tailwindcss__oxide-linux-x64-gnu-4.3.1.tgz\":{\"integrity\":\"Ymi8O8T15HYQdOUWUtTI6ldN0neHP85FC+Qz32xTcZ7iJXtem/x8ITev0o1e9e5rkqj4lONZfTRLvkmin1+tKg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"6268bc3bc4f5e4761074e51652d4c8ea574dd277873fce450be433df6c53719ee2257b5e9bfc7c2137afd28d5ef5ee6b92a8f894e3597d344bbe49a29f5fad2a\",\"name\":\"@tailwindcss/oxide-linux-x64-gnu\",\"version\":\"4.3.1\"},\"@tailwindcss__oxide-linux-x64-musl-4.3.1.tgz\":{\"integrity\":\"M+P/91qJ6uILLw4k2G93GMDRAXj61SMvFQYt39AqvUqYgExXpLL5aepfns7sj4HiAQeolirQF9E0lzRvdf4zPQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"33e3fff75a89eae20b2f0e24d86f7718c0d10178fad5232f15062ddfd02abd4a98804c57a4b2f969ea5f9eceec8f81e20107a8962ad017d13497346f75fe333d\",\"name\":\"@tailwindcss/oxide-linux-x64-musl\",\"version\":\"4.3.1\"},\"@tailwindcss__oxide-wasm32-wasi-4.3.1.tgz\":{\"integrity\":\"zsM8uOeqvVGHsAXsJxsT28ttosFahLJKCLOTUBqRAtKnVgGSRitds9T432QiT8b77Yga7JIBkulIRRlJPtYhRA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"cec33cb8e7aabd5187b005ec271b13dbcb6da2c15a84b24a08b393501a9102d2a7560192462b5db3d4f8df64224fc6fbed881aec920192e9484519493ed62144\",\"name\":\"@tailwindcss/oxide-wasm32-wasi\",\"version\":\"4.3.1\"},\"@tailwindcss__oxide-win32-arm64-msvc-4.3.1.tgz\":{\"integrity\":\"aiNvSq9BsVk8V513lDKlrCFAgf8qBMPZTpgEhInL+NwQqs97mYmupVMrPrgBBSL8Pv/0zXu9MrMF9rMun1ZeNg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"6a236f4aaf41b1593c579d779432a5ac214081ff2a04c3d94e98048489cbf8dc10aacf7b9989aea5532b3eb8010522fc3efff4cd7bbd32b305f6b32e9f565e36\",\"name\":\"@tailwindcss/oxide-win32-arm64-msvc\",\"version\":\"4.3.1\"},\"@tailwindcss__oxide-win32-x64-msvc-4.3.1.tgz\":{\"integrity\":\"xDEyu1rg290472FEGaKHnzyDyh5QH+AlWvsU5hMoMtPpzmKlRI0jaYKCgSHDYtaQWZOYbMaduSyCwFwY4n1HmA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"c43132bb5ae0dbdd38ef614419a2879f3c83ca1e501fe0255afb14e6132832d3e9ce62a5448d236982828121c362d6905993986cc69db92c82c05c18e27d4798\",\"name\":\"@tailwindcss/oxide-win32-x64-msvc\",\"version\":\"4.3.1\"},\"@tailwindcss__postcss-4.3.1.tgz\":{\"integrity\":\"dNJuNbdEJT/SWRuXTYP1WSamelsz3ztkUsdtWQPjrexysrTpaEPM40P/71knXiXLYEojqPOEGitVLLpPMS5T6A==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"74d26e35b744253fd2591b974d83f55926a67a5b33df3b6452c76d5903e3adec72b2b4e96843cce343ffef59275e25cb604a23a8f3841a2b552cba4f312e53e8\",\"name\":\"@tailwindcss/postcss\",\"version\":\"4.3.1\"},\"@tanstack__query-core-5.101.2.tgz\":{\"integrity\":\"hH5MLoJhF7KaIGd7q3xTXGXvslI+GYlM1Z/35aSHHWaCJWB7XvTSHYuV3eM7tw+aE0mT/xMro4M4Q9rCGHT0lw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"847e4c2e826117b29a20677bab7c535c65efb2523e19894cd59ff7e5a4871d668225607b5ef4d21d8b95dde33bb70f9a134993ff132ba3833843dac21874f497\",\"name\":\"@tanstack/query-core\",\"version\":\"5.101.2\"},\"@tanstack__react-query-5.101.2.tgz\":{\"integrity\":\"seDkr6kzGzX1okaaTtZPtgA688CDPlXUz1C6xSg0ESqn04Vuc8tlrYms1s3de+znBqhPVxFRfpAfUf+6XvfPWg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"b1e0e4afa9331b35f5a2469a4ed64fb6003af3c0833e55d4cf50bac52834112aa7d3856e73cb65ad89acd6cddd7bece706a84f5711517e901f51ffba5ef7cf5a\",\"name\":\"@tanstack/react-query\",\"version\":\"5.101.2\"},\"@tauri-apps__api-2.10.1.tgz\":{\"integrity\":\"hKL/jWf293UDSUN09rR69hrToyIXBb8CjGaWC7gfinvnQrBVvnLr08FeFi38gxtugAVyVcTa5/FD/Xnkb1siBw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"84a2ff8d67f6f77503494374f6b47af61ad3a3221705bf028c66960bb81f8a7be742b055be72ebd3c15e162dfc831b6e80057255c4dae7f143fd79e46f5b2207\",\"name\":\"@tauri-apps/api\",\"version\":\"2.10.1\"},\"@tauri-apps__api-2.11.1.tgz\":{\"integrity\":\"M2FPuYND2m+wh5hfW9ZpSdxMPdEJovPBWwoHJmwUpysTYNHaOkVFN419m/K0LIgjb/7KU2vBgsUepJWugQCvAA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"33614fb98343da6fb087985f5bd66949dc4c3dd109a2f3c15b0a07266c14a72b1360d1da3a4545378d7d9bf2b42c88236ffeca536bc182c51ea495ae8100af00\",\"name\":\"@tauri-apps/api\",\"version\":\"2.11.1\"},\"@tauri-apps__cli-2.10.1.tgz\":{\"integrity\":\"jQNGF/5quwORdZSSLtTluyKQ+o6SMa/AUICfhf4egCGFdMHqWssApVgYSbg+jmrZoc8e1DscNvjTnXtlHLS11g==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"8d034617fe6abb03917594922ed4e5bb2290fa8e9231afc050809f85fe1e80218574c1ea5acb00a5581849b83e8e6ad9a1cf1ed43b1c36f8d39d7b651cb4b5d6\",\"name\":\"@tauri-apps/cli\",\"version\":\"2.10.1\"},\"@tauri-apps__cli-darwin-arm64-2.10.1.tgz\":{\"integrity\":\"Z2OjCXiZ+fbYZy7PmP3WRnOpM9+Fy+oonKDEmUE6MwN4IGaYqgceTjwHucc/kEEYZos5GICve35f7ZiizgqEnQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"6763a3097899f9f6d8672ecf98fdd64673a933df85cbea289ca0c499413a330378206698aa071e4e3c07b9c73f904118668b391880af7b7e5fed98a2ce0a849d\",\"name\":\"@tauri-apps/cli-darwin-arm64\",\"version\":\"2.10.1\"},\"@tauri-apps__cli-darwin-x64-2.10.1.tgz\":{\"integrity\":\"V/irQVvjPMGOTQqNj55PnQPVuH4VJP8vZCN7ajnj+ZS8Kom1tEM2hR3qbbIRoS3dBKs5mbG8yg1WC+97dq17Pw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"57f8ab415be33cc18e4d0a8d8f9e4f9d03d5b87e1524ff2f64237b6a39e3f994bc2a89b5b44336851dea6db211a12ddd04ab3999b1bcca0d560bef7b76ad7b3f\",\"name\":\"@tauri-apps/cli-darwin-x64\",\"version\":\"2.10.1\"},\"@tauri-apps__cli-linux-arm-gnueabihf-2.10.1.tgz\":{\"integrity\":\"Hyzwsb4VnCWKGfTw+wSt15Z2pLw2f0JdFBfq2vHBOBhvg7oi6uhKiF87hmbXOBXUZaGkyRDkCHsdzJcIfoJC2w==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"1f2cf0b1be159c258a19f4f0fb04add79676a4bc367f425d1417eadaf1c138186f83ba22eae84a885f3b8666d73815d465a1a4c910e4087b1dcc97087e8242db\",\"name\":\"@tauri-apps/cli-linux-arm-gnueabihf\",\"version\":\"2.10.1\"},\"@tauri-apps__cli-linux-arm64-gnu-2.10.1.tgz\":{\"integrity\":\"OyOYs2t5GkBIvyWjA1+h4CZxTcdz1OZPCWAPz5DYEfB0cnWHERTnQ/SLayQzncrT0kwRoSfSz9KxenkyJoTelA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"3b2398b36b791a4048bf25a3035fa1e026714dc773d4e64f09600fcf90d811f0747275871114e743f48b6b24339dcad3d24c11a127d2cfd2b17a79322684de94\",\"name\":\"@tauri-apps/cli-linux-arm64-gnu\",\"version\":\"2.10.1\"},\"@tauri-apps__cli-linux-arm64-musl-2.10.1.tgz\":{\"integrity\":\"MIj78PDDGjkg3NqGptDOGgfXks7SYJwhiMh8SBoZS+vfdz7yP5jN18bNaLnDhsVIPARcAhE1TlsZe/8Yxo2zqg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"3088fbf0f0c31a3920dcda86a6d0ce1a07d792ced2609c2188c87c481a194bebdf773ef23f98cdd7c6cd68b9c386c5483c045c0211354e5b197bff18c68db3aa\",\"name\":\"@tauri-apps/cli-linux-arm64-musl\",\"version\":\"2.10.1\"},\"@tauri-apps__cli-linux-riscv64-gnu-2.10.1.tgz\":{\"integrity\":\"X0lvOVUg8PCVaoEtEAnpxmnkwlE1gcMDTqfhbefICKDnOTJ5Est3qL0SrWxizDackIOKBcvtpejrSiVpuJI1kw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"5f496f395520f0f0956a812d1009e9c669e4c2513581c3034ea7e16de7c808a0e739327912cb77a8bd12ad6c62cc369c90838a05cbeda5e8eb4a2569b8923593\",\"name\":\"@tauri-apps/cli-linux-riscv64-gnu\",\"version\":\"2.10.1\"},\"@tauri-apps__cli-linux-x64-gnu-2.10.1.tgz\":{\"integrity\":\"2/12bEzsJS9fAKybxgicCDFxYD1WEI9kO+tlDwX5znWG2GwMBaiWcmhGlZ8fi+DMe9CXlcVarMTYc0L3REIRxw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"dbfd766c4cec252f5f00ac9bc6089c083171603d56108f643beb650f05f9ce7586d86c0c05a896726846959f1f8be0cc7bd09795c55aacc4d87342f7444211c7\",\"name\":\"@tauri-apps/cli-linux-x64-gnu\",\"version\":\"2.10.1\"},\"@tauri-apps__cli-linux-x64-musl-2.10.1.tgz\":{\"integrity\":\"Y8J0ZzswPz50UcGOFuXGEMrxbjwKSPgXftx5qnkuMs2rmwQB5ssvLb6tn54wDSYxe7S6vlLob9vt0VKuNOaCIQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"63c274673b303f3e7451c18e16e5c610caf16e3c0a48f8177edc79aa792e32cdab9b0401e6cb2f2dbead9f9e300d26317bb4babe52e86fdbedd152ae34e68221\",\"name\":\"@tauri-apps/cli-linux-x64-musl\",\"version\":\"2.10.1\"},\"@tauri-apps__cli-win32-arm64-msvc-2.10.1.tgz\":{\"integrity\":\"iSt5B86jHYAPJa/IlYw++SXtFPGnWtFJriHn7X0NFBVunF6zu9+/zOn8OgqIWSl8RgzhLGXQEEtGBdR4wzpVgg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"892b7907cea31d800f25afc8958c3ef925ed14f1a75ad149ae21e7ed7d0d14156e9c5eb3bbdfbfcce9fc3a0a8859297c460ce12c65d0104b4605d478c33a5582\",\"name\":\"@tauri-apps/cli-win32-arm64-msvc\",\"version\":\"2.10.1\"},\"@tauri-apps__cli-win32-ia32-msvc-2.10.1.tgz\":{\"integrity\":\"gXyxgEzsFegmnWywYU5pEBURkcFN/Oo45EAwvZrHMh+zUSEAvO5E8TXsgPADYm31d1u7OQU3O3HsYfVBf2moHw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"817cb1804cec15e8269d6cb0614e6910151191c14dfcea38e44030bd9ac7321fb3512100bcee44f135ec80f003626df5775bbb3905373b71ec61f5417f69a81f\",\"name\":\"@tauri-apps/cli-win32-ia32-msvc\",\"version\":\"2.10.1\"},\"@tauri-apps__cli-win32-x64-msvc-2.10.1.tgz\":{\"integrity\":\"6Cn7YpPFwzChy0ERz6djKEmUehWrYlM+xTaNzGPgZocw3BD7OfwfWHKVWxXzdjEW2KfKkHddfdxK1XXTYqBRLg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"e829fb6293c5c330a1cb4111cfa7632849947a15ab62533ec5368dcc63e0668730dc10fb39fc1f5872955b15f3763116d8a7ca90775d7ddc4ad575d362a0512e\",\"name\":\"@tauri-apps/cli-win32-x64-msvc\",\"version\":\"2.10.1\"},\"@tauri-apps__plugin-deep-link-2.4.6.tgz\":{\"integrity\":\"UUOSt0U5juK20uhO2MoHZX/IPblkrhUh+VPtIeu3RwtzI0R9Em3Auzfg/PwcZ9Pv8mLne3cQ4p9CFXD6WxqCZA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"514392b745398ee2b6d2e84ed8ca07657fc83db964ae1521f953ed21ebb7470b7323447d126dc0bb37e0fcfc1c67d3eff262e77b7710e29f421570fa5b1a8264\",\"name\":\"@tauri-apps/plugin-deep-link\",\"version\":\"2.4.6\"},\"@tauri-apps__plugin-dialog-2.7.1.tgz\":{\"integrity\":\"OK1UBXYt+ojcmxMktzzuyonYIFta8CmAASpX+CA+DTGK24KlHjhYI6x2iOJ/TjZF4N7/ACK1oFmEOjIY9IhzOQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"38ad5405762dfa88dc9b1324b73ceeca89d8205b5af02980012a57f8203e0d318adb82a51e385823ac7688e27f4e3645e0deff0022b5a059843a3218f4887339\",\"name\":\"@tauri-apps/plugin-dialog\",\"version\":\"2.7.1\"},\"@tauri-apps__plugin-notification-2.3.3.tgz\":{\"integrity\":\"Zw+ZH18RJb41G4NrfHgIuofJiymusqN+q8fGUIIV7vyCH+5sSn5coqRv/MWB9qETsUs97vmU045q7OyseCV3Qg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"670f991f5f1125be351b836b7c7808ba87c98b29aeb2a37eabc7c6508215eefc821fee6c4a7e5ca2a46ffcc581f6a113b14b3deef994d38e6aececac78257742\",\"name\":\"@tauri-apps/plugin-notification\",\"version\":\"2.3.3\"},\"@tauri-apps__plugin-opener-2.5.4.tgz\":{\"integrity\":\"1HnPkb+AmgO29HBazm4uPLKB+r7zzcTBW1d0fyYp1uP+jwtpoiNDGKMMzz58SFp49nOIrxdE3aUJtT57lfO9CQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"d479cf91bf809a03b6f4705ace6e2e3cb281fabef3cdc4c15b57747f2629d6e3fe8f0b69a2234318a30ccf3e7c485a78f67388af1744dda509b53e7b95f3bd09\",\"name\":\"@tauri-apps/plugin-opener\",\"version\":\"2.5.4\"},\"@tauri-apps__plugin-os-2.3.2.tgz\":{\"integrity\":\"n+nXWeuSeF9wcEsSPmRnBEGrRgOy6jjkSU+UVCOV8YUGKb2erhDOxis7IqRXiRVHhY8XMKks00BJ0OAdkpf6+A==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"9fe9d759eb92785f70704b123e64670441ab4603b2ea38e4494f94542395f1850629bd9eae10cec62b3b22a457891547858f1730a92cd34049d0e01d9297faf8\",\"name\":\"@tauri-apps/plugin-os\",\"version\":\"2.3.2\"},\"@tauri-apps__plugin-process-2.3.1.tgz\":{\"integrity\":\"nCa4fGVaDL/B9ai03VyPOjfAHRHSBz5v6F/ObsB73r/dA3MHHhZtldaDMIc0V/pnUw9ehzr2iEG+XkSEyC0JJA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"9c26b87c655a0cbfc1f5a8b4dd5c8f3a37c01d11d2073e6fe85fce6ec07bdebfdd0373071e166d95d68330873457fa67530f5e873af68841be5e4484c82d0924\",\"name\":\"@tauri-apps/plugin-process\",\"version\":\"2.3.1\"},\"@tauri-apps__plugin-store-2.4.3.tgz\":{\"integrity\":\"9LWPj9yMphRi9czEtUv87XHbl1b6xgd9EXpPrUnq6nG7+nbtoF84d4Kwz9xhAv/Hf30sr58pq7EOlyI936y8qw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"f4b58f8fdc8ca61462f5ccc4b54bfced71db9756fac6077d117a4fad49eaea71bbfa76eda05f387782b0cfdc6102ffc77f7d2caf9f29abb10e97223ddfacbcab\",\"name\":\"@tauri-apps/plugin-store\",\"version\":\"2.4.3\"},\"@tauri-apps__plugin-updater-2.10.1.tgz\":{\"integrity\":\"NFYMg+tWOZPJdzE/PpFj2qfqwAWwNS3kXrb1tm1gnBJ9mYzZ4WDRrwy8udzWoAnfGCHLuePNLY1WVCNHnh3eRA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"34560c83eb563993c977313f3e9163daa7eac005b0352de45eb6f5b66d609c127d998cd9e160d1af0cbcb9dcd6a009df1821cbb9e3cd2d8d565423479e1dde44\",\"name\":\"@tauri-apps/plugin-updater\",\"version\":\"2.10.1\"},\"@tybys__wasm-util-0.10.3.tgz\":{\"integrity\":\"F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"1777e8d4c62b44960bdf3111d0e50e9a4bad8ebd55a76de6eceb12829ee7ab848fe8ea97e82ff9e971483c09796eddf3681463996ed21b3deeffa2f016961c3a\",\"name\":\"@tybys/wasm-util\",\"version\":\"0.10.3\"},\"@types__node-20.19.43.tgz\":{\"integrity\":\"6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"ea8601022e62920e0f97e906b2862d6b050c053db364c0af3cd17ba552e71d97ddd737f7f034625a7fe04f4d51602754aa4bfb161afe0bda2de3fb5bfb6b15bc\",\"name\":\"@types/node\",\"version\":\"20.19.43\"},\"@types__prop-types-15.7.15.tgz\":{\"integrity\":\"F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"17a6c4c9a995f632860050449a54277ac44f18e42a4b6f94c22d049b5e717a73b11da7f686fe8bf180959f7acf74f24e8897cf8829cb211cafc156aa318dcc23\",\"name\":\"@types/prop-types\",\"version\":\"15.7.15\"},\"@types__react-18.3.31.tgz\":{\"integrity\":\"vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"bdf12aa574efc13f75ca19b075fa2e4ad3768522b04efc91b3caa92df003cababf9310f0d2164ced693d520d4510b8fc8486f2f92ffe910092445177da7bf643\",\"name\":\"@types/react\",\"version\":\"18.3.31\"},\"@types__react-dom-18.3.7.tgz\":{\"integrity\":\"MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"3047b751ea043585455f3a17116b2f72983a66f96b14d94e43b10eb2f848dc27c05f0ccf7cef10c2ec5de349dea6c60aab2c954274dd11fbfaf2af75c8b70aad\",\"name\":\"@types/react-dom\",\"version\":\"18.3.7\"},\"@vitejs__plugin-react-6.0.3.tgz\":{\"integrity\":\"vmFvco5/QuC2f9Oj+wTk0+9XeDFkHxSamwZKYc7MxYwKICfvUvlMhqKI0VuICPltGqh1neqBKDvO4kes1ya8vg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"be616f728e7f42e0b67fd3a3fb04e4d3ef577831641f149a9b064a61ceccc58c0a2027ef52f94c86a288d15b8808f96d1aa8759dea81283bcee247acd726bcbe\",\"name\":\"@vitejs/plugin-react\",\"version\":\"6.0.3\"},\"ajv-8.20.0.tgz\":{\"integrity\":\"Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"4e16e58be3a53a3fa230f60505505f2773a60809da4b2367e0cd6fcfd4fa1a46b926df5b6bf1c8479ea3a32eb9b58ea4c7f142179557341f35f58eff194ac118\",\"name\":\"ajv\",\"version\":\"8.20.0\"},\"ansi-regex-6.2.2.tgz\":{\"integrity\":\"Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"06add2992a721476968cf93c21ff7273ab2f33c739e9d079040b56e106f0e631d3c305d77132e844c9290c9a7a54bd17ce559a0874d7ae415444c6260f4b0baa\",\"name\":\"ansi-regex\",\"version\":\"6.2.2\"},\"ansi-styles-6.2.3.tgz\":{\"integrity\":\"4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"e038fa336f0907ea001fc9059132d4a3e6b68f038592ea9bdf2b9c53408035c45151bc52d1c3f49d96021a371cdc1357c1122c5159831a0cdac267bbcef247be\",\"name\":\"ansi-styles\",\"version\":\"6.2.3\"},\"argparse-2.0.1.tgz\":{\"integrity\":\"8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"f3ef56a9e6db173a57f4e47e59ae8edbd6ac22881e44ccdc1ad00835da4c1c7c80835d1fd3969215505b704a867ff3d7c35123019faadbf6c4060dc3beeacadd\",\"name\":\"argparse\",\"version\":\"2.0.1\"},\"argue-cli-3.1.0.tgz\":{\"integrity\":\"DhBpBfXL4SS2uC0N922MMajKR3CdrTG0u2or1PNYgXMsrSzViJrbtvT0nCLlLGUI0plam/ZZCs7aAauHtW9thw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"0e106905f5cbe124b6b82d0df76d8c31a8ca47709dad31b4bb6a2bd4f35881732cad2cd5889adbb6f4f49c22e52c6508d2995a9bf6590aceda01ab87b56f6d87\",\"name\":\"argue-cli\",\"version\":\"3.1.0\"},\"aria-hidden-1.2.6.tgz\":{\"integrity\":\"ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"8a4dd9802f5d63f95855533ef8e212b1a6037a0d6d6f456d3f9b8bde8ba1d64a0639a50c0cfa5b1487a2e099058a659414f9fdd2c6cc34c5d000854e96760a24\",\"name\":\"aria-hidden\",\"version\":\"1.2.6\"},\"attr-accept-2.2.5.tgz\":{\"integrity\":\"0bDNnY/u6pPwHDMoF0FieU354oBi0a8rD9FcsLwzcGWbc8KS8KPIi7y+s13OlVY+gMWc/9xEMUgNE6Qm8ZllYQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"d1b0cd9d8feeea93f01c3328174162794df9e28062d1af2b0fd15cb0bc3370659b73c292f0a3c88bbcbeb35dce95563e80c59cffdc4431480d13a426f1996561\",\"name\":\"attr-accept\",\"version\":\"2.2.5\"},\"callsites-3.1.0.tgz\":{\"integrity\":\"P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"3fc06302c5ef652f95203508d7584709012fef8613ebb6148b924914d588a8bdb7e6c0668d7e3eab1f4cbaf96ce62bf234435cb71e3ac502d0dda4ee13bb2c69\",\"name\":\"callsites\",\"version\":\"3.1.0\"},\"class-variance-authority-0.7.1.tgz\":{\"integrity\":\"Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"29afbd4ebbadbfb1bc33a593e927a2456cfbf762b9a84a881841b35ca84013ac4e58063aa4f1fc53ef48637a0232fea4a9398bb2fed787fdb0d918a091e3ccb2\",\"name\":\"class-variance-authority\",\"version\":\"0.7.1\"},\"cliui-9.0.1.tgz\":{\"integrity\":\"k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"93b9dd80a870a10bde04bfbfd6da86258373d3dec8ed63afc1b9a6536011e7e99a82d6e33d64134b50b9bf31a4042f189bc5164737ca533514a852f2a58e10fb\",\"name\":\"cliui\",\"version\":\"9.0.1\"},\"clsx-2.1.1.tgz\":{\"integrity\":\"eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"7989b441606d52b0566561b4777f3a386030d7a67df793e2395a3607b6e35926c779d1a5e5ed1959aabae6438681448d7ac1080e407d2126d383f24af5d84264\",\"name\":\"clsx\",\"version\":\"2.1.1\"},\"conventional-changelog-angular-9.2.1.tgz\":{\"integrity\":\"oWSL6ZhnXbYraOFTK3PgRAQJ8fADDAEv5K6AdeyQPLvjFmhG8+ejL0jZZp/R7vTmGJaBvZEE+sE7dB4bCv7sAw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"a1648be998675db62b68e1532b73e0440409f1f0030c012fe4ae8075ec903cbbe3166846f3e7a32f48d9669fd1eef4e6189681bd9104fac13b741e1b0afeec03\",\"name\":\"conventional-changelog-angular\",\"version\":\"9.2.1\"},\"conventional-changelog-conventionalcommits-10.2.1.tgz\":{\"integrity\":\"n4Kr1HFMTf3iMbES0TMxKIcYtUUv4rKqyQQp2JwfOEfFCOfGT3Tq4mCyJ8S9/YPyWhydjfKrrvnyl+gCjA+mJQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"9f82abd4714c4dfde231b112d13331288718b5452fe2b2aac90429d89c1f3847c508e7c64f74eae260b227c4bdfd83f25a1c9d8df2abaef9f297e8028c0fa625\",\"name\":\"conventional-changelog-conventionalcommits\",\"version\":\"10.2.1\"},\"conventional-commits-parser-7.1.1.tgz\":{\"integrity\":\"B0f42jI++V5Vb7qK+DDw68r0dNxz5hk+RdKUkx2NOi39emc9hsHa3u2M3doF7QQhRFzCrAj7uM90teG+RBTaYQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"0747f8da323ef95e556fba8af830f0ebcaf474dc73e6193e45d294931d8d3a2dfd7a673d86c1dadeed8cddda05ed0421445cc2ac08fbb8cf74b5e1be4414da61\",\"name\":\"conventional-commits-parser\",\"version\":\"7.1.1\"},\"cookie-1.1.1.tgz\":{\"integrity\":\"ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"7a2f00a2cee36b4c1e469173267100f541c9ffb5d09aa8256d1c277f60138dc07d5aaf3be15287f647e38e2acce94854dbf1397c561a77297284595d72a4a275\",\"name\":\"cookie\",\"version\":\"1.1.1\"},\"cosmiconfig-9.0.2.tgz\":{\"integrity\":\"gtTZxTDau1wL7Y7zifc2dd8jHSK/k6BTx/2Xp/BpdlAdnlYWFVt7qhJqgwi7637yRwRQ3qL4ZidbB4I8tA5VOg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"82d4d9c530dabb5c0bed8ef389f73675df231d22bf93a053c7fd97a7f06976501d9e5616155b7baa126a8308bbeb7ef2470450dea2f866275b07823cb40e553a\",\"name\":\"cosmiconfig\",\"version\":\"9.0.2\"},\"cosmiconfig-typescript-loader-6.3.0.tgz\":{\"integrity\":\"Akr82WH1Wfqatyiqpj8HDkO2o2KmJRu1FhKfSNJP3K4IdXwHfEyL7MOb62i1AGQVLtIQM+iCE9CGOtrfhR+mmA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"024afcd961f559fa9ab728aaa63f070e43b6a362a6251bb516129f48d24fdcae08757c077c4c8becc39beb68b50064152ed21033e88213d0863adadf851fa698\",\"name\":\"cosmiconfig-typescript-loader\",\"version\":\"6.3.0\"},\"country-flag-icons-1.6.20.tgz\":{\"integrity\":\"py8JiEKzjhYw6HPJ0L7SxLgCYim36UPRTZX43/kqGueUCZLSvnrqAiwW8HtQibur7mdkFQUkjOgdK+o/9FBtaw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"a72f098842b38e1630e873c9d0bed2c4b8026229b7e943d14d95f8dff92a1ae7940992d2be7aea022c16f07b5089bbabee67641505248ce81d2bea3ff4506d6b\",\"name\":\"country-flag-icons\",\"version\":\"1.6.20\"},\"csstype-3.2.3.tgz\":{\"integrity\":\"z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"cf51c629c632db103c00641fc2b9f43c0cbe3c1ed7fc64a3dd45495bda8aca7e37c566be825e675e6538aaa2cc4735952c50bc2aeb145fc4ffd240a2398a4021\",\"name\":\"csstype\",\"version\":\"3.2.3\"},\"detect-libc-2.1.2.tgz\":{\"integrity\":\"Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"06d8f604e38ef37a375b21f9f5ef0c817b3111055c6ab9143a9118aee6c1d2eaf09cdd74c90dfae2bb22072535d67665a966199b4e62fe87fb8a8e26ce2841b5\",\"name\":\"detect-libc\",\"version\":\"2.1.2\"},\"detect-node-es-1.1.0.tgz\":{\"integrity\":\"ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"ca9766254fd36c16f2d83c626eebfb64b5b706cd5012633b9c78c400d7e88492ef1345d5ba38ac9f5a8f25c67183ea83b9cb2bf9b3fa7cb0f5acf4b702127b11\",\"name\":\"detect-node-es\",\"version\":\"1.1.0\"},\"emoji-regex-10.6.0.tgz\":{\"integrity\":\"toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"b68508f38612e589b15b6d7d7ab9e2583d022153a8e3ac46282a2578d41180ecc3a2b8018b5bf80fbd7f385ce00fd18ed9418a22fd42dd2a7c0c09f4fa3e70ec\",\"name\":\"emoji-regex\",\"version\":\"10.6.0\"},\"enhanced-resolve-5.21.6.tgz\":{\"integrity\":\"aNnGCvbJ/RIyWo1IuhNdVjnNF+EjH9wpzpNHt+ci/m9He9LJvUN8wrCcXjp9cWsGNAuvSpVFTx/vraAFQ8qGjQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"68d9c60af6c9fd12325a8d48ba135d5639cd17e1231fdc29ce9347b7e722fe6f477bd2c9bd437cc2b09c5e3a7d716b06340baf4a95454f1fefada00543ca868d\",\"name\":\"enhanced-resolve\",\"version\":\"5.21.6\"},\"env-paths-2.2.1.tgz\":{\"integrity\":\"+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"fa1d6590b2a164c4d88e8835544a49346ecd64959cb9cd830e4feab2a49345108e5e22e3790d5dd7fb9dad41a1a8cc5480097028d67471fdaea9a9f918bb92d8\",\"name\":\"env-paths\",\"version\":\"2.2.1\"},\"error-ex-1.3.4.tgz\":{\"integrity\":\"sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"b2a41a9809d1d785600abd40eb5f00dec1abca07292be1c46de9c0fc7884024914c1c648201fed816a871715a03b20e1e270782424629a1efd751e58c1cf4c0d\",\"name\":\"error-ex\",\"version\":\"1.3.4\"},\"es-toolkit-1.50.0.tgz\":{\"integrity\":\"OyZKhUVvEep9ITEiwHn8GKnMRQIVqoSIX7WnRbkWgJkllCujilqP2rD0u979tkl8wqyc8ICwlc1UBVv/Sl1G6w==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"3b264a85456f11ea7d213122c079fc18a9cc450215aa84885fb5a745b916809925942ba38a5a8fdab0f4bbdefdb6497cc2ac9cf080b095cd54055bff4a5d46eb\",\"name\":\"es-toolkit\",\"version\":\"1.50.0\"},\"escalade-3.2.0.tgz\":{\"integrity\":\"WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"5948f6aa5c5a42d3b883a3eae5cdbd193716183c9df22b4bf334e58a98040b3dc97ac02288e2a8b5df0953aa2d0773c00a01bac64254c9585ba0c4be6e37bf8c\",\"name\":\"escalade\",\"version\":\"3.2.0\"},\"fast-deep-equal-3.1.3.tgz\":{\"integrity\":\"f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"7f7a90f68432f63d808417bf1fd542f75c0b98a042094fe00ce9ca340606e61b303bb04b2a3d3d1dce4760dcfd70623efb19690c22200da8ad56cd3701347ce1\",\"name\":\"fast-deep-equal\",\"version\":\"3.1.3\"},\"fast-uri-3.1.4.tgz\":{\"integrity\":\"8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"f099db910e23b83caf62ce26805190aa0e32098b450ed52d9a9d90210ab5d5965ee42150e7072a9b5aea0e0021fd074cc92b819cfccc5222543591b937f02243\",\"name\":\"fast-uri\",\"version\":\"3.1.4\"},\"fdir-6.5.0.tgz\":{\"integrity\":\"tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"b486d8b596ee70eb340511aa3c992c84951874bf920c7edd54cf208f2f84469dd60148cb105244fb4da46a7c87b708d63a7c2b298062c0098cd29e242c90275e\",\"name\":\"fdir\",\"version\":\"6.5.0\"},\"file-selector-2.1.2.tgz\":{\"integrity\":\"QgXo+mXTe8ljeqUFaX3QVHc5osSItJ/Km+xpocx0aSqWGMSCf6qYs/VnzZgS864Pjn5iceMRFigeAV7AfTlaig==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"4205e8fa65d37bc9637aa505697dd0547739a2c488b49fca9bec69a1cc74692a9618c4827faa98b3f567cd9812f3ae0f8e7e6271e31116281e015ec07d395a8a\",\"name\":\"file-selector\",\"version\":\"2.1.2\"},\"framer-motion-12.42.0.tgz\":{\"integrity\":\"wp7EJnfWaaEScVygKv3e20udoRz+LbtxScsuTkakAxfXmt+ReC6WyPW2nINRAGvd+hG9odwcjBLyOTPjH5pBRA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"c29ec42677d669a112715ca02afddedb4b9da11cfe2dbb7149cb2e4e46a40317d79adf91782e96c8f5b69c8351006bddfa11bda1dc1c8c12f23933e31f9a4144\",\"name\":\"framer-motion\",\"version\":\"12.42.0\"},\"fsevents-2.3.3.tgz\":{\"integrity\":\"5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"e71a037d7f9f2fb7da0139da82658fa5b16dc21fd1efb5a630caaa1c64bae42defbc1d181eb805f81d58999df8e35b4c8f99fade4d36d765cda09c339617df43\",\"name\":\"fsevents\",\"version\":\"2.3.3\"},\"get-caller-file-2.0.5.tgz\":{\"integrity\":\"DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"0f214fdc133fdd81d340e0942ffc343991d1d25a4a786af1a2d70759ca8d11d9e5b6a1705d57e110143de1e228df801f429a34ac6922e1cc8889fb58d3a87616\",\"name\":\"get-caller-file\",\"version\":\"2.0.5\"},\"get-east-asian-width-1.6.0.tgz\":{\"integrity\":\"QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"4116ef0c86f1e9892551ee91c5e4de95e311d32bf77181fa3ec3d91dc9d59fbc6fef33b504737caf45c44eef27e987b743e6a1b526ab7375a0b4d5a67a12017c\",\"name\":\"get-east-asian-width\",\"version\":\"1.6.0\"},\"get-nonce-1.0.1.tgz\":{\"integrity\":\"FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"1498584680da89ab5f12450af072a589c9aeff7486143e75ab78ad2831a8493cac4090677ce7315391b19e113513ab2807be8c6d3d0c06d9ca26e5f2031fbde9\",\"name\":\"get-nonce\",\"version\":\"1.0.1\"},\"global-directory-5.0.0.tgz\":{\"integrity\":\"1pgFdhK3J2LeM+dVf2Pd424yHx2ou338lC0ErNP2hPx4j8eW1Sp0XqSjNxtk6Tc4Kr5wlWtSvz8cn2yb7/SG/w==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"d698057612b72762de33e7557f63dde36e321f1da8bb7dfc942d04acd3f684fc788fc796d52a745ea4a3371b64e937382abe70956b52bf3f1c9f6c9beff486ff\",\"name\":\"global-directory\",\"version\":\"5.0.0\"},\"graceful-fs-4.2.11.tgz\":{\"integrity\":\"RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"45b279fe398570d342703579a3d7939c12c9fc7b33595d0fef76dcf857f89d2feb263f98692e881b288e2f45680585fe9755ab97793ade1fcaac7fa7849d17bd\",\"name\":\"graceful-fs\",\"version\":\"4.2.11\"},\"husky-9.1.7.tgz\":{\"integrity\":\"5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"e60b39cad68d8c1ae1e4ec37cebbdd51463ed15c48b9654be22f62aede9fae257e06a7427e6575d4241358c8816161db5e1728f89d641df4ce52478f8420ef30\",\"name\":\"husky\",\"version\":\"9.1.7\"},\"import-fresh-3.3.1.tgz\":{\"integrity\":\"TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"4d1dca7eb4d94d82cf07a8d48dfc7a305f56716ac72fdb2ee5339b2b866462005d58a3ce1684a8408744b93b91f36a66b711f6b29586f61e9eb707ebd692c1a9\",\"name\":\"import-fresh\",\"version\":\"3.3.1\"},\"ini-6.0.0.tgz\":{\"integrity\":\"IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"2014dd224cd934ea6a9bbab7751a89bcc6a57578c31d69040dfaf0184413b3979a40c595f9d8c0851fb06a1c8d34c01afaaa5b0d4841315b7864a370a4f9bbc5\",\"name\":\"ini\",\"version\":\"6.0.0\"},\"is-arrayish-0.2.1.tgz\":{\"integrity\":\"zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"cf3d3a4bcb74a33a035cc1beb9b7b6eb37824cd5dc2883c96498bc841ac5e227422e6b38086f50b4aeea065d5ba22e4e0f31698ecc1be493e61c26cca63698ce\",\"name\":\"is-arrayish\",\"version\":\"0.2.1\"},\"is-plain-obj-4.1.0.tgz\":{\"integrity\":\"+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"f8f822faf32e50d909c84c62301b792251683322a7af9ce127852ca73e7c58e841179428219905c8d1c86c102d1f0cd502093946d9dd54db0344deb5fe6983aa\",\"name\":\"is-plain-obj\",\"version\":\"4.1.0\"},\"jiti-2.6.1.tgz\":{\"integrity\":\"ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"7a48a50923758f046f21b81e83fe7b60587ca900cd6f00dbf714ffaaed830076c5159522708978ca055a02fcef78c84c56bdcb9e948a4cd9f0b7c3e839f98a85\",\"name\":\"jiti\",\"version\":\"2.6.1\"},\"jiti-2.7.0.tgz\":{\"integrity\":\"AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"002ffb2687c9bd91abae779635a12725e38b531f89946b7bb4d6b4c198913d3e0c635c267ca8eddbee8eda9daecf6fac92597c39966624c36a7a47bb90a6cd81\",\"name\":\"jiti\",\"version\":\"2.7.0\"},\"js-tokens-4.0.0.tgz\":{\"integrity\":\"RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"45d2547e5704ddc5332a232a420b02bb4e853eef5474824ed1b7986cf84737893a6a9809b627dca02b53f5b7313a9601b690f690233a49bce0e026aeb16fcf29\",\"name\":\"js-tokens\",\"version\":\"4.0.0\"},\"js-yaml-4.3.0.tgz\":{\"integrity\":\"1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"d6d77bf3c6809e7679aaced5d90211975a308ed6296cab7be3d637c5abaa420c0820617fc575b3d70313101c793b72cade55cb56ea973dd3f18f6068147696f5\",\"name\":\"js-yaml\",\"version\":\"4.3.0\"},\"json-parse-even-better-errors-2.3.1.tgz\":{\"integrity\":\"xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"c72170ca1ae8fc91287fa1a17b68b3d8d717a23dac96836c5abfd7b044432bfa223c27da36197938d7e9fa341d01945043420958dcc7f7321917b962f75921db\",\"name\":\"json-parse-even-better-errors\",\"version\":\"2.3.1\"},\"json-schema-traverse-1.0.0.tgz\":{\"integrity\":\"NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"34cf3f3fd9f75e35e12199f594b86415a0024ce5114178d6855e0103f4673aff31be0aadaa9017f483b89914314b1d51968e2dab37aa6f4b0e96bb9a3b2dddba\",\"name\":\"json-schema-traverse\",\"version\":\"1.0.0\"},\"lightningcss-1.32.0.tgz\":{\"integrity\":\"NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"357601ce29cdadb95fada3c6cab6cfa03d7d0b587d95f23fd66ce0598bd75137b8d781b3fd7d450f65c165264ceeb453acc03c24bdceb4068689fac82a1439c9\",\"name\":\"lightningcss\",\"version\":\"1.32.0\"},\"lightningcss-android-arm64-1.32.0.tgz\":{\"integrity\":\"YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"60aeff0a54ede2400ad2fa3ac375fe3e79b40f671fdaf3c76e139776836d8b519ad1a9753f84c1661c23013be33702c40429cabe325cda34201d71f4344c2502\",\"name\":\"lightningcss-android-arm64\",\"version\":\"1.32.0\"},\"lightningcss-darwin-arm64-1.32.0.tgz\":{\"integrity\":\"RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"473786f49bb96da83606fd7f97095526f044deae93b57b247592cb0b27e0e69b7e1cbcfd06a94808eecb64ced51cd4d39ffe4f4611c50528e4e65738726b1c3d\",\"name\":\"lightningcss-darwin-arm64\",\"version\":\"1.32.0\"},\"lightningcss-darwin-x64-1.32.0.tgz\":{\"integrity\":\"U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"53e42c069da6fecdb0aa95184ffeb09e56a07596ed65d9dd4a6badfcd26a94270c2d35a9e66b82ac80fe2b9509ea3a83d8116c85e8c26179e23c36cd87bdd5f3\",\"name\":\"lightningcss-darwin-x64\",\"version\":\"1.32.0\"},\"lightningcss-freebsd-x64-1.32.0.tgz\":{\"integrity\":\"JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"2424e281e74492c664ded1d34ed86731d55f19feb5164cbc262d84e188d44c4417d78c62cbf953cd79eed6fc2265eddb61ed2af92a6c487fc24de0d72ba5878a\",\"name\":\"lightningcss-freebsd-x64\",\"version\":\"1.32.0\"},\"lightningcss-linux-arm-gnueabihf-1.32.0.tgz\":{\"integrity\":\"x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"c7aae79e945ad862f4cd03a4b7aaedb376033f376e2e95afc0017a10c8571556570f8b4fac190416acc6a30cc2b085ac3e3a922beb723443835015de7951d293\",\"name\":\"lightningcss-linux-arm-gnueabihf\",\"version\":\"1.32.0\"},\"lightningcss-linux-arm64-gnu-1.32.0.tgz\":{\"integrity\":\"0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"d279ccca8c8e2d12577db30e8a569245c2c7dc9c39cfd1c33467d3fe0c023e06838e7c748bcc3bbc1cc52c54757fa08c2ca17c8156de6e69143777dafe4409a5\",\"name\":\"lightningcss-linux-arm64-gnu\",\"version\":\"1.32.0\"},\"lightningcss-linux-arm64-musl-1.32.0.tgz\":{\"integrity\":\"UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"529424a1e9ebe14244ce054862923cd250c5bd198f560ea8a9ba0d1dfa07e024087cd03e1cead9ecca3b2993f4d9d0ba2e38213d025e06cbd7849a1dff09c806\",\"name\":\"lightningcss-linux-arm64-musl\",\"version\":\"1.32.0\"},\"lightningcss-linux-x64-gnu-1.32.0.tgz\":{\"integrity\":\"V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"57b42be7622166674a3d5afe56dc3ca3e58bb1025809377c96821fa4368c45619465f04e60425ec89224a862033193f03f1db8a5431fc12c7123ca61aff31b38\",\"name\":\"lightningcss-linux-x64-gnu\",\"version\":\"1.32.0\"},\"lightningcss-linux-x64-musl-1.32.0.tgz\":{\"integrity\":\"bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"6d870ba7e55bd1ac2c89783ff34b8245ecc2607360d7f9779add20cc79d657d5cfd56e6c29ae7f4c274659a47fcc13363de17f1dbb10bff8f651134e895bb15a\",\"name\":\"lightningcss-linux-x64-musl\",\"version\":\"1.32.0\"},\"lightningcss-win32-arm64-msvc-1.32.0.tgz\":{\"integrity\":\"8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"f126c2f01478d294ba6da08cf2c6ed6034b011541de099454ce95a0f78161877d385370006734305d6ba79365ea9ba1f6a5209845c74a8ace01c999c3d39c677\",\"name\":\"lightningcss-win32-arm64-msvc\",\"version\":\"1.32.0\"},\"lightningcss-win32-x64-msvc-1.32.0.tgz\":{\"integrity\":\"Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"026abd07f4a86587438b5905ae88e7a2a3cbc58850e16a395e22fc11526b56c07c011a02d4f596e951ad4f458a09e9a3cbc682fa5a2e2678d2ed4d7cc776f4e9\",\"name\":\"lightningcss-win32-x64-msvc\",\"version\":\"1.32.0\"},\"lines-and-columns-1.2.4.tgz\":{\"integrity\":\"7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"ef297295eb1943f3d5dbd8e110397751f8e8e995fb802a89af917b3caaea73ddefedfcd2ca6b75069c0453c9c0517b3cab3cefaa16e384ae50660e8cb7f1e406\",\"name\":\"lines-and-columns\",\"version\":\"1.2.4\"},\"loose-envify-1.4.0.tgz\":{\"integrity\":\"lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"972bb13c6aff59f86b95e9b608bfd472751cd7372a280226043cee918ed8e45ff242235d928ebe7d12debe5c351e03324b0edfeb5d54218e34f04b71452a0add\",\"name\":\"loose-envify\",\"version\":\"1.4.0\"},\"lottie-react-2.4.1.tgz\":{\"integrity\":\"LQrH7jlkigIIv++wIyrOYFLHSKQpEY4zehPicL9bQsrt1rnoKRYCYgpCUe5maqylNtacy58/sQDZTkwMcTRxZw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"2d0ac7ee39648a0208bfefb0232ace6052c748a429118e337a13e270bf5b42caedd6b9e8291602620a4251ee666aaca536d69ccb9f3fb100d94e4c0c71347167\",\"name\":\"lottie-react\",\"version\":\"2.4.1\"},\"lottie-web-5.13.0.tgz\":{\"integrity\":\"+gfBXl6sxXMPe8tKQm7qzLnUy5DUPJPKIyRHwtpCpyUEYjHYRJC/5gjUvdkuO2c3JllrPtHXH5UJJK8LRYl5yQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"fa07c15e5eacc5730f7bcb4a426eeaccb9d4cb90d43c93ca232447c2da42a725046231d84490bfe608d4bdd92e3b673726596b3ed1d71f950924af0b458979c9\",\"name\":\"lottie-web\",\"version\":\"5.13.0\"},\"lucide-react-0.292.0.tgz\":{\"integrity\":\"rRgUkpEHWpa5VCT66YscInCQmQuPCB1RFRzkkxMxg4b+jaL0V12E3riWWR2Sh5OIiUhCwGW/ZExuEO4Az32E6Q==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"ad18149291075a96b95424fae98b1c227090990b8f081d51151ce49313318386fe8da2f4575d84deb896591d92879388894842c065bf644c6e10ee00cf7d84e9\",\"name\":\"lucide-react\",\"version\":\"0.292.0\"},\"magic-string-0.30.21.tgz\":{\"integrity\":\"vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"bddd85e1853211728670b1e8abe4c4c828f1b9e49e1e7171cb28cda7cd328345d5e2f5219c37abfe5bef96a33f6ab0796d740de4adbfde88a7c82472c7c4f609\",\"name\":\"magic-string\",\"version\":\"0.30.21\"},\"motion-12.42.0.tgz\":{\"integrity\":\"Qhwvu9sVl5/URSq5CNzwMCpSKK8Uhnrwb6VO977kZyj/wOCS7mWebJUnBoHx5cZU1Zv8a9BD5CSICWKAlrLJgA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"421c2fbbdb15979fd4452ab908dcf0302a5228af14867af06fa54ef7bee46728ffc0e092ee659e6c95270681f1e5c654d59bfc6bd043e4248809628096b2c980\",\"name\":\"motion\",\"version\":\"12.42.0\"},\"motion-dom-12.42.0.tgz\":{\"integrity\":\"M63h4n8R+quJdNhBwuLlgxM+OLYa9+I/T2pzDRboB9fLXRdbou+Gw7Zury+SkpaCyACP1JHSjHgZ1EgTkBr30w==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"33ade1e27f11faab8974d841c2e2e583133e38b61af7e23f4f6a730d16e807d7cb5d175ba2ef86c3b66eaf2f92929682c8008fd491d28c7819d44813901af7d3\",\"name\":\"motion-dom\",\"version\":\"12.42.0\"},\"motion-utils-12.39.0.tgz\":{\"integrity\":\"8nadJAJjTtqRkmRF36FoJTrywK9nnFmnPwnSMyxaOCU7GDjN9RTMJIxx9De8ErM+vpPhMccr/6fo5WciyQLnMQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"f2769d2402634eda91926445dfa168253af2c0af679c59a73f09d2332c5a38253b1838cdf514cc248c71f437bc12b33ebe93e131c72bffa7e8e56722c902e731\",\"name\":\"motion-utils\",\"version\":\"12.39.0\"},\"nanoid-3.3.15.tgz\":{\"integrity\":\"y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"cbb5b282fffb9843afc53b8440307c4ad5dd3110567f5911fed961033051505901da37dc2ce0313bf48798e3b6ce0cf5a5580adbdfe4caea67d39f7f6c21dd8c\",\"name\":\"nanoid\",\"version\":\"3.3.15\"},\"object-assign-4.1.1.tgz\":{\"integrity\":\"rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"ac98134279149c7d6c170f324fa552537cc3dec5a6bbab19848b1e63c557f8646edcfe85ec5bbe24d0e85df9251256cb2529dcdc55101d57b8714e618fe05c52\",\"name\":\"object-assign\",\"version\":\"4.1.1\"},\"parent-module-1.0.1.tgz\":{\"integrity\":\"GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"190d84591a5057cfe8f80c3c62ab5f6593df3515996246e2744f64e6ba65fe10b7bed1c705f1a6d887e2eaa595f9ca031a4ad42990311372e8b7991cb11961fa\",\"name\":\"parent-module\",\"version\":\"1.0.1\"},\"parse-json-5.2.0.tgz\":{\"integrity\":\"ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"6b208abe6fe98421b13a461148233cda20f072df3f1289d2120092c56c43eef7ba8c7820b059787d955004f44d810a0a8ae57fa1d845ac6cd05d9c1b89f0bc46\",\"name\":\"parse-json\",\"version\":\"5.2.0\"},\"picocolors-1.1.1.tgz\":{\"integrity\":\"xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"c5c787dac9e1b5be4cf658aa0ec984c39ea57b7efa993664117fe311bfd1c4d1727a036e97b78db250973fd1438ff2dcbb45fc284c8c71e3f69eda5a1eb0c454\",\"name\":\"picocolors\",\"version\":\"1.1.1\"},\"picomatch-4.0.4.tgz\":{\"integrity\":\"QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"40ff3c0402af31a9bfdcdc47eaf8f6a36d51e8c8f165401dea7970012fe99c6bcdf4854ba1c2c7c46608cc5860e9f510fb9b61e8fe1dbf8796f635f70d2223ec\",\"name\":\"picomatch\",\"version\":\"4.0.4\"},\"postcss-8.5.15.tgz\":{\"integrity\":\"FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"15f47cb237787a6d93e9f6f723633000953b1d654cafdcdb6be7a799079e5857c26e6f94382ff45f80d2f17b6951333058c19b8ca60fef18df35e933c86981dc\",\"name\":\"postcss\",\"version\":\"8.5.15\"},\"prop-types-15.8.1.tgz\":{\"integrity\":\"oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"a23f3b0a064809dba5528868815011ec08e50b4df6ed4e1e9782fa780bcea827ae74c0d553435384d695f9bf437f87578123f58173139cf7617deff6a831f972\",\"name\":\"prop-types\",\"version\":\"15.8.1\"},\"radix-ui-1.6.0.tgz\":{\"integrity\":\"EUEC70O03EgxWMP5aoqfBZ6iLC5bczFagGy7zhSYRt8o5DP7IWNiP3ywetse3L9b8843ExB0OGWZvgbYVJuNeg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"114102ef43b4dc483158c3f96a8a9f059ea22c2e5b73315a806cbbce149846df28e433fb2163623f7cb07adb1edcbf5bf3ce37131074386599be06d8549b8d7a\",\"name\":\"radix-ui\",\"version\":\"1.6.0\"},\"react-18.3.1.tgz\":{\"integrity\":\"wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"c12fa1020252851d0a844bcf240adfb8f54dd7e1f3d6dd18ea7e632eb1906e46f8bab80f13fd11bdefb590c075bffa16807826e1621c57e8bb176a53563fb689\",\"name\":\"react\",\"version\":\"18.3.1\"},\"react-dom-18.3.1.tgz\":{\"integrity\":\"5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"e66e2740aa7ead945bd3d2cd1f9f463380714e1f76e75ff295b2886e97bb4e91b17c9fbd92fe812e42c15c88e3b296e06e720136a948db7b519d3593d2c9d423\",\"name\":\"react-dom\",\"version\":\"18.3.1\"},\"react-dropzone-14.4.1.tgz\":{\"integrity\":\"QDuV76v3uKbHiH34SpwifZ+gOLi1+RdsCO1kl5vxMT4wW8R82+sthjvBw4th3NHF/XX6FBsqDYZVNN+pnhaw0g==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"403b95efabf7b8a6c7887df84a9c227d9fa038b8b5f9176c08ed64979bf1313e305bc47cdbeb2d863bc1c38b61dcd1c5fd75fa141b2a0d865534dfa99e16b0d2\",\"name\":\"react-dropzone\",\"version\":\"14.4.1\"},\"react-is-16.13.1.tgz\":{\"integrity\":\"24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"db87baca71361fe38ab7892ab0ebcd77c901a55eb9ce8c5b038055b04381dc0455590922fc31f3694a02e4ab8e37f06271c0da0824d906e39c7d9b3bd2447c6d\",\"name\":\"react-is\",\"version\":\"16.13.1\"},\"react-remove-scroll-2.7.2.tgz\":{\"integrity\":\"Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"22a6fd3630824ede877febce74d21919d4e21f5412aabdbb1ff124f6cbff6bdee07ee788ff9875b37c918b59e783331468e393a229f9748d5d5ca757885faed1\",\"name\":\"react-remove-scroll\",\"version\":\"2.7.2\"},\"react-remove-scroll-bar-2.3.8.tgz\":{\"integrity\":\"9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"f6bfb28bdfa6814df700a723e886d3f684423bbf16ae24a3eadfdc17c0d605927d68e18f393103bdd503cf51702a29bb4175b0987aad7479d125f840c441b8e9\",\"name\":\"react-remove-scroll-bar\",\"version\":\"2.3.8\"},\"react-router-7.18.0.tgz\":{\"integrity\":\"pTTGt8J+ji1NOmYnjzT+bAJy/1zD+Jp4ziO6cL7T3ZLvXKtusO7BpFqlRXitqpcPVqllsIXFHRMt+2/k3Xn6HQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"a534c6b7c27e8e2d4d3a66278f34fe6c0272ff5cc3f89a78ce23ba70bed3dd92ef5cab6eb0eec1a45aa54578adaa970f56a965b085c51d132dfb6fe4dd79fa1d\",\"name\":\"react-router\",\"version\":\"7.18.0\"},\"react-router-dom-7.18.0.tgz\":{\"integrity\":\"Fi0yY6kgtKae/Th2xibdWK0KSdYZ4B53Gyf6wRtomOKWgpNm7H7+DyfDhncdz9FKbpS+1jmDhg3F4WoGJ+yFOA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"162d3263a920b4a69efd3876c626dd58ad0a49d619e01e771b27fac11b6898e296829366ec7efe0f27c386771dcfd14a6e94bed63983860dc5e16a0627ec8538\",\"name\":\"react-router-dom\",\"version\":\"7.18.0\"},\"react-style-singleton-2.2.3.tgz\":{\"integrity\":\"b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"6fa8d2bf1bd59f2a6d0222e36e458b13f94e9d1e257d3b43025f9e502ed1672f9041673ac11cc8576084eb106e3260f1736a888a1b430990f934f38597b7d105\",\"name\":\"react-style-singleton\",\"version\":\"2.2.3\"},\"require-from-string-2.0.2.tgz\":{\"integrity\":\"Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"5dfd2759ee91b1ece214cbbe029f5b8a251b9a996ae92f7fa7eef0ed85cffc904786b5030d48706bebc0372b9bbaa7d9593bde53ffc36151ac0c6ed128bfef13\",\"name\":\"require-from-string\",\"version\":\"2.0.2\"},\"reselect-5.2.0.tgz\":{\"integrity\":\"AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"02067750e666dd89dd7eb2783988e0ad3edb9829bfd62aa48ef11f1ffa188f387a3c3daac3842e4f78e39d722ba5db78313a4c5dc94c4f79576e6458f9745a93\",\"name\":\"reselect\",\"version\":\"5.2.0\"},\"resolve-from-4.0.0.tgz\":{\"integrity\":\"pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"a5bfcc6265ecb40932b11171f2988d235b4614d408140def904dc6ab812e035745ea01e9ffebe066ab021896a9bf2f0ddd0fb8a3b170beab8f25c9d9ed1632e2\",\"name\":\"resolve-from\",\"version\":\"4.0.0\"},\"resolve-from-5.0.0.tgz\":{\"integrity\":\"qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"a9883d28fdb8743e6a91af49e3b774695932d0df9be1f4d4f3d2cdf620e78c1e706a4b220b8f6bbcc0743eb509406a13987e745cf8aa3af0230df6a28c6c5867\",\"name\":\"resolve-from\",\"version\":\"5.0.0\"},\"rolldown-1.1.3.tgz\":{\"integrity\":\"1F1eEtUBtFvcGm1HQ9TiUIUHPQG7mSAODrhIzjxoUEFuo8OcbrGLiVLkevNgj84TE4lnHvnumwFjhJO5Eu135g==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"d45d5e12d501b45bdc1a6d4743d4e25085073d01bb99200e0eb848ce3c6850416ea3c39c6eb18b8952e47af3608fce131389671ef9ee9b01638493b912ed77e6\",\"name\":\"rolldown\",\"version\":\"1.1.3\"},\"scheduler-0.23.2.tgz\":{\"integrity\":\"UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"50e4a1b0fc33ecdacc52a851eadd215a315dbaf3b36edbfbb680c7d7f848adf44d2030679c159dd02c094c6bd3a67815966c0609d3fdfd997fb55ac3a9cb98cd\",\"name\":\"scheduler\",\"version\":\"0.23.2\"},\"semver-7.8.5.tgz\":{\"integrity\":\"Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"63bfca0ec6fc2e3a28669c1aa86cae94ee8342592c8029dc7211c693eb19218e1206f52870c044147e54af57c8e1d57e26f974c3a723bee71a222e34a6e462a0\",\"name\":\"semver\",\"version\":\"7.8.5\"},\"set-cookie-parser-2.7.2.tgz\":{\"integrity\":\"oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"a1e33596953f52f853c70fa0ddc21fc571f225173fba275ddf22b53f6e368331ddb34b9d401633b37cbc8f8802096f9927b69dd3272d95df1160ef9b76eae5bf\",\"name\":\"set-cookie-parser\",\"version\":\"2.7.2\"},\"source-map-js-1.2.1.tgz\":{\"integrity\":\"UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"51758c2a12cec1529bef6f0852d40f5f17d853ebac7726ed52b2bff2e184f0240cbeb84ea70bf30c1c23d108522fb31073bbc8b084811bc550f3e203431a5f40\",\"name\":\"source-map-js\",\"version\":\"1.2.1\"},\"string-width-7.2.0.tgz\":{\"integrity\":\"tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"b6c693224296f5be0df80123f92540f96849cd5effccc85c4aeefc98b2964a4edc5cc3921ec04a15652cd1f5b0abc4322b73202414115fa19b8b89186ddbc691\",\"name\":\"string-width\",\"version\":\"7.2.0\"},\"string-width-8.2.2.tgz\":{\"integrity\":\"GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"19a3d487981f76b633a9e54d66f51f4f6def618c57cca62275472732d260ff7af1455eb7105672de4eb17ca9667de243d35efa967515fd4b2bdd77304af173a6\",\"name\":\"string-width\",\"version\":\"8.2.2\"},\"strip-ansi-7.2.0.tgz\":{\"integrity\":\"yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"c833cc363a785b27d80641e78c844b7dc6b58ba28cc860adb1582829eff3d7eeafba481a10d76018166df9998a3dce206afbc46793a01df1ddadace180dc86ef\",\"name\":\"strip-ansi\",\"version\":\"7.2.0\"},\"tailwind-merge-3.6.0.tgz\":{\"integrity\":\"uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"bb12fba80550ae2a9140f0322b7a63eba56ab245aaa19dfb3d6f788f0393c0d7eaff3f68caed55f9eaab66ab51dbe7c28977583997bf32876df06b6fa8dceefb\",\"name\":\"tailwind-merge\",\"version\":\"3.6.0\"},\"tailwindcss-4.3.1.tgz\":{\"integrity\":\"hk+TB1m+K8CYNrP6rjQaq/Y+4Zylwpa87mLYBKCunwnnQ9p+fHb7kmSfGqyEJoxF/O6CDyABWVFEafNSYKll+Q==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"864f930759be2bc09836b3faae341aabf63ee19ca5c296bcee62d804a0ae9f09e743da7e7c76fb92649f1aac84268c45fcee820f200159514469f35260a965f9\",\"name\":\"tailwindcss\",\"version\":\"4.3.1\"},\"tapable-2.3.3.tgz\":{\"integrity\":\"uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"bb173fce9a8583ac7b0bcbce13b961e8b6dd6bc7842fdce6566fcf2de4cf051861d710a0756690f89d42522786a487e6d8776db14a51bfe1ec8626ac04c71ce8\",\"name\":\"tapable\",\"version\":\"2.3.3\"},\"tinyexec-1.2.4.tgz\":{\"integrity\":\"SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"4877ffaf8f1beef3ab8ef7bd3f1268dcc379bf9caeca31ef75472b41f7d3dd65cc51f9c69870d56c2e24dec1c96894e0642c29529948680a3900db4cca9dd81e\",\"name\":\"tinyexec\",\"version\":\"1.2.4\"},\"tinyglobby-0.2.17.tgz\":{\"integrity\":\"wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"c1747f758a5ca8a99f5a911d66388a24ec023459dd0f40cc9eb5bf7188d51adb449017d581c2c51e836b963e3b9a339589cf72c8dbbae5a96c805e0d4324dada\",\"name\":\"tinyglobby\",\"version\":\"0.2.17\"},\"tslib-2.8.1.tgz\":{\"integrity\":\"oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"a0916ef781d06fe29576e49440bef09e99aa9df98bb0e03f9c087a6fa107d30084a0ad3f98f79753a737c0a0d5f373243ae1cf447b525ca294f7d2016b34bfdb\",\"name\":\"tslib\",\"version\":\"2.8.1\"},\"tw-animate-css-1.4.0.tgz\":{\"integrity\":\"7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"edbce23a546a1f4849c7cd21ff799b89c2d6ee8f2a2ec1f9f9168b476b7e3873370f426558638340a4387316caed696f994c69723e8a82ee842aa8eb1857b741\",\"name\":\"tw-animate-css\",\"version\":\"1.4.0\"},\"typescript-5.9.3.tgz\":{\"integrity\":\"jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"8e5d6f6733c38a72ebf5e52ddc9feded5e8580d130f508ef04f772b33f4a7d00c3e357d0ac2d98e2f290762694a454f86d795bd511e12e9a7cc2d9ba3394e04b\",\"name\":\"typescript\",\"version\":\"5.9.3\"},\"undici-types-6.21.0.tgz\":{\"integrity\":\"iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"8b00d9aa0d10006ae0f516afe47e27d0ceb87379a4479f5c27ac10a7eec2e2723482c984c5a79d6982cd3b8e1e4f802d041c236d38863cc96dd8c7744fd1fd25\",\"name\":\"undici-types\",\"version\":\"6.21.0\"},\"use-callback-ref-1.3.3.tgz\":{\"integrity\":\"jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"8d02f79519e871a16dbb7574d094e8633ff8424356b30c628c368254d6518914cedc74032ec76ed59b66214bd5e323e9fabbd69b98f4cb44c6fd2eb572e8a34e\",\"name\":\"use-callback-ref\",\"version\":\"1.3.3\"},\"use-sidecar-1.1.3.tgz\":{\"integrity\":\"Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"15e770d1a66f921ca7a0f625039597acc080326fa7496759b7a973250ece93c4ba43e56c1e61e94569dd55127c05ed196e47cf7392d1607fb95ebcd770478b45\",\"name\":\"use-sidecar\",\"version\":\"1.1.3\"},\"use-sync-external-store-1.6.0.tgz\":{\"integrity\":\"Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"3e9e864b018ffcdacf22bc551402243907b2c3c9457a73878a34169144eb0efac5e002eaca53f60bf28291e4bd76950cdcabd84508676b9bedec82fde7e650f7\",\"name\":\"use-sync-external-store\",\"version\":\"1.6.0\"},\"vite-8.1.0.tgz\":{\"integrity\":\"BuJcQK/56NQTWDGn4ABea3q4SSBdNPWwNZKTkkUpcMPnLoquSYH8llRtSUIgoL1KSCpHt5eghLShn50mH36y7Q==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"06e25c40aff9e8d4135831a7e0005e6b7ab849205d34f5b035929392452970c3e72e8aae4981fc96546d494220a0bd4a482a47b797a084b4a19f9d261f7eb2ed\",\"name\":\"vite\",\"version\":\"8.1.0\"},\"wrap-ansi-9.0.2.tgz\":{\"integrity\":\"42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"e3602d9a0aa357e5f556974e7f24c6398462d3fceca0baad5d07244e6a937b26d3f810c86ccfc6bb1a3bc77a44dafb69af5a24eb146a33d3a905ef89ca8ab2c3\",\"name\":\"wrap-ansi\",\"version\":\"9.0.2\"},\"y18n-5.0.8.tgz\":{\"integrity\":\"0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"d297c5cde81e0d62472480264cb44fd83c078dd179b3b8e8f6dbb3b5d43102120d09dbd2fb79c620da8f774d00a61a8947fd0b8403544baffeed209bf7c60e7c\",\"name\":\"y18n\",\"version\":\"5.0.8\"},\"yaml-2.9.0.tgz\":{\"integrity\":\"2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"d80be1357de66fccdde99cbb20d4ed4a9975175e475ba5a7aa3d2cad696428b729625fe03083098b2b86ab629e236605c543e376507edcb735d2c78c2ed2f870\",\"name\":\"yaml\",\"version\":\"2.9.0\"},\"yargs-18.1.0.tgz\":{\"integrity\":\"2rAgRKu54VsHkqI0/tYkmluGXHD4KW7yZoycuqDQ15QOTnc2VVfy0nN/1eMhnQLO00A+dwtK20xuCnc1YGeUyg==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"dab02044abb9e15b0792a234fed6249a5b865c70f8296ef2668c9cbaa0d0d7940e4e77365557f2d2737fd5e3219d02ced3403e770b4adb4c6e0a7735606794ca\",\"name\":\"yargs\",\"version\":\"18.1.0\"},\"yargs-parser-22.0.0.tgz\":{\"integrity\":\"rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"af0bbf0a535d48ca644ab51bf9de8146c4a42d4ab57e67ec63a4cea58cd3c2fc24835fcd446f39281cb792afbe03c2ca4305fa96cbbe69669dfb6921bee5ebab\",\"name\":\"yargs-parser\",\"version\":\"22.0.0\"},\"zustand-5.0.14.tgz\":{\"integrity\":\"/8tAspM5LMPr28b3fwLYrtdj77ECpfZviaP75CMTnwO8ISyaE4GDIG/9rDDYq/cH9D2Xw2A2RXglLInmVBQB/g==\",\"integrity_algo\":\"sha512\",\"integrity_digest\":\"ffcb40b293392cc3ebdbc6f77f02d8aed763efb102a5f66f89a3fbe423139f03bc212c9a138183206ffdac30d8abf707f43d97c360364578252c89e6541401fe\",\"name\":\"zustand\",\"version\":\"5.0.14\"}},\"store_version\":\"v10\"}",
+        "dest-filename": "pnpm-manifest.json",
+        "dest": "flatpak-node"
+    },
+    {
+        "type": "script",
+        "commands": [
+            "version=$(node --version | sed \"s/^v//\")",
+            "nodedir=$(dirname \"$(dirname \"$(which node)\")\")",
+            "mkdir -p \"flatpak-node/cache/node-gyp/$version\"",
+            "ln -s \"$nodedir/include\" \"flatpak-node/cache/node-gyp/$version/include\"",
+            "echo 11 > \"flatpak-node/cache/node-gyp/$version/installVersion\""
+        ],
+        "dest-filename": "setup_sdk_node_headers.sh",
+        "dest": "flatpak-node"
+    },
+    {
+        "type": "shell",
+        "commands": [
+            "python3 flatpak-node/populate_pnpm_store.py flatpak-node/pnpm-manifest.json flatpak-node/pnpm-tarballs flatpak-node/pnpm-store",
+            "echo \"store-dir=$PWD/flatpak-node/pnpm-store\" >> .npmrc",
+            "bash flatpak-node/setup_sdk_node_headers.sh"
+        ]
+    }
 ]


### PR DESCRIPTION
## Summary
- Point Flatpak `tag`/`commit` at the real `v0.6.2` tip (`c24a704…`) so flatpak-builder verification succeeds
- Regenerate `cargo-sources.json` and `node-sources.json` from the lockfiles that release ships

## Test plan
- [ ] Confirm `git rev-parse v0.6.2^{commit}` matches the pinned commit in `flatpak/net.dashbeam.DashBeam.yml`
- [ ] Run Flatpak lint workflow / `flatpak-builder-lint` on the manifest
- [ ] Use these files when opening the Flathub submission PR

