### PR TITLE
fix(tray): use native left/right context-menu interactions on Windows

### DIFF
--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -183,27 +183,33 @@ pub fn setup_tray(app: &AppHandle) -> tauri::Result<()> {
     let quit = MenuItem::with_id(app, "quit", &labels.quit, true, None::<&str>)?;
     let menu = Menu::with_items(app, &[&status, &separator, &open, &quit])?;
 
-    // macOS/Windows: attach the menu so the platform places it correctly
-    // (under the status item / TPM_BOTTOMALIGN above the tray icon).
-    // Linux: left-click menu attach is unsupported — pop manually.
+    // macOS/Windows: attach the context menu so the platform opens it natively.
+    // Left-click focuses the window (screen is: left = primary action, right =
+    // context menu). macOS ignores show_menu_on_left_click and always opens the
+    // menu on click, so its right-click handler still focuses the window only.
     #[cfg(any(target_os = "macos", target_os = "windows"))]
     let mut builder = TrayIconBuilder::new()
         .menu(&menu)
-        .show_menu_on_left_click(true)
+        .show_menu_on_left_click(false)
         .tooltip("DashBeam")
         .on_tray_icon_event(move |tray, event| {
-            // Right-click shows/focuses the window. tray-icon 0.21 still opens
-            // the attached menu on right-click as well; left-click is menu-only.
+            #[cfg(target_os = "windows")]
+            let focus_button = MouseButton::Left;
+            #[cfg(target_os = "macos")]
+            let focus_button = MouseButton::Right;
             if let TrayIconEvent::Click {
-                button: MouseButton::Right,
+                button,
                 button_state: MouseButtonState::Up,
                 ..
             } = event
             {
-                let _ = open_and_focus(tray.app_handle());
+                if button == focus_button {
+                    let _ = open_and_focus(tray.app_handle());
+                }
             }
         });
 
+    // Linux: left-click menu attach is unsupported — pop manually.
     #[cfg(not(any(target_os = "macos", target_os = "windows")))]
     let mut builder = {
         let menu_for_click = menu.clone();

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -184,13 +184,18 @@ pub fn setup_tray(app: &AppHandle) -> tauri::Result<()> {
     let menu = Menu::with_items(app, &[&status, &separator, &open, &quit])?;
 
     // macOS/Windows: attach the context menu so the platform opens it natively.
-    // Left-click focuses the window (screen is: left = primary action, right =
-    // context menu). macOS ignores show_menu_on_left_click and always opens the
-    // menu on click, so its right-click handler still focuses the window only.
+    // On Windows left-click focuses the window (left = primary action, right =
+    // context menu), so left-click must not open the menu. macOS keeps its native
+    // left-click-to-open-menu behavior, so there only right-click focuses the window.
+    #[cfg(target_os = "windows")]
+    let show_menu_on_left_click = false;
+    #[cfg(target_os = "macos")]
+    let show_menu_on_left_click = true;
+
     #[cfg(any(target_os = "macos", target_os = "windows"))]
     let mut builder = TrayIconBuilder::new()
         .menu(&menu)
-        .show_menu_on_left_click(false)
+        .show_menu_on_left_click(show_menu_on_left_click)
         .tooltip("DashBeam")
         .on_tray_icon_event(move |tray, event| {
             #[cfg(target_os = "windows")]


### PR DESCRIPTION
Open the tray context menu on right-click and focus the main window on left-click, matching native Windows tray behavior.

Prior behavior: the tray menu opened on left-click, and right-click opened the menu while also focusing the window.

On Windows:
- Left-click -> focus the main window
- Right-click -> open the context menu

macOS keeps its native click-to-open-menu behavior; the Linux manual-popup branch is unchanged.

## Test Plan
Run the Windows desktop build and verify:
- Left-clicking the tray icon focuses the window
- Right-clicking the tray icon opens the menu