### PR TITLE
fix(theme): default to auto instead of light on web

### DIFF
--- a/frontend/src/store/theme-store.ts
+++ b/frontend/src/store/theme-store.ts
@@ -4,7 +4,6 @@ import {
 	// createJSONStorage
 } from 'zustand/middleware'
 import { APP_THEMES, type AppTheme } from '../types/app'
-import { IS_WEB } from '../lib/platform'
 
 export type IThemeStore = {
 	themes: AppTheme[]
@@ -22,35 +21,35 @@ export const useThemeStore = create<IThemeStore>()(
 	persist(
 		(set) => ({
 			themes: APP_THEMES,
-			activeTheme: IS_WEB ? 'light' : 'auto',
+			activeTheme: 'auto',
 			setTheme: (activeTheme: AppTheme) => set(() => ({ activeTheme })),
 			isDark: false,
 			setIsDark: (isDark: boolean) => set(() => ({ isDark })),
 		}),
 		{
 			name: 'active-theme',
-			version: 3,
+			version: 4,
 			// storage: createJSONStorage(() => sessionStorage),
 			partialize: (state) =>
 				Object.fromEntries(
 					Object.entries(state).filter(([key]) => key === 'activeTheme')
 				),
-			migrate: (persistedState) => {
+			migrate: (persistedState, version) => {
 				const state = (persistedState ?? {}) as PersistedThemeState
 				const removed = new Set(['ocean', 'forest', 'high-contrast'])
+
 				if (state.activeTheme && removed.has(state.activeTheme as string)) {
-					return { activeTheme: 'light' as const }
+					return { activeTheme: 'auto' as const }
 				}
-				if (IS_WEB && state.activeTheme === 'auto') {
-					return { activeTheme: 'light' as const }
+				// Pre-v4 web defaulted to 'light'; migrate any older version to 'auto'.
+				if (version < 4 && state.activeTheme === 'light') {
+					return { activeTheme: 'auto' as const }
 				}
 				if (
 					state.activeTheme &&
 					!(APP_THEMES as readonly string[]).includes(state.activeTheme)
 				) {
-					return {
-						activeTheme: (IS_WEB ? 'light' : 'auto') as AppTheme,
-					}
+					return { activeTheme: 'auto' as AppTheme }
 				}
 				return state
 			},


### PR DESCRIPTION
## Description
Web previously forced `activeTheme` to `light` on first load and via migration; Tauri already defaulted to `auto`. No platform reason for the split - theme resolution is identical on both.
- Default activeTheme to `auto` everywhere
- Bump store version to `4`, migrate pre-v4 `light` -> `auto`
- Drop now-unused `IS_WEB` import

Fixes #297

## Checklist
- [x] PR title follows Conventional Commits (`type(scope): description`)
- [x] I have run **`pnpm lint`** before raising this PR
- [x] I have run **`pnpm format`** before raising this PR