### PR TITLE
chore(flatpak): strip process comments and enable appstream lint

### DIFF
--- a/.github/workflows/flatpak-lint.yml
+++ b/.github/workflows/flatpak-lint.yml
@@ -1,10 +1,5 @@
 name: Flatpak lint
 
-# Lints the Flathub packaging (manifest + metainfo) on PRs, no full build.
-# Manifest errors block the PR. The AppStream check stays report-only until
-# dashbeam.net serves the screenshots; drop its `|| true` afterward to make it
-# blocking too.
-
 on:
   push:
     branches:
@@ -44,16 +39,12 @@ jobs:
           test -f flatpak/net.dashbeam.DashBeam.yml
           test -f flatpak/net.dashbeam.DashBeam.metainfo.xml
 
-          # Manifest lint blocks the PR on structural errors. Mount read-write so
-          # the linter can create its .flatpak-builder cache; :ro makes it crash.
           { echo '### Manifest'; echo '```'; } >> "$GITHUB_STEP_SUMMARY"
           docker run --rm -v "$PWD":/w -w /w "$img" \
             manifest flatpak/net.dashbeam.DashBeam.yml 2>&1 | tee -a "$GITHUB_STEP_SUMMARY"
           echo '```' >> "$GITHUB_STEP_SUMMARY"
 
-          # AppStream lint is report-only until dashbeam.net serves the
-          # screenshots; drop the `|| true` afterward to make it blocking too.
           { echo '### AppStream metainfo'; echo '```'; } >> "$GITHUB_STEP_SUMMARY"
           docker run --rm -v "$PWD":/w:ro -w /w "$img" \
-            appstream flatpak/net.dashbeam.DashBeam.metainfo.xml 2>&1 | tee -a "$GITHUB_STEP_SUMMARY" || true
+            appstream flatpak/net.dashbeam.DashBeam.metainfo.xml 2>&1 | tee -a "$GITHUB_STEP_SUMMARY"
           echo '```' >> "$GITHUB_STEP_SUMMARY"

--- a/flatpak/build-sources.sh
+++ b/flatpak/build-sources.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
-# Regenerates the offline dependency manifests Flathub needs (its build has no
-# network). Run inside the Fedora container from the repo root:
+# Regenerate offline Flathub dependency manifests. From the repo root:
 #   bash flatpak/build-sources.sh
 set -euo pipefail
 
@@ -9,12 +8,10 @@ if [ ! -d "$TOOLS_DIR" ]; then
 	git clone --depth=1 https://github.com/flatpak/flatpak-builder-tools "$TOOLS_DIR"
 fi
 
-# Rust: src-tauri/Cargo.lock already includes the engine workspace's crates.
 python3 -m pip install --quiet --root-user-action=ignore aiohttp tomlkit
 python3 "$TOOLS_DIR/cargo/flatpak-cargo-generator.py" \
 	src-tauri/Cargo.lock -o flatpak/cargo-sources.json
 
-# pnpm: the node generator is now a pip-installable package.
 python3 -m pip install --quiet --root-user-action=ignore "$TOOLS_DIR/node"
 flatpak-node-generator pnpm pnpm-lock.yaml -o flatpak/node-sources.json
 

--- a/flatpak/net.dashbeam.DashBeam.yml
+++ b/flatpak/net.dashbeam.DashBeam.yml
@@ -28,8 +28,6 @@ modules:
     sources:
       - type: git
         url: https://github.com/tonyantony300/dashbeam.git
-        # Must point at a release tag whose tree contains this flatpak/ dir.
-        # commit must be the exact SHA that tag v0.6.2 resolves to.
         tag: v0.6.2
         commit: c24a704d6f7efd20beadd8707fac3e44e9a9cc5d
       - cargo-sources.json

--- a/frontend/src/hooks/use-updater.ts
+++ b/frontend/src/hooks/use-updater.ts
@@ -15,8 +15,7 @@ import { isWindowsPortableBuild } from './use-windows-portable'
 type UpdateInfo = Awaited<ReturnType<typeof check>>
 
 async function checkForDesktopUpdate(): Promise<UpdateInfo> {
-	// Flatpak ships immutable app files and updates via `flatpak update`, so the
-	// updater plugin is never registered there and check() would throw.
+	// Flatpak builds omit the updater plugin.
 	if (IS_WEB || IS_FLATPAK) {
 		return null
 	}

--- a/frontend/src/lib/platform.ts
+++ b/frontend/src/lib/platform.ts
@@ -34,5 +34,4 @@ export const IS_DESKTOP =
 /** Persistent pairing node (host/join/invite) — desktop apps and Android. */
 export const IS_PAIRING_CAPABLE = IS_DESKTOP || IS_ANDROID
 
-// Set by the Flatpak build; the in-app updater is disabled there (OS handles it).
 export const IS_FLATPAK = IS_TAURI && import.meta.env.VITE_IS_FLATPAK === 'true'

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -44,8 +44,7 @@ fn cleanup_orphaned_directories() {
 pub fn run() {
     let builder = tauri::Builder::default().plugin(tauri_plugin_store::Builder::new().build());
 
-    // Flatpak ships immutable app files and updates via `flatpak update`, so the
-    // in-app updater is skipped there. FLATPAK_ID is only set inside the sandbox.
+    // Skip in-app updater under Flatpak (`flatpak update` handles it).
     #[cfg(desktop)]
     let builder = if std::env::var_os("FLATPAK_ID").is_none() {
         builder.plugin(tauri_plugin_updater::Builder::new().build())

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -30,7 +30,6 @@ export default defineConfig(({ mode }) => {
 			'import.meta.env.TAURI_PLATFORM': JSON.stringify(
 				process.env.TAURI_ENV_PLATFORM ?? ''
 			),
-			// Set to 'true' by the Flatpak build so the frontend hides the updater.
 			'import.meta.env.VITE_IS_FLATPAK': JSON.stringify(
 				process.env.VITE_IS_FLATPAK ?? ''
 			),


### PR DESCRIPTION
## Summary
- Remove temporary/process comments from Flatpak packaging and related updater notes
- Make AppStream metainfo lint blocking (screenshots are live)

## Test plan
- [ ] Flatpak lint workflow passes on this PR (manifest + appstream)